### PR TITLE
Add a warning message about interactivity not working on static website

### DIFF
--- a/examples/user_guide/Interactive.ipynb
+++ b/examples/user_guide/Interactive.ipynb
@@ -25,6 +25,15 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<div class=\"alert alert-warning\" role=\"alert\">\n",
+    "  When viewing on a static website, the widgets will be inoperable. To explore this functionality fully, download the notebook and run it!\n",
+    "</div>"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},


### PR DESCRIPTION
It took me a little bit of time to realise why the interactivity was not working on the website... 
Then I saw the warning message on the widget page (https://hvplot.holoviz.org/user_guide/Widgets.html). I think it would be worth having the same type of message on this webpage...