### PR TITLE
color_key alias for cmap

### DIFF
--- a/hvplot/converter.py
+++ b/hvplot/converter.py
@@ -235,7 +235,8 @@ class HoloViewsConverter(object):
                      'min_height', 'min_width', 'frame_height', 'frame_width',
                      'aspect', 'data_aspect', 'fontscale']
 
-    _style_options = ['color', 'alpha', 'colormap', 'fontsize', 'c', 'cmap']
+    _style_options = ['color', 'alpha', 'colormap', 'fontsize', 'c', 'cmap',
+                      'color_key']
 
     _op_options = ['datashade', 'rasterize', 'x_sampling', 'y_sampling',
                    'aggregator']
@@ -794,10 +795,12 @@ class HoloViewsConverter(object):
         style_opts.update(**{k: v for k, v in kwds.items() if k in valid_opts})
 
         # Color
-        if 'cmap' in kwds and 'colormap' in kwds:
-            raise TypeError("Only specify one of `cmap` and `colormap`.")
+        cmap_kwds = {'cmap', 'colormap', 'color_key'}.intersection(kwds)
+        if len(cmap_kwds) > 1:
+            raise TypeError('Specify at most one of `cmap`, `colormap`, or '
+                            '`color_key`.')
 
-        cmap = kwds.pop('cmap', kwds.pop('colormap', None))
+        cmap = kwds[cmap_kwds.pop()] if cmap_kwds else None
         color = kwds.pop('color', kwds.pop('c', None))
 
         if color is not None:

--- a/hvplot/tests/testoperations.py
+++ b/hvplot/tests/testoperations.py
@@ -100,6 +100,9 @@ class TestDatashader(ComparisonTestCase):
     def test_cmap_can_be_color_key(self):
         color_key = {'A': '#ff0000', 'B': '#00ff00', 'C': '#0000ff'}
         self.df.hvplot.points(x='x', y='y', by='category', cmap=color_key, datashade=True)
+        with self.assertRaises(TypeError):
+            self.df.hvplot.points(x='x', y='y', by='category', datashade=True,
+                                  cmap='kbc_r', color_key=color_key)
 
     def test_when_datashade_is_true_set_hover_to_false_by_default(self):
         plot = self.df.hvplot(x='x', y='y', datashade=True)


### PR DESCRIPTION
Closes #444 

This PR is WIP because:
1. I cannot get tox to run tests locally, hoping automation does it, but mostly
1. Use of `color_key` causes the faulty warning `WARNING:param.main: color_key option not found for image plot; similar options include: ['color_key', 'color']`

I suspect this has to do with [converter.py#L786](https://github.com/itcarroll/hvplot/blob/b43020cdc317f75f54a2395546f387e5c84afd43/hvplot/converter.py#L786), which looks a teensy bit like a dumpster fire and I'm not sure what it's supposed to do. Plz advise.