### PR TITLE
Add support for passing in explicit HoloViews stream

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -27,7 +27,7 @@ jobs:
       DESC: "Python ${{ matrix.python-version }} tests"
       HV_REQUIREMENTS: "unit_tests"
       PYTHON_VERSION: ${{ matrix.python-version }}
-      CHANS_DEV: "-c pyviz/label/dev -c conda-forge"
+      CHANS_DEV: "-c pyviz/label/dev"
       CHANS: "-c pyviz"
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
@@ -64,6 +64,7 @@ jobs:
           conda activate test-environment
           conda list
           doit develop_install ${{ env.CHANS_DEV}} -o examples -o tests
+          conda install -c conda-forge fsspec
       - name: pygraphviz
         if: contains(matrix.os, 'ubuntu')
         run: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ['ubuntu-latest', 'windows-latest']
-        python-version: [2.7, 3.7, 3.8]
+        python-version: [2.7, 3.7]
         exclude:
           - os: windows-latest
             python-version: 2.7

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ['ubuntu-latest', 'windows-latest']
-        python-version: [2.7, 3.6, 3.7]
+        python-version: [2.7, 3.7, 3.8]
         exclude:
           - os: windows-latest
             python-version: 2.7

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -27,7 +27,7 @@ jobs:
       DESC: "Python ${{ matrix.python-version }} tests"
       HV_REQUIREMENTS: "unit_tests"
       PYTHON_VERSION: ${{ matrix.python-version }}
-      CHANS_DEV: "-c pyviz/label/dev"
+      CHANS_DEV: "-c pyviz/label/dev -c conda-forge"
       CHANS: "-c pyviz"
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:

--- a/hvplot/tests/teststreaming.py
+++ b/hvplot/tests/teststreaming.py
@@ -1,0 +1,30 @@
+from unittest import TestCase
+
+import pandas as pd
+
+from holoviews.streams import Buffer, Pipe
+
+from hvplot.converter import HoloViewsConverter
+
+
+class TestExplicitStreamPlotting(TestCase):
+    
+    def setUp(self):
+        import hvplot.pandas   # noqa
+        self.df = pd.DataFrame([[1, 2], [3, 4], [5, 6]], columns=['x', 'y'])
+
+    def test_pipe_stream(self):
+        stream = Pipe(data=self.df)
+        plot = self.df.hvplot('x', 'y', stream=stream)
+        pd.testing.assert_frame_equal(plot[()].data, self.df)
+        new_df = pd.DataFrame([[7, 8], [9, 10]], columns=['x', 'y'])
+        stream.send(new_df)
+        pd.testing.assert_frame_equal(plot[()].data, new_df)
+
+    def test_buffer_stream(self):
+        stream = Buffer(data=self.df, index=False)
+        plot = self.df.hvplot('x', 'y', stream=stream)
+        pd.testing.assert_frame_equal(plot[()].data, self.df)
+        new_df = pd.DataFrame([[7, 8], [9, 10]], columns=['x', 'y'])
+        stream.send(new_df)
+        pd.testing.assert_frame_equal(plot[()].data, pd.concat([self.df, new_df]))

--- a/hvplot/tests/teststreaming.py
+++ b/hvplot/tests/teststreaming.py
@@ -4,8 +4,6 @@ import pandas as pd
 
 from holoviews.streams import Buffer, Pipe
 
-from hvplot.converter import HoloViewsConverter
-
 
 class TestExplicitStreamPlotting(TestCase):
     


### PR DESCRIPTION
This allows external code to pipe data through hvPlot without instantiating a `streamz.DataFrame` instance. Very useful when you have some updating datasource.