### PR TITLE
Disable interactivity warning on homepage

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -4,6 +4,7 @@
 
 .. notebook:: hvplot ../examples/homepage.ipynb
    :offset: 0
+   :disable_interactivity_warning:
 
 .. toctree::
    :hidden:


### PR DESCRIPTION
Disables the warning on the homepage (when built with latest nbsite).