### PR TITLE
Support string projection kwd

### DIFF
--- a/examples/user_guide/Geographic_Data.ipynb
+++ b/examples/user_guide/Geographic_Data.ipynb
@@ -111,7 +111,7 @@
     "\n",
     "world.hvplot(geo=True) * cities.hvplot(geo=True, color='orange')"
    ]
-  },  
+  },
   {
    "cell_type": "markdown",
    "metadata": {},
@@ -154,6 +154,24 @@
     "    'lon', 'lat', 'air', projection=ccrs.Orthographic(-90, 30),\n",
     "    global_extent=True, frame_height=540, cmap='viridis',\n",
     "    coastline=True\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If you don't need to pass any keyword arguments to a given projection and you don't have cartopy.crs (ccrs) imported, you can use the string representation: e.g. ``'LambertConformal'`` instead of ``ccrs.LambertConformal()``. Note that it is case sensitive!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "air_ds.hvplot.quadmesh(\n",
+    "    'lon', 'lat', 'air', projection='LambertConformal',\n",
     ")"
    ]
   },

--- a/hvplot/converter.py
+++ b/hvplot/converter.py
@@ -337,6 +337,22 @@ class HoloViewsConverter(object):
                     "following plot types: %r" % (self.kind, self._geo_types))
             from cartopy import crs as ccrs
             from geoviews.util import project_extents
+
+            if isinstance(projection, basestring):
+                all_crs = [proj for proj in dir(ccrs) if
+                           callable(getattr(ccrs, proj)) and
+                           proj not in ['ABCMeta', 'CRS'] and
+                           proj[0].isupper() or
+                           proj == 'GOOGLE_MERCATOR']
+                if projection in all_crs and projection != 'GOOGLE_MERCATOR':
+                    projection = getattr(ccrs, projection)()
+                elif projection == 'GOOGLE_MERCATOR':
+                    projection = getattr(ccrs, projection)
+                else:
+                    raise ValueError(
+                        "Projection must be defined as cartopy CRS or "
+                        "one of the following CRS string:\n {0}".format(all_crs))
+
             proj_crs = projection or ccrs.GOOGLE_MERCATOR
             if self.crs != proj_crs:
                 px0, py0, px1, py1 = ccrs.GOOGLE_MERCATOR.boundary.bounds

--- a/hvplot/tests/testgeo.py
+++ b/hvplot/tests/testgeo.py
@@ -10,7 +10,6 @@ class TestGeo(TestCase):
     def setUp(self):
         try:
             import xarray as xr
-            import rasterio  # noqa
             import geoviews  # noqa
             import cartopy.crs as ccrs
         except:
@@ -27,7 +26,7 @@ class TestGeo(TestCase):
 
     def assert_projection(self, plot, proj):
         opts = hv.Store.lookup_options('bokeh', plot, 'plot')
-        assert opts.kwargs['projection'].proj4_params == proj
+        assert opts.kwargs['projection'].proj4_params['proj'] == proj
 
     def test_plot_with_crs_as_object(self):
         plot = self.da.hvplot.image('x', 'y', crs=self.crs)

--- a/hvplot/tests/testgeo.py
+++ b/hvplot/tests/testgeo.py
@@ -10,6 +10,7 @@ class TestGeo(TestCase):
     def setUp(self):
         try:
             import xarray as xr
+            import rasterio  # noqa
             import geoviews  # noqa
             import cartopy.crs as ccrs
         except:

--- a/hvplot/tests/testgeo.py
+++ b/hvplot/tests/testgeo.py
@@ -25,6 +25,10 @@ class TestGeo(TestCase):
     def assertCRS(self, plot, proj='utm'):
         assert plot.crs.proj4_params['proj'] == proj
 
+    def assert_projection(self, plot, proj):
+        opts = hv.Store.lookup_options('bokeh', plot, 'plot')
+        assert opts.kwargs['projection'].proj4_params == proj
+
     def test_plot_with_crs_as_object(self):
         plot = self.da.hvplot.image('x', 'y', crs=self.crs)
         self.assertCRS(plot)
@@ -52,6 +56,20 @@ class TestGeo(TestCase):
         da.attrs = {'bar': self.crs}
         plot = da.hvplot.image('x', 'y', geo=True)
         self.assertCRS(plot, 'eqc')
+
+    def test_plot_with_projection_as_string(self):
+        da = self.da.copy()
+        plot = da.hvplot.image('x', 'y', projection='Robinson')
+        assert_projection(plot, 'robin')
+
+    def test_plot_with_projection_as_string_google_mercator(self):
+        da = self.da.copy()
+        plot = da.hvplot.image('x', 'y', projection='GOOGLE_MERCATOR')
+        assert_projection(plot, 'merc')
+
+    def test_plot_with_projection_as_invalid_string(self):
+        with self.assertRaisesRegex(ValueError, "Projection must be defined"):
+            self.da.hvplot.image('x', 'y', projection='foo')
 
 
 class TestGeoAnnotation(TestCase):


### PR DESCRIPTION
As jsignell suggested, string crs probably isn't too useful since you need to pass arguments in most cases if it's not degree latitude/longitude crs so I didn't support that, but I think being able to use a simple string for `projection` is useful.
![image](https://user-images.githubusercontent.com/15331990/68730144-818b2c80-0591-11ea-959b-58343c1eca2e.png)

https://github.com/holoviz/hvplot/issues/363