### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -115,6 +115,8 @@ setup_args = dict(
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
         "Operating System :: OS Independent",
         "Intended Audience :: Science/Research",
         "Intended Audience :: Developers",


### PR DESCRIPTION
 #580
loicduffar 
According to installation instructions, hvplot is supported by python 3.5-3.7 (and only 3.6 according to setup.py ).

I would like to migrate to python 3.8 (Anaconda), but I want to be sure all libraries I use are compatibles.

philippjfr
 This is simply a matter of not having updated the setup.py (a PR to fix it would be very welcome). I've been using 3.8 daily for months without issues.