### PR TITLE
Specifying S3 region for airline_flights.parq

### DIFF
--- a/examples/datasets.yaml
+++ b/examples/datasets.yaml
@@ -8,7 +8,7 @@ sources:
         type: file
     args:
       urlpath: 's3://assets.holoviews.org/data/airline_flights.parq'
-      storage_options: {'anon': True}
+      storage_options: {'anon': True, 'region_name':'eu-west-1'}
 
   us_crime:
     description: US Crime data


### PR DESCRIPTION
Quick PR needed to make sure the download from S3 of `airline_flights.parq` can be reliably executed by intake.