### PR TITLE
add keyword fontscale (solving #395)

### DIFF
--- a/hvplot/converter.py
+++ b/hvplot/converter.py
@@ -230,10 +230,9 @@ class HoloViewsConverter(object):
                      'yaxis', 'xformatter', 'yformatter', 'xlabel', 'ylabel',
                      'clabel', 'padding', 'responsive', 'max_height', 'max_width',
                      'min_height', 'min_width', 'frame_height', 'frame_width',
-                     'aspect', 'data_aspect']
+                     'aspect', 'data_aspect', 'fontscale']
 
-    _style_options = ['color', 'alpha', 'colormap', 'fontsize', 'c', 'cmap',
-                      'fontscale']
+    _style_options = ['color', 'alpha', 'colormap', 'fontsize', 'c', 'cmap']
 
     _op_options = ['datashade', 'rasterize', 'x_sampling', 'y_sampling',
                    'aggregator']

--- a/hvplot/converter.py
+++ b/hvplot/converter.py
@@ -86,6 +86,9 @@ class HoloViewsConverter(object):
     fontscale: number
         Scales the size of all fonts by the same amount, e.g. fontscale=1.5
         enlarges all fonts (title, xticks, labels etc.) by 50%
+    fontsize: number or dict
+        Set title, label and legend text to the same fontsize. Finer control
+        by using a dict: {'title': '15pt', 'ylabel': '5px', 'ticks': 20}
     flip_xaxis/flip_yaxis: boolean
         Whether to flip the axis left to right or up and down respectively
     grid (default=False): boolean
@@ -296,7 +299,7 @@ class HoloViewsConverter(object):
                  xlim=None, ylim=None, clim=None, symmetric=None,
                  logx=None, logy=None, loglog=None, hover=None,
                  subplots=False, label=None, invert=False,
-                 stacked=False, colorbar=None, fontsize=None,
+                 stacked=False, colorbar=None,
                  datashade=False, rasterize=False,
                  row=None, col=None, figsize=None, debug=False,
                  framewise=True, aggregator=None,

--- a/hvplot/converter.py
+++ b/hvplot/converter.py
@@ -83,6 +83,9 @@ class HoloViewsConverter(object):
     ---------------
     colorbar (default=False): boolean
         Enables colorbar
+    fontscale: number
+        Scales the size of all fonts by the same amount, e.g. fontscale=1.5
+        enlarges all fonts (title, xticks, labels etc.) by 50%
     flip_xaxis/flip_yaxis: boolean
         Whether to flip the axis left to right or up and down respectively
     grid (default=False): boolean
@@ -229,7 +232,8 @@ class HoloViewsConverter(object):
                      'min_height', 'min_width', 'frame_height', 'frame_width',
                      'aspect', 'data_aspect']
 
-    _style_options = ['color', 'alpha', 'colormap', 'fontsize', 'c', 'cmap']
+    _style_options = ['color', 'alpha', 'colormap', 'fontsize', 'c', 'cmap',
+                      'fontscale']
 
     _op_options = ['datashade', 'rasterize', 'x_sampling', 'y_sampling',
                    'aggregator']
@@ -398,7 +402,8 @@ class HoloViewsConverter(object):
                    'padding', 'xformatter', 'yformatter',
                    'height', 'width', 'frame_height', 'frame_width',
                    'min_width', 'min_height', 'max_width', 'max_height',
-                   'fontsize', 'responsive', 'shared_axes', 'aspect', 'data_aspect']
+                   'fontsize', 'fontscale', 'responsive', 'shared_axes', 
+                   'aspect', 'data_aspect']
         for plotwd in plotwds:
             if plotwd in kwds:
                 plot_opts[plotwd] = kwds.pop(plotwd)


### PR DESCRIPTION
Fontscale keyword was added so that hvplot can also handle this keyword. This should solve #395 . 

Also added documentation about fontscale in docstring of class HoloViewsConverter(object).

I didn't add fontscale to the __init__() of class HoloViewsConverter(object), but it falls now under the **kwds. If this still needs to be done, please let me know.

Tested some simple plots myself in Jupyter, that seemed to work. Didn't add any formal tests.