### PR TITLE
Adding default coordinates to Datasets with missing image coords

### DIFF
--- a/hvplot/converter.py
+++ b/hvplot/converter.py
@@ -1026,6 +1026,12 @@ class HoloViewsConverter(object):
             elif self.datatype == 'xarray':
                 import xarray as xr
                 if isinstance(data, xr.Dataset):
+                    if kind == 'image':
+                        dims_with_coords = set(data.coords.keys())
+                        missing_coords =  set(self.indexes) - dims_with_coords
+                        for missing_coord in missing_coords:
+                            new_coord = np.arange(data[missing_coord].shape[0])
+                            data = data.assign_coords(**{missing_coord:new_coord})
                     dataset = Dataset(data, self.indexes)
                 else:
                     name = data.name or self.label or self.value_label

--- a/hvplot/converter.py
+++ b/hvplot/converter.py
@@ -1029,9 +1029,9 @@ class HoloViewsConverter(object):
                     if kind == 'image':
                         dims_with_coords = set(data.coords.keys())
                         missing_coords =  set(self.indexes) - dims_with_coords
-                        for missing_coord in missing_coords:
-                            new_coord = np.arange(data[missing_coord].shape[0])
-                            data = data.assign_coords(**{missing_coord:new_coord})
+                        new_coords = {coord: np.arange(data[coord].shape[0])
+                                      for coord in missing_coords}
+                        data = data.assign_coords(**new_coords)
                     dataset = Dataset(data, self.indexes)
                 else:
                     name = data.name or self.label or self.value_label

--- a/hvplot/converter.py
+++ b/hvplot/converter.py
@@ -1026,12 +1026,6 @@ class HoloViewsConverter(object):
             elif self.datatype == 'xarray':
                 import xarray as xr
                 if isinstance(data, xr.Dataset):
-                    if kind == 'image':
-                        dims_with_coords = set(data.coords.keys())
-                        missing_coords =  set(self.indexes) - dims_with_coords
-                        for missing_coord in missing_coords:
-                            new_coord = np.arange(data[missing_coord].shape[0])
-                            data = data.assign_coords(**{missing_coord:new_coord})
                     dataset = Dataset(data, self.indexes)
                 else:
                     name = data.name or self.label or self.value_label

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ install_requires = [
     'bokeh >=1.0.0',
     'colorcet >=2',
     'holoviews >=1.11.0',
-    'pandas',
+    'pandas <=1.2.2',
     'numpy>=1.15'
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ install_requires = [
     'bokeh >=1.0.0',
     'colorcet >=2',
     'holoviews >=1.11.0',
-    'pandas <=1.2.2',
+    'pandas',
     'numpy>=1.15'
 ]
 


### PR DESCRIPTION
This PR aims to address #603 by generating default image coordinates when they are missing.

Before the PR, using the example given in #603:

<img src="https://user-images.githubusercontent.com/890576/116992872-507a4c80-ac9c-11eb-998d-afb09c971bd7.png" width=70%>

With the PR:

<img src="https://user-images.githubusercontent.com/890576/116992987-76075600-ac9c-11eb-8ca3-dc352c9d4178.png" width=70%>

So far I've only thought about the `Dataset` branch, to finish this PR I'll need to handle the `DataArray` case as well.