### PR TITLE
Add a title to xarray plots with scalar coords

### DIFF
--- a/hvplot/converter.py
+++ b/hvplot/converter.py
@@ -498,7 +498,7 @@ class HoloViewsConverter(object):
             plot_opts['global_extent'] = global_extent
         if projection:
             plot_opts['projection'] = process_crs(projection)
-        title = title if title else getattr(self, '_title', None)
+        title = title if title is not None else getattr(self, '_title', None)
         if title is not None:
             plot_opts['title'] = title
         if (self.kind in self._colorbar_types or self.rasterize or self.datashade or self._color_dim):

--- a/hvplot/converter.py
+++ b/hvplot/converter.py
@@ -655,6 +655,9 @@ class HoloViewsConverter(object):
         elif is_xarray(data):
             import xarray as xr
             z = kwds.get('z')
+            if isinstance(data, xr.Dataset):
+                if len(data.data_vars) == 0:
+                    raise ValueError("Cannot plot an empty xarray.Dataset object.")
             if z is None:
                 if isinstance(data, xr.Dataset):
                     z = list(data.data_vars)[0]

--- a/hvplot/converter.py
+++ b/hvplot/converter.py
@@ -498,6 +498,7 @@ class HoloViewsConverter(object):
             plot_opts['global_extent'] = global_extent
         if projection:
             plot_opts['projection'] = process_crs(projection)
+        title = title if title else getattr(self, '_title', None)
         if title is not None:
             plot_opts['title'] = title
         if (self.kind in self._colorbar_types or self.rasterize or self.datashade or self._color_dim):
@@ -703,6 +704,15 @@ class HoloViewsConverter(object):
 
             if groupby:
                 groupby = [g for g in groupby if g not in grid]
+
+            if not groupby and not grid:
+                # Set a title for coords of size 1 (e.g. da.isel(lon=0).hvplot())
+                if isinstance(da, xr.DataArray):
+                    self._title = da._title_for_slice()
+                elif isinstance(da, xr.Dataset):
+                    one_var = list(da.data_vars)[0]
+                    self._title = da[one_var]._title_for_slice()
+
             self.data = data
         else:
             raise ValueError('Supplied data type %s not understood' % type(data).__name__)

--- a/hvplot/converter.py
+++ b/hvplot/converter.py
@@ -708,14 +708,14 @@ class HoloViewsConverter(object):
             if groupby:
                 groupby = [g for g in groupby if g not in grid]
 
+            # Add a title to hvplot.xarray plots that displays scalar coords values,
+            # as done by xarray.plot()  
             if not groupby and not grid:
-                # Set a title for coords of size 1 (e.g. da.isel(lon=0).hvplot())
                 if isinstance(da, xr.DataArray):
                     self._title = da._title_for_slice()
                 elif isinstance(da, xr.Dataset):
-                    one_var = list(da.data_vars)[0]
-                    self._title = da[one_var]._title_for_slice()
-
+                    self._title = partial(xr.DataArray._title_for_slice, da)()
+                        
             self.data = data
         else:
             raise ValueError('Supplied data type %s not understood' % type(data).__name__)

--- a/hvplot/tests/testoptions.py
+++ b/hvplot/tests/testoptions.py
@@ -10,296 +10,296 @@ from holoviews.element.comparison import ComparisonTestCase
 import holoviews as hv
 
 
-# class TestOptions(ComparisonTestCase):
+class TestOptions(ComparisonTestCase):
 
-#     def setUp(self):
-#         try:
-#             import pandas as pd
-#         except:
-#             raise SkipTest('Pandas not available')
-#         self.backend = 'bokeh'
-#         hv.extension(self.backend)
-#         Store.current_backend = self.backend
-#         self.store_copy = OptionTree(sorted(Store.options().items()),
-#                                      groups=Options._option_groups)
-#         import hvplot.pandas   # noqa
-#         self.df = pd.DataFrame([[1, 2, 'A', 0.1], [3, 4, 'B', 0.2], [5, 6, 'C', 0.3]],
-#                                columns=['x', 'y', 'category', 'number'])
-#         self.symmetric_df = pd.DataFrame([[1, 2, -1], [3, 4, 0], [5, 6, 1]],
-#                                           columns=['x', 'y', 'number'])
+    def setUp(self):
+        try:
+            import pandas as pd
+        except:
+            raise SkipTest('Pandas not available')
+        self.backend = 'bokeh'
+        hv.extension(self.backend)
+        Store.current_backend = self.backend
+        self.store_copy = OptionTree(sorted(Store.options().items()),
+                                     groups=Options._option_groups)
+        import hvplot.pandas   # noqa
+        self.df = pd.DataFrame([[1, 2, 'A', 0.1], [3, 4, 'B', 0.2], [5, 6, 'C', 0.3]],
+                               columns=['x', 'y', 'category', 'number'])
+        self.symmetric_df = pd.DataFrame([[1, 2, -1], [3, 4, 0], [5, 6, 1]],
+                                          columns=['x', 'y', 'number'])
 
-#     def tearDown(self):
-#         Store.options(val=self.store_copy)
-#         Store._custom_options = {k:{} for k in Store._custom_options.keys()}
-#         super(TestOptions, self).tearDown()
+    def tearDown(self):
+        Store.options(val=self.store_copy)
+        Store._custom_options = {k:{} for k in Store._custom_options.keys()}
+        super(TestOptions, self).tearDown()
 
-#     def test_scatter_legend_position(self):
-#         plot = self.df.hvplot.scatter('x', 'y', c='category', legend='left')
-#         opts = Store.lookup_options('bokeh', plot, 'plot')
-#         self.assertEqual(opts.kwargs['legend_position'], 'left')
+    def test_scatter_legend_position(self):
+        plot = self.df.hvplot.scatter('x', 'y', c='category', legend='left')
+        opts = Store.lookup_options('bokeh', plot, 'plot')
+        self.assertEqual(opts.kwargs['legend_position'], 'left')
 
-#     def test_histogram_by_category_legend_position(self):
-#         plot = self.df.hvplot.hist('y', by='category', legend='left')
-#         opts = Store.lookup_options('bokeh', plot, 'plot')
-#         self.assertEqual(opts.kwargs['legend_position'], 'left')
+    def test_histogram_by_category_legend_position(self):
+        plot = self.df.hvplot.hist('y', by='category', legend='left')
+        opts = Store.lookup_options('bokeh', plot, 'plot')
+        self.assertEqual(opts.kwargs['legend_position'], 'left')
 
-#     @parameterized.expand(['scatter', 'points'])
-#     def test_logz(self, kind):
-#         plot = self.df.hvplot('x', 'y', c='x', logz=True, kind=kind)
-#         opts = Store.lookup_options('bokeh', plot, 'plot')
-#         self.assertEqual(opts.kwargs['logz'], True)
+    @parameterized.expand(['scatter', 'points'])
+    def test_logz(self, kind):
+        plot = self.df.hvplot('x', 'y', c='x', logz=True, kind=kind)
+        opts = Store.lookup_options('bokeh', plot, 'plot')
+        self.assertEqual(opts.kwargs['logz'], True)
 
-#     @parameterized.expand(['scatter', 'points'])
-#     def test_color_dim(self, kind):
-#         plot = self.df.hvplot('x', 'y', c='number', kind=kind)
-#         opts = Store.lookup_options('bokeh', plot, 'style')
-#         self.assertEqual(opts.kwargs['color'], 'number')
-#         self.assertIn('number', plot.vdims)
+    @parameterized.expand(['scatter', 'points'])
+    def test_color_dim(self, kind):
+        plot = self.df.hvplot('x', 'y', c='number', kind=kind)
+        opts = Store.lookup_options('bokeh', plot, 'style')
+        self.assertEqual(opts.kwargs['color'], 'number')
+        self.assertIn('number', plot.vdims)
 
-#     @parameterized.expand(['scatter', 'points'])
-#     def test_size_dim(self, kind):
-#         plot = self.df.hvplot('x', 'y', s='number', kind=kind)
-#         opts = Store.lookup_options('bokeh', plot, 'style')
-#         self.assertEqual(opts.kwargs['size'], 'number')
-#         self.assertIn('number', plot.vdims)
+    @parameterized.expand(['scatter', 'points'])
+    def test_size_dim(self, kind):
+        plot = self.df.hvplot('x', 'y', s='number', kind=kind)
+        opts = Store.lookup_options('bokeh', plot, 'style')
+        self.assertEqual(opts.kwargs['size'], 'number')
+        self.assertIn('number', plot.vdims)
 
-#     @parameterized.expand(['scatter', 'points'])
-#     def test_alpha_dim(self, kind):
-#         plot = self.df.hvplot('x', 'y', alpha='number', kind=kind)
-#         opts = Store.lookup_options('bokeh', plot, 'style')
-#         self.assertEqual(opts.kwargs['alpha'], 'number')
-#         self.assertIn('number', plot.vdims)
+    @parameterized.expand(['scatter', 'points'])
+    def test_alpha_dim(self, kind):
+        plot = self.df.hvplot('x', 'y', alpha='number', kind=kind)
+        opts = Store.lookup_options('bokeh', plot, 'style')
+        self.assertEqual(opts.kwargs['alpha'], 'number')
+        self.assertIn('number', plot.vdims)
 
-#     @parameterized.expand(['scatter', 'points'])
-#     def test_marker_dim(self, kind):
-#         plot = self.df.hvplot('x', 'y', marker='category', kind=kind)
-#         opts = Store.lookup_options('bokeh', plot, 'style')
-#         self.assertEqual(opts.kwargs['marker'], 'category')
-#         self.assertIn('category', plot.vdims)
+    @parameterized.expand(['scatter', 'points'])
+    def test_marker_dim(self, kind):
+        plot = self.df.hvplot('x', 'y', marker='category', kind=kind)
+        opts = Store.lookup_options('bokeh', plot, 'style')
+        self.assertEqual(opts.kwargs['marker'], 'category')
+        self.assertIn('category', plot.vdims)
 
-#     @parameterized.expand(['scatter', 'points'])
-#     def test_color_dim_overlay(self, kind):
-#         plot = self.df.hvplot('x', 'y', c='number', by='category', kind=kind)
-#         opts = Store.lookup_options('bokeh', plot.last, 'style')
-#         self.assertEqual(opts.kwargs['color'], 'number')
-#         self.assertIn('number', plot.last.vdims)
+    @parameterized.expand(['scatter', 'points'])
+    def test_color_dim_overlay(self, kind):
+        plot = self.df.hvplot('x', 'y', c='number', by='category', kind=kind)
+        opts = Store.lookup_options('bokeh', plot.last, 'style')
+        self.assertEqual(opts.kwargs['color'], 'number')
+        self.assertIn('number', plot.last.vdims)
 
-#     @parameterized.expand(['scatter', 'points'])
-#     def test_size_dim_overlay(self, kind):
-#         plot = self.df.hvplot('x', 'y', s='number', by='category', kind=kind)
-#         opts = Store.lookup_options('bokeh', plot.last, 'style')
-#         self.assertEqual(opts.kwargs['size'], 'number')
-#         self.assertIn('number', plot.last.vdims)
+    @parameterized.expand(['scatter', 'points'])
+    def test_size_dim_overlay(self, kind):
+        plot = self.df.hvplot('x', 'y', s='number', by='category', kind=kind)
+        opts = Store.lookup_options('bokeh', plot.last, 'style')
+        self.assertEqual(opts.kwargs['size'], 'number')
+        self.assertIn('number', plot.last.vdims)
 
-#     @parameterized.expand(['scatter', 'points'])
-#     def test_alpha_dim_overlay(self, kind):
-#         plot = self.df.hvplot('x', 'y', alpha='number', by='category', kind=kind)
-#         opts = Store.lookup_options('bokeh', plot.last, 'style')
-#         self.assertEqual(opts.kwargs['alpha'], 'number')
-#         self.assertIn('number', plot.last.vdims)
+    @parameterized.expand(['scatter', 'points'])
+    def test_alpha_dim_overlay(self, kind):
+        plot = self.df.hvplot('x', 'y', alpha='number', by='category', kind=kind)
+        opts = Store.lookup_options('bokeh', plot.last, 'style')
+        self.assertEqual(opts.kwargs['alpha'], 'number')
+        self.assertIn('number', plot.last.vdims)
 
-#     def test_hvplot_defaults(self):
-#         plot = self.df.hvplot.scatter('x', 'y', c='category')
-#         opts = Store.lookup_options('bokeh', plot, 'plot')
-#         self.assertEqual(opts.kwargs['show_legend'], True)
-#         self.assertEqual(opts.kwargs['legend_position'], 'right')
-#         self.assertEqual(opts.kwargs['show_grid'], False)
-#         self.assertEqual(opts.kwargs['responsive'], False)
-#         self.assertEqual(opts.kwargs['shared_axes'], True)
-#         self.assertEqual(opts.kwargs['height'], 300)
-#         self.assertEqual(opts.kwargs['width'], 700)
-#         self.assertEqual(opts.kwargs['logx'], False)
-#         self.assertEqual(opts.kwargs['logy'], False)
-#         self.assertEqual(opts.kwargs.get('logz'), None)
+    def test_hvplot_defaults(self):
+        plot = self.df.hvplot.scatter('x', 'y', c='category')
+        opts = Store.lookup_options('bokeh', plot, 'plot')
+        self.assertEqual(opts.kwargs['show_legend'], True)
+        self.assertEqual(opts.kwargs['legend_position'], 'right')
+        self.assertEqual(opts.kwargs['show_grid'], False)
+        self.assertEqual(opts.kwargs['responsive'], False)
+        self.assertEqual(opts.kwargs['shared_axes'], True)
+        self.assertEqual(opts.kwargs['height'], 300)
+        self.assertEqual(opts.kwargs['width'], 700)
+        self.assertEqual(opts.kwargs['logx'], False)
+        self.assertEqual(opts.kwargs['logy'], False)
+        self.assertEqual(opts.kwargs.get('logz'), None)
 
-#     def test_holoviews_defined_default_opts(self):
-#         hv.opts.defaults(hv.opts.Scatter( height=400, width=900 ,show_grid=True))
-#         plot = self.df.hvplot.scatter('x', 'y', c='category')
-#         opts = Store.lookup_options('bokeh', plot, 'plot')
-#         self.assertEqual(opts.kwargs['legend_position'], 'right')
-#         self.assertEqual(opts.kwargs['show_grid'], True)
-#         self.assertEqual(opts.kwargs['height'], 400)
-#         self.assertEqual(opts.kwargs['width'], 900)
+    def test_holoviews_defined_default_opts(self):
+        hv.opts.defaults(hv.opts.Scatter( height=400, width=900 ,show_grid=True))
+        plot = self.df.hvplot.scatter('x', 'y', c='category')
+        opts = Store.lookup_options('bokeh', plot, 'plot')
+        self.assertEqual(opts.kwargs['legend_position'], 'right')
+        self.assertEqual(opts.kwargs['show_grid'], True)
+        self.assertEqual(opts.kwargs['height'], 400)
+        self.assertEqual(opts.kwargs['width'], 900)
 
-#     def test_holoviews_defined_default_opts_overwritten_in_call(self):
-#         hv.opts.defaults(hv.opts.Scatter(height=400, width=900, show_grid=True))
-#         plot = self.df.hvplot.scatter('x', 'y', c='category', width=300, legend='left')
-#         opts = Store.lookup_options('bokeh', plot, 'plot')
-#         self.assertEqual(opts.kwargs['legend_position'], 'left')
-#         self.assertEqual(opts.kwargs['show_grid'], True)
-#         self.assertEqual(opts.kwargs['height'], 400)
-#         self.assertEqual(opts.kwargs['width'], 300)
+    def test_holoviews_defined_default_opts_overwritten_in_call(self):
+        hv.opts.defaults(hv.opts.Scatter(height=400, width=900, show_grid=True))
+        plot = self.df.hvplot.scatter('x', 'y', c='category', width=300, legend='left')
+        opts = Store.lookup_options('bokeh', plot, 'plot')
+        self.assertEqual(opts.kwargs['legend_position'], 'left')
+        self.assertEqual(opts.kwargs['show_grid'], True)
+        self.assertEqual(opts.kwargs['height'], 400)
+        self.assertEqual(opts.kwargs['width'], 300)
 
-#     def test_holoviews_defined_default_opts_are_not_mutable(self):
-#         hv.opts.defaults(hv.opts.Scatter(tools=['tap']))
-#         plot = self.df.hvplot.scatter('x', 'y', c='category')
-#         opts = Store.lookup_options('bokeh', plot, 'plot')
-#         self.assertEqual(opts.kwargs['tools'], ['tap', 'hover'])
-#         default_opts = Store.options(backend='bokeh')['Scatter'].groups['plot'].options
-#         self.assertEqual(default_opts['tools'], ['tap'])
+    def test_holoviews_defined_default_opts_are_not_mutable(self):
+        hv.opts.defaults(hv.opts.Scatter(tools=['tap']))
+        plot = self.df.hvplot.scatter('x', 'y', c='category')
+        opts = Store.lookup_options('bokeh', plot, 'plot')
+        self.assertEqual(opts.kwargs['tools'], ['tap', 'hover'])
+        default_opts = Store.options(backend='bokeh')['Scatter'].groups['plot'].options
+        self.assertEqual(default_opts['tools'], ['tap'])
 
-#     def test_axis_set_to_visible_by_default(self):
-#         plot = self.df.hvplot.scatter('x', 'y', c='category')
-#         opts = Store.lookup_options('bokeh', plot, 'plot')
-#         assert 'xaxis' not in opts.kwargs
-#         assert 'yaxis' not in opts.kwargs
+    def test_axis_set_to_visible_by_default(self):
+        plot = self.df.hvplot.scatter('x', 'y', c='category')
+        opts = Store.lookup_options('bokeh', plot, 'plot')
+        assert 'xaxis' not in opts.kwargs
+        assert 'yaxis' not in opts.kwargs
 
-#     def test_axis_set_to_none(self):
-#         plot = self.df.hvplot.scatter('x', 'y', c='category', xaxis=None, yaxis=None)
-#         opts = Store.lookup_options('bokeh', plot, 'plot')
-#         self.assertEqual(opts.kwargs['xaxis'], None)
-#         self.assertEqual(opts.kwargs['yaxis'], None)
+    def test_axis_set_to_none(self):
+        plot = self.df.hvplot.scatter('x', 'y', c='category', xaxis=None, yaxis=None)
+        opts = Store.lookup_options('bokeh', plot, 'plot')
+        self.assertEqual(opts.kwargs['xaxis'], None)
+        self.assertEqual(opts.kwargs['yaxis'], None)
 
-#     def test_axis_set_to_false(self):
-#         plot = self.df.hvplot.scatter('x', 'y', c='category', xaxis=False, yaxis=False)
-#         opts = Store.lookup_options('bokeh', plot, 'plot')
-#         self.assertEqual(opts.kwargs['xaxis'], None)
-#         self.assertEqual(opts.kwargs['yaxis'], None)
+    def test_axis_set_to_false(self):
+        plot = self.df.hvplot.scatter('x', 'y', c='category', xaxis=False, yaxis=False)
+        opts = Store.lookup_options('bokeh', plot, 'plot')
+        self.assertEqual(opts.kwargs['xaxis'], None)
+        self.assertEqual(opts.kwargs['yaxis'], None)
 
-#     def test_axis_set_to_none_in_holoviews_opts_default(self):
-#         hv.opts.defaults(hv.opts.Scatter(xaxis=None, yaxis=None))
-#         plot = self.df.hvplot.scatter('x', 'y', c='category')
-#         opts = Store.lookup_options('bokeh', plot, 'plot')
-#         self.assertEqual(opts.kwargs['xaxis'], None)
-#         self.assertEqual(opts.kwargs['yaxis'], None)
+    def test_axis_set_to_none_in_holoviews_opts_default(self):
+        hv.opts.defaults(hv.opts.Scatter(xaxis=None, yaxis=None))
+        plot = self.df.hvplot.scatter('x', 'y', c='category')
+        opts = Store.lookup_options('bokeh', plot, 'plot')
+        self.assertEqual(opts.kwargs['xaxis'], None)
+        self.assertEqual(opts.kwargs['yaxis'], None)
 
-#     @expectedFailure
-#     def test_axis_set_to_none_in_holoviews_opts_default_overwrite_in_call(self):
-#         hv.opts.defaults(hv.opts.Scatter(xaxis=None, yaxis=None))
-#         plot = self.df.hvplot.scatter('x', 'y', c='category', xaxis=True, yaxis=True)
-#         opts = Store.lookup_options('bokeh', plot, 'plot')
-#         assert 'xaxis' not in opts.kwargs
-#         assert 'yaxis' not in opts.kwargs
+    @expectedFailure
+    def test_axis_set_to_none_in_holoviews_opts_default_overwrite_in_call(self):
+        hv.opts.defaults(hv.opts.Scatter(xaxis=None, yaxis=None))
+        plot = self.df.hvplot.scatter('x', 'y', c='category', xaxis=True, yaxis=True)
+        opts = Store.lookup_options('bokeh', plot, 'plot')
+        assert 'xaxis' not in opts.kwargs
+        assert 'yaxis' not in opts.kwargs
 
-#     def test_loglog_opts(self):
-#         plot = self.df.hvplot.scatter('x', 'y', c='category', loglog=True)
-#         opts = Store.lookup_options('bokeh', plot, 'plot')
-#         self.assertEqual(opts.kwargs['logx'], True)
-#         self.assertEqual(opts.kwargs['logy'], True)
-#         self.assertEqual(opts.kwargs.get('logz'), None)
+    def test_loglog_opts(self):
+        plot = self.df.hvplot.scatter('x', 'y', c='category', loglog=True)
+        opts = Store.lookup_options('bokeh', plot, 'plot')
+        self.assertEqual(opts.kwargs['logx'], True)
+        self.assertEqual(opts.kwargs['logy'], True)
+        self.assertEqual(opts.kwargs.get('logz'), None)
 
-#     def test_logy_opts(self):
-#         plot = self.df.hvplot.scatter('x', 'y', c='category', logy=True)
-#         opts = Store.lookup_options('bokeh', plot, 'plot')
-#         self.assertEqual(opts.kwargs['logx'], False)
-#         self.assertEqual(opts.kwargs['logy'], True)
-#         self.assertEqual(opts.kwargs.get('logz'), None)
+    def test_logy_opts(self):
+        plot = self.df.hvplot.scatter('x', 'y', c='category', logy=True)
+        opts = Store.lookup_options('bokeh', plot, 'plot')
+        self.assertEqual(opts.kwargs['logx'], False)
+        self.assertEqual(opts.kwargs['logy'], True)
+        self.assertEqual(opts.kwargs.get('logz'), None)
 
-#     def test_holoviews_defined_default_opts_logx(self):
-#         hv.opts.defaults(hv.opts.Scatter(logx=True))
-#         plot = self.df.hvplot.scatter('x', 'y', c='category')
-#         opts = Store.lookup_options('bokeh', plot, 'plot')
-#         self.assertEqual(opts.kwargs['logx'], True)
-#         self.assertEqual(opts.kwargs['logy'], False)
-#         self.assertEqual(opts.kwargs.get('logz'), None)
+    def test_holoviews_defined_default_opts_logx(self):
+        hv.opts.defaults(hv.opts.Scatter(logx=True))
+        plot = self.df.hvplot.scatter('x', 'y', c='category')
+        opts = Store.lookup_options('bokeh', plot, 'plot')
+        self.assertEqual(opts.kwargs['logx'], True)
+        self.assertEqual(opts.kwargs['logy'], False)
+        self.assertEqual(opts.kwargs.get('logz'), None)
 
-#     def test_holoviews_defined_default_opts_logx_overwritten_in_call(self):
-#         hv.opts.defaults(hv.opts.Scatter(logx=True))
-#         plot = self.df.hvplot.scatter('x', 'y', c='category', logx=False)
-#         opts = Store.lookup_options('bokeh', plot, 'plot')
-#         self.assertEqual(opts.kwargs['logx'], False)
-#         self.assertEqual(opts.kwargs['logy'], False)
-#         self.assertEqual(opts.kwargs.get('logz'), None)
+    def test_holoviews_defined_default_opts_logx_overwritten_in_call(self):
+        hv.opts.defaults(hv.opts.Scatter(logx=True))
+        plot = self.df.hvplot.scatter('x', 'y', c='category', logx=False)
+        opts = Store.lookup_options('bokeh', plot, 'plot')
+        self.assertEqual(opts.kwargs['logx'], False)
+        self.assertEqual(opts.kwargs['logy'], False)
+        self.assertEqual(opts.kwargs.get('logz'), None)
 
-#     def test_hvplot_default_cat_cmap_opts(self):
-#         import colorcet as cc
-#         plot = self.df.hvplot.scatter('x', 'y', c='category')
-#         opts = Store.lookup_options('bokeh', plot, 'style')
-#         self.assertEqual(opts.kwargs['cmap'], cc.palette['glasbey_category10'])
+    def test_hvplot_default_cat_cmap_opts(self):
+        import colorcet as cc
+        plot = self.df.hvplot.scatter('x', 'y', c='category')
+        opts = Store.lookup_options('bokeh', plot, 'style')
+        self.assertEqual(opts.kwargs['cmap'], cc.palette['glasbey_category10'])
 
-#     def test_hvplot_default_num_cmap_opts(self):
-#         plot = self.df.hvplot.scatter('x', 'y', c='number')
-#         opts = Store.lookup_options('bokeh', plot, 'style')
-#         self.assertEqual(opts.kwargs['cmap'], 'kbc_r')
+    def test_hvplot_default_num_cmap_opts(self):
+        plot = self.df.hvplot.scatter('x', 'y', c='number')
+        opts = Store.lookup_options('bokeh', plot, 'style')
+        self.assertEqual(opts.kwargs['cmap'], 'kbc_r')
 
-#     def test_cmap_opts_by_type(self):
-#         plot = self.df.hvplot.scatter('x', 'y', c='number', cmap='diverging')
-#         opts = Store.lookup_options('bokeh', plot, 'style')
-#         self.assertEqual(opts.kwargs['cmap'], 'coolwarm')
+    def test_cmap_opts_by_type(self):
+        plot = self.df.hvplot.scatter('x', 'y', c='number', cmap='diverging')
+        opts = Store.lookup_options('bokeh', plot, 'style')
+        self.assertEqual(opts.kwargs['cmap'], 'coolwarm')
 
-#     def test_cmap_opts_by_name(self):
-#         plot = self.df.hvplot.scatter('x', 'y', c='number', cmap='fire')
-#         opts = Store.lookup_options('bokeh', plot, 'style')
-#         self.assertEqual(opts.kwargs['cmap'], 'fire')
+    def test_cmap_opts_by_name(self):
+        plot = self.df.hvplot.scatter('x', 'y', c='number', cmap='fire')
+        opts = Store.lookup_options('bokeh', plot, 'style')
+        self.assertEqual(opts.kwargs['cmap'], 'fire')
 
-#     def test_colormap_opts_by_name(self):
-#         plot = self.df.hvplot.scatter('x', 'y', c='number', colormap='fire')
-#         opts = Store.lookup_options('bokeh', plot, 'style')
-#         self.assertEqual(opts.kwargs['cmap'], 'fire')
+    def test_colormap_opts_by_name(self):
+        plot = self.df.hvplot.scatter('x', 'y', c='number', colormap='fire')
+        opts = Store.lookup_options('bokeh', plot, 'style')
+        self.assertEqual(opts.kwargs['cmap'], 'fire')
 
-#     def test_cmap_opts_as_a_list(self):
-#         plot = self.df.hvplot.scatter('x', 'y', c='number', cmap=['red', 'blue', 'green'])
-#         opts = Store.lookup_options('bokeh', plot, 'style')
-#         self.assertEqual(opts.kwargs['cmap'], ['red', 'blue', 'green'])
+    def test_cmap_opts_as_a_list(self):
+        plot = self.df.hvplot.scatter('x', 'y', c='number', cmap=['red', 'blue', 'green'])
+        opts = Store.lookup_options('bokeh', plot, 'style')
+        self.assertEqual(opts.kwargs['cmap'], ['red', 'blue', 'green'])
 
-#     @parameterized.expand([('aspect',), ('data_aspect',)])
-#     def test_aspect(self, opt):
-#         plot = self.df.hvplot(x='x', y='y', **{opt: 2})
-#         opts = Store.lookup_options('bokeh', plot, 'plot').kwargs
-#         self.assertEqual(opts[opt], 2)
-#         self.assertEqual(opts.get('width'), None)
-#         self.assertEqual(opts.get('height'), None)
+    @parameterized.expand([('aspect',), ('data_aspect',)])
+    def test_aspect(self, opt):
+        plot = self.df.hvplot(x='x', y='y', **{opt: 2})
+        opts = Store.lookup_options('bokeh', plot, 'plot').kwargs
+        self.assertEqual(opts[opt], 2)
+        self.assertEqual(opts.get('width'), None)
+        self.assertEqual(opts.get('height'), None)
 
-#     @parameterized.expand([('aspect',), ('data_aspect',)])
-#     def test_aspect_and_width(self, opt):
-#         plot = self.df.hvplot(x='x', y='y', width=150, **{opt: 2})
-#         opts = hv.Store.lookup_options('bokeh', plot, 'plot').kwargs
-#         self.assertEqual(opts[opt], 2)
-#         self.assertEqual(opts.get('width'), 150)
-#         self.assertEqual(opts.get('height'), None)
+    @parameterized.expand([('aspect',), ('data_aspect',)])
+    def test_aspect_and_width(self, opt):
+        plot = self.df.hvplot(x='x', y='y', width=150, **{opt: 2})
+        opts = hv.Store.lookup_options('bokeh', plot, 'plot').kwargs
+        self.assertEqual(opts[opt], 2)
+        self.assertEqual(opts.get('width'), 150)
+        self.assertEqual(opts.get('height'), None)
 
-#     def test_symmetric_dataframe(self):
-#         import pandas as pd
-#         df = pd.DataFrame([[1, 2, -1], [3, 4, 0], [5, 6, 1]],
-#                           columns=['x', 'y', 'number'])
-#         plot = df.hvplot.scatter('x', 'y', c='number')
-#         plot_opts = Store.lookup_options('bokeh', plot, 'plot')
-#         self.assertEqual(plot_opts.kwargs['symmetric'], True)
-#         style_opts = Store.lookup_options('bokeh', plot, 'style')
-#         self.assertEqual(style_opts.kwargs['cmap'], 'coolwarm')
+    def test_symmetric_dataframe(self):
+        import pandas as pd
+        df = pd.DataFrame([[1, 2, -1], [3, 4, 0], [5, 6, 1]],
+                          columns=['x', 'y', 'number'])
+        plot = df.hvplot.scatter('x', 'y', c='number')
+        plot_opts = Store.lookup_options('bokeh', plot, 'plot')
+        self.assertEqual(plot_opts.kwargs['symmetric'], True)
+        style_opts = Store.lookup_options('bokeh', plot, 'style')
+        self.assertEqual(style_opts.kwargs['cmap'], 'coolwarm')
 
-#     def test_symmetric_is_deduced_dataframe(self):
-#         plot = self.symmetric_df.hvplot.scatter('x', 'y', c='number')
-#         plot_opts = Store.lookup_options('bokeh', plot, 'plot')
-#         self.assertEqual(plot_opts.kwargs['symmetric'], True)
-#         style_opts = Store.lookup_options('bokeh', plot, 'style')
-#         self.assertEqual(style_opts.kwargs['cmap'], 'coolwarm')
+    def test_symmetric_is_deduced_dataframe(self):
+        plot = self.symmetric_df.hvplot.scatter('x', 'y', c='number')
+        plot_opts = Store.lookup_options('bokeh', plot, 'plot')
+        self.assertEqual(plot_opts.kwargs['symmetric'], True)
+        style_opts = Store.lookup_options('bokeh', plot, 'style')
+        self.assertEqual(style_opts.kwargs['cmap'], 'coolwarm')
 
-#     def test_symmetric_from_opts(self):
-#         plot = self.df.hvplot.scatter('x', 'y', c='number', symmetric=True)
-#         plot_opts = Store.lookup_options('bokeh', plot, 'plot')
-#         self.assertEqual(plot_opts.kwargs['symmetric'], True)
-#         style_opts = Store.lookup_options('bokeh', plot, 'style')
-#         self.assertEqual(style_opts.kwargs['cmap'], 'coolwarm')
+    def test_symmetric_from_opts(self):
+        plot = self.df.hvplot.scatter('x', 'y', c='number', symmetric=True)
+        plot_opts = Store.lookup_options('bokeh', plot, 'plot')
+        self.assertEqual(plot_opts.kwargs['symmetric'], True)
+        style_opts = Store.lookup_options('bokeh', plot, 'style')
+        self.assertEqual(style_opts.kwargs['cmap'], 'coolwarm')
 
-#     def test_symmetric_from_opts_does_not_deduce(self):
-#         plot = self.symmetric_df.hvplot.scatter('x', 'y', c='number', symmetric=False)
-#         plot_opts = Store.lookup_options('bokeh', plot, 'plot')
-#         self.assertEqual(plot_opts.kwargs['symmetric'], False)
-#         style_opts = Store.lookup_options('bokeh', plot, 'style')
-#         self.assertEqual(style_opts.kwargs['cmap'], 'kbc_r')
+    def test_symmetric_from_opts_does_not_deduce(self):
+        plot = self.symmetric_df.hvplot.scatter('x', 'y', c='number', symmetric=False)
+        plot_opts = Store.lookup_options('bokeh', plot, 'plot')
+        self.assertEqual(plot_opts.kwargs['symmetric'], False)
+        style_opts = Store.lookup_options('bokeh', plot, 'style')
+        self.assertEqual(style_opts.kwargs['cmap'], 'kbc_r')
 
-#     def test_if_clim_is_set_symmetric_is_not_deduced(self):
-#         plot = self.symmetric_df.hvplot.scatter('x', 'y', c='number', clim=(-1,1))
-#         plot_opts = Store.lookup_options('bokeh', plot, 'plot')
-#         self.assertEqual(plot_opts.kwargs.get('symmetric'), None)
-#         style_opts = Store.lookup_options('bokeh', plot, 'style')
-#         self.assertEqual(style_opts.kwargs['cmap'], 'kbc_r')
+    def test_if_clim_is_set_symmetric_is_not_deduced(self):
+        plot = self.symmetric_df.hvplot.scatter('x', 'y', c='number', clim=(-1,1))
+        plot_opts = Store.lookup_options('bokeh', plot, 'plot')
+        self.assertEqual(plot_opts.kwargs.get('symmetric'), None)
+        style_opts = Store.lookup_options('bokeh', plot, 'style')
+        self.assertEqual(style_opts.kwargs['cmap'], 'kbc_r')
 
-#     def test_bivariate_opts(self):
-#         plot = self.df.hvplot.bivariate('x', 'y', bandwidth=0.2, cut=1, levels=5, filled=True)
-#         opts = Store.lookup_options('bokeh', plot, 'plot')
-#         self.assertEqual(opts.kwargs['bandwidth'], 0.2)
-#         self.assertEqual(opts.kwargs['cut'], 1)
-#         self.assertEqual(opts.kwargs['levels'], 5)
-#         self.assertEqual(opts.kwargs['filled'], True)
+    def test_bivariate_opts(self):
+        plot = self.df.hvplot.bivariate('x', 'y', bandwidth=0.2, cut=1, levels=5, filled=True)
+        opts = Store.lookup_options('bokeh', plot, 'plot')
+        self.assertEqual(opts.kwargs['bandwidth'], 0.2)
+        self.assertEqual(opts.kwargs['cut'], 1)
+        self.assertEqual(opts.kwargs['levels'], 5)
+        self.assertEqual(opts.kwargs['filled'], True)
 
-#     def test_kde_opts(self):
-#         plot = self.df.hvplot.kde('x', bandwidth=0.2, cut=1, filled=True)
-#         opts = Store.lookup_options('bokeh', plot, 'plot')
-#         self.assertEqual(opts.kwargs['bandwidth'], 0.2)
-#         self.assertEqual(opts.kwargs['cut'], 1)
-#         self.assertEqual(opts.kwargs['filled'], True)
+    def test_kde_opts(self):
+        plot = self.df.hvplot.kde('x', bandwidth=0.2, cut=1, filled=True)
+        opts = Store.lookup_options('bokeh', plot, 'plot')
+        self.assertEqual(opts.kwargs['bandwidth'], 0.2)
+        self.assertEqual(opts.kwargs['cut'], 1)
+        self.assertEqual(opts.kwargs['filled'], True)
 
 class TestXarrayTitle(ComparisonTestCase):
 

--- a/hvplot/tests/testoptions.py
+++ b/hvplot/tests/testoptions.py
@@ -1,5 +1,7 @@
 from unittest import SkipTest, expectedFailure
 
+import numpy as np
+
 from parameterized import parameterized
 
 from holoviews import Store
@@ -8,293 +10,377 @@ from holoviews.element.comparison import ComparisonTestCase
 import holoviews as hv
 
 
-class TestOptions(ComparisonTestCase):
+# class TestOptions(ComparisonTestCase):
+
+#     def setUp(self):
+#         try:
+#             import pandas as pd
+#         except:
+#             raise SkipTest('Pandas not available')
+#         self.backend = 'bokeh'
+#         hv.extension(self.backend)
+#         Store.current_backend = self.backend
+#         self.store_copy = OptionTree(sorted(Store.options().items()),
+#                                      groups=Options._option_groups)
+#         import hvplot.pandas   # noqa
+#         self.df = pd.DataFrame([[1, 2, 'A', 0.1], [3, 4, 'B', 0.2], [5, 6, 'C', 0.3]],
+#                                columns=['x', 'y', 'category', 'number'])
+#         self.symmetric_df = pd.DataFrame([[1, 2, -1], [3, 4, 0], [5, 6, 1]],
+#                                           columns=['x', 'y', 'number'])
+
+#     def tearDown(self):
+#         Store.options(val=self.store_copy)
+#         Store._custom_options = {k:{} for k in Store._custom_options.keys()}
+#         super(TestOptions, self).tearDown()
+
+#     def test_scatter_legend_position(self):
+#         plot = self.df.hvplot.scatter('x', 'y', c='category', legend='left')
+#         opts = Store.lookup_options('bokeh', plot, 'plot')
+#         self.assertEqual(opts.kwargs['legend_position'], 'left')
+
+#     def test_histogram_by_category_legend_position(self):
+#         plot = self.df.hvplot.hist('y', by='category', legend='left')
+#         opts = Store.lookup_options('bokeh', plot, 'plot')
+#         self.assertEqual(opts.kwargs['legend_position'], 'left')
+
+#     @parameterized.expand(['scatter', 'points'])
+#     def test_logz(self, kind):
+#         plot = self.df.hvplot('x', 'y', c='x', logz=True, kind=kind)
+#         opts = Store.lookup_options('bokeh', plot, 'plot')
+#         self.assertEqual(opts.kwargs['logz'], True)
+
+#     @parameterized.expand(['scatter', 'points'])
+#     def test_color_dim(self, kind):
+#         plot = self.df.hvplot('x', 'y', c='number', kind=kind)
+#         opts = Store.lookup_options('bokeh', plot, 'style')
+#         self.assertEqual(opts.kwargs['color'], 'number')
+#         self.assertIn('number', plot.vdims)
+
+#     @parameterized.expand(['scatter', 'points'])
+#     def test_size_dim(self, kind):
+#         plot = self.df.hvplot('x', 'y', s='number', kind=kind)
+#         opts = Store.lookup_options('bokeh', plot, 'style')
+#         self.assertEqual(opts.kwargs['size'], 'number')
+#         self.assertIn('number', plot.vdims)
+
+#     @parameterized.expand(['scatter', 'points'])
+#     def test_alpha_dim(self, kind):
+#         plot = self.df.hvplot('x', 'y', alpha='number', kind=kind)
+#         opts = Store.lookup_options('bokeh', plot, 'style')
+#         self.assertEqual(opts.kwargs['alpha'], 'number')
+#         self.assertIn('number', plot.vdims)
+
+#     @parameterized.expand(['scatter', 'points'])
+#     def test_marker_dim(self, kind):
+#         plot = self.df.hvplot('x', 'y', marker='category', kind=kind)
+#         opts = Store.lookup_options('bokeh', plot, 'style')
+#         self.assertEqual(opts.kwargs['marker'], 'category')
+#         self.assertIn('category', plot.vdims)
+
+#     @parameterized.expand(['scatter', 'points'])
+#     def test_color_dim_overlay(self, kind):
+#         plot = self.df.hvplot('x', 'y', c='number', by='category', kind=kind)
+#         opts = Store.lookup_options('bokeh', plot.last, 'style')
+#         self.assertEqual(opts.kwargs['color'], 'number')
+#         self.assertIn('number', plot.last.vdims)
+
+#     @parameterized.expand(['scatter', 'points'])
+#     def test_size_dim_overlay(self, kind):
+#         plot = self.df.hvplot('x', 'y', s='number', by='category', kind=kind)
+#         opts = Store.lookup_options('bokeh', plot.last, 'style')
+#         self.assertEqual(opts.kwargs['size'], 'number')
+#         self.assertIn('number', plot.last.vdims)
+
+#     @parameterized.expand(['scatter', 'points'])
+#     def test_alpha_dim_overlay(self, kind):
+#         plot = self.df.hvplot('x', 'y', alpha='number', by='category', kind=kind)
+#         opts = Store.lookup_options('bokeh', plot.last, 'style')
+#         self.assertEqual(opts.kwargs['alpha'], 'number')
+#         self.assertIn('number', plot.last.vdims)
+
+#     def test_hvplot_defaults(self):
+#         plot = self.df.hvplot.scatter('x', 'y', c='category')
+#         opts = Store.lookup_options('bokeh', plot, 'plot')
+#         self.assertEqual(opts.kwargs['show_legend'], True)
+#         self.assertEqual(opts.kwargs['legend_position'], 'right')
+#         self.assertEqual(opts.kwargs['show_grid'], False)
+#         self.assertEqual(opts.kwargs['responsive'], False)
+#         self.assertEqual(opts.kwargs['shared_axes'], True)
+#         self.assertEqual(opts.kwargs['height'], 300)
+#         self.assertEqual(opts.kwargs['width'], 700)
+#         self.assertEqual(opts.kwargs['logx'], False)
+#         self.assertEqual(opts.kwargs['logy'], False)
+#         self.assertEqual(opts.kwargs.get('logz'), None)
+
+#     def test_holoviews_defined_default_opts(self):
+#         hv.opts.defaults(hv.opts.Scatter( height=400, width=900 ,show_grid=True))
+#         plot = self.df.hvplot.scatter('x', 'y', c='category')
+#         opts = Store.lookup_options('bokeh', plot, 'plot')
+#         self.assertEqual(opts.kwargs['legend_position'], 'right')
+#         self.assertEqual(opts.kwargs['show_grid'], True)
+#         self.assertEqual(opts.kwargs['height'], 400)
+#         self.assertEqual(opts.kwargs['width'], 900)
+
+#     def test_holoviews_defined_default_opts_overwritten_in_call(self):
+#         hv.opts.defaults(hv.opts.Scatter(height=400, width=900, show_grid=True))
+#         plot = self.df.hvplot.scatter('x', 'y', c='category', width=300, legend='left')
+#         opts = Store.lookup_options('bokeh', plot, 'plot')
+#         self.assertEqual(opts.kwargs['legend_position'], 'left')
+#         self.assertEqual(opts.kwargs['show_grid'], True)
+#         self.assertEqual(opts.kwargs['height'], 400)
+#         self.assertEqual(opts.kwargs['width'], 300)
+
+#     def test_holoviews_defined_default_opts_are_not_mutable(self):
+#         hv.opts.defaults(hv.opts.Scatter(tools=['tap']))
+#         plot = self.df.hvplot.scatter('x', 'y', c='category')
+#         opts = Store.lookup_options('bokeh', plot, 'plot')
+#         self.assertEqual(opts.kwargs['tools'], ['tap', 'hover'])
+#         default_opts = Store.options(backend='bokeh')['Scatter'].groups['plot'].options
+#         self.assertEqual(default_opts['tools'], ['tap'])
+
+#     def test_axis_set_to_visible_by_default(self):
+#         plot = self.df.hvplot.scatter('x', 'y', c='category')
+#         opts = Store.lookup_options('bokeh', plot, 'plot')
+#         assert 'xaxis' not in opts.kwargs
+#         assert 'yaxis' not in opts.kwargs
+
+#     def test_axis_set_to_none(self):
+#         plot = self.df.hvplot.scatter('x', 'y', c='category', xaxis=None, yaxis=None)
+#         opts = Store.lookup_options('bokeh', plot, 'plot')
+#         self.assertEqual(opts.kwargs['xaxis'], None)
+#         self.assertEqual(opts.kwargs['yaxis'], None)
+
+#     def test_axis_set_to_false(self):
+#         plot = self.df.hvplot.scatter('x', 'y', c='category', xaxis=False, yaxis=False)
+#         opts = Store.lookup_options('bokeh', plot, 'plot')
+#         self.assertEqual(opts.kwargs['xaxis'], None)
+#         self.assertEqual(opts.kwargs['yaxis'], None)
+
+#     def test_axis_set_to_none_in_holoviews_opts_default(self):
+#         hv.opts.defaults(hv.opts.Scatter(xaxis=None, yaxis=None))
+#         plot = self.df.hvplot.scatter('x', 'y', c='category')
+#         opts = Store.lookup_options('bokeh', plot, 'plot')
+#         self.assertEqual(opts.kwargs['xaxis'], None)
+#         self.assertEqual(opts.kwargs['yaxis'], None)
+
+#     @expectedFailure
+#     def test_axis_set_to_none_in_holoviews_opts_default_overwrite_in_call(self):
+#         hv.opts.defaults(hv.opts.Scatter(xaxis=None, yaxis=None))
+#         plot = self.df.hvplot.scatter('x', 'y', c='category', xaxis=True, yaxis=True)
+#         opts = Store.lookup_options('bokeh', plot, 'plot')
+#         assert 'xaxis' not in opts.kwargs
+#         assert 'yaxis' not in opts.kwargs
+
+#     def test_loglog_opts(self):
+#         plot = self.df.hvplot.scatter('x', 'y', c='category', loglog=True)
+#         opts = Store.lookup_options('bokeh', plot, 'plot')
+#         self.assertEqual(opts.kwargs['logx'], True)
+#         self.assertEqual(opts.kwargs['logy'], True)
+#         self.assertEqual(opts.kwargs.get('logz'), None)
+
+#     def test_logy_opts(self):
+#         plot = self.df.hvplot.scatter('x', 'y', c='category', logy=True)
+#         opts = Store.lookup_options('bokeh', plot, 'plot')
+#         self.assertEqual(opts.kwargs['logx'], False)
+#         self.assertEqual(opts.kwargs['logy'], True)
+#         self.assertEqual(opts.kwargs.get('logz'), None)
+
+#     def test_holoviews_defined_default_opts_logx(self):
+#         hv.opts.defaults(hv.opts.Scatter(logx=True))
+#         plot = self.df.hvplot.scatter('x', 'y', c='category')
+#         opts = Store.lookup_options('bokeh', plot, 'plot')
+#         self.assertEqual(opts.kwargs['logx'], True)
+#         self.assertEqual(opts.kwargs['logy'], False)
+#         self.assertEqual(opts.kwargs.get('logz'), None)
+
+#     def test_holoviews_defined_default_opts_logx_overwritten_in_call(self):
+#         hv.opts.defaults(hv.opts.Scatter(logx=True))
+#         plot = self.df.hvplot.scatter('x', 'y', c='category', logx=False)
+#         opts = Store.lookup_options('bokeh', plot, 'plot')
+#         self.assertEqual(opts.kwargs['logx'], False)
+#         self.assertEqual(opts.kwargs['logy'], False)
+#         self.assertEqual(opts.kwargs.get('logz'), None)
+
+#     def test_hvplot_default_cat_cmap_opts(self):
+#         import colorcet as cc
+#         plot = self.df.hvplot.scatter('x', 'y', c='category')
+#         opts = Store.lookup_options('bokeh', plot, 'style')
+#         self.assertEqual(opts.kwargs['cmap'], cc.palette['glasbey_category10'])
+
+#     def test_hvplot_default_num_cmap_opts(self):
+#         plot = self.df.hvplot.scatter('x', 'y', c='number')
+#         opts = Store.lookup_options('bokeh', plot, 'style')
+#         self.assertEqual(opts.kwargs['cmap'], 'kbc_r')
+
+#     def test_cmap_opts_by_type(self):
+#         plot = self.df.hvplot.scatter('x', 'y', c='number', cmap='diverging')
+#         opts = Store.lookup_options('bokeh', plot, 'style')
+#         self.assertEqual(opts.kwargs['cmap'], 'coolwarm')
+
+#     def test_cmap_opts_by_name(self):
+#         plot = self.df.hvplot.scatter('x', 'y', c='number', cmap='fire')
+#         opts = Store.lookup_options('bokeh', plot, 'style')
+#         self.assertEqual(opts.kwargs['cmap'], 'fire')
+
+#     def test_colormap_opts_by_name(self):
+#         plot = self.df.hvplot.scatter('x', 'y', c='number', colormap='fire')
+#         opts = Store.lookup_options('bokeh', plot, 'style')
+#         self.assertEqual(opts.kwargs['cmap'], 'fire')
+
+#     def test_cmap_opts_as_a_list(self):
+#         plot = self.df.hvplot.scatter('x', 'y', c='number', cmap=['red', 'blue', 'green'])
+#         opts = Store.lookup_options('bokeh', plot, 'style')
+#         self.assertEqual(opts.kwargs['cmap'], ['red', 'blue', 'green'])
+
+#     @parameterized.expand([('aspect',), ('data_aspect',)])
+#     def test_aspect(self, opt):
+#         plot = self.df.hvplot(x='x', y='y', **{opt: 2})
+#         opts = Store.lookup_options('bokeh', plot, 'plot').kwargs
+#         self.assertEqual(opts[opt], 2)
+#         self.assertEqual(opts.get('width'), None)
+#         self.assertEqual(opts.get('height'), None)
+
+#     @parameterized.expand([('aspect',), ('data_aspect',)])
+#     def test_aspect_and_width(self, opt):
+#         plot = self.df.hvplot(x='x', y='y', width=150, **{opt: 2})
+#         opts = hv.Store.lookup_options('bokeh', plot, 'plot').kwargs
+#         self.assertEqual(opts[opt], 2)
+#         self.assertEqual(opts.get('width'), 150)
+#         self.assertEqual(opts.get('height'), None)
+
+#     def test_symmetric_dataframe(self):
+#         import pandas as pd
+#         df = pd.DataFrame([[1, 2, -1], [3, 4, 0], [5, 6, 1]],
+#                           columns=['x', 'y', 'number'])
+#         plot = df.hvplot.scatter('x', 'y', c='number')
+#         plot_opts = Store.lookup_options('bokeh', plot, 'plot')
+#         self.assertEqual(plot_opts.kwargs['symmetric'], True)
+#         style_opts = Store.lookup_options('bokeh', plot, 'style')
+#         self.assertEqual(style_opts.kwargs['cmap'], 'coolwarm')
+
+#     def test_symmetric_is_deduced_dataframe(self):
+#         plot = self.symmetric_df.hvplot.scatter('x', 'y', c='number')
+#         plot_opts = Store.lookup_options('bokeh', plot, 'plot')
+#         self.assertEqual(plot_opts.kwargs['symmetric'], True)
+#         style_opts = Store.lookup_options('bokeh', plot, 'style')
+#         self.assertEqual(style_opts.kwargs['cmap'], 'coolwarm')
+
+#     def test_symmetric_from_opts(self):
+#         plot = self.df.hvplot.scatter('x', 'y', c='number', symmetric=True)
+#         plot_opts = Store.lookup_options('bokeh', plot, 'plot')
+#         self.assertEqual(plot_opts.kwargs['symmetric'], True)
+#         style_opts = Store.lookup_options('bokeh', plot, 'style')
+#         self.assertEqual(style_opts.kwargs['cmap'], 'coolwarm')
+
+#     def test_symmetric_from_opts_does_not_deduce(self):
+#         plot = self.symmetric_df.hvplot.scatter('x', 'y', c='number', symmetric=False)
+#         plot_opts = Store.lookup_options('bokeh', plot, 'plot')
+#         self.assertEqual(plot_opts.kwargs['symmetric'], False)
+#         style_opts = Store.lookup_options('bokeh', plot, 'style')
+#         self.assertEqual(style_opts.kwargs['cmap'], 'kbc_r')
+
+#     def test_if_clim_is_set_symmetric_is_not_deduced(self):
+#         plot = self.symmetric_df.hvplot.scatter('x', 'y', c='number', clim=(-1,1))
+#         plot_opts = Store.lookup_options('bokeh', plot, 'plot')
+#         self.assertEqual(plot_opts.kwargs.get('symmetric'), None)
+#         style_opts = Store.lookup_options('bokeh', plot, 'style')
+#         self.assertEqual(style_opts.kwargs['cmap'], 'kbc_r')
+
+#     def test_bivariate_opts(self):
+#         plot = self.df.hvplot.bivariate('x', 'y', bandwidth=0.2, cut=1, levels=5, filled=True)
+#         opts = Store.lookup_options('bokeh', plot, 'plot')
+#         self.assertEqual(opts.kwargs['bandwidth'], 0.2)
+#         self.assertEqual(opts.kwargs['cut'], 1)
+#         self.assertEqual(opts.kwargs['levels'], 5)
+#         self.assertEqual(opts.kwargs['filled'], True)
+
+#     def test_kde_opts(self):
+#         plot = self.df.hvplot.kde('x', bandwidth=0.2, cut=1, filled=True)
+#         opts = Store.lookup_options('bokeh', plot, 'plot')
+#         self.assertEqual(opts.kwargs['bandwidth'], 0.2)
+#         self.assertEqual(opts.kwargs['cut'], 1)
+#         self.assertEqual(opts.kwargs['filled'], True)
+
+class TestXarrayTitle(ComparisonTestCase):
 
     def setUp(self):
         try:
-            import pandas as pd
+            import xarray as xr
         except:
-            raise SkipTest('Pandas not available')
+            raise SkipTest('Xarray not available')
         self.backend = 'bokeh'
         hv.extension(self.backend)
         Store.current_backend = self.backend
         self.store_copy = OptionTree(sorted(Store.options().items()),
                                      groups=Options._option_groups)
-        import hvplot.pandas   # noqa
-        self.df = pd.DataFrame([[1, 2, 'A', 0.1], [3, 4, 'B', 0.2], [5, 6, 'C', 0.3]],
-                               columns=['x', 'y', 'category', 'number'])
-        self.symmetric_df = pd.DataFrame([[1, 2, -1], [3, 4, 0], [5, 6, 1]],
-                                          columns=['x', 'y', 'number'])
+        import hvplot.xarray   # noqa
+        self.da = xr.DataArray(
+            data=np.arange(16).reshape((2, 2, 2, 2)),
+            coords={'time': [0, 1], 'y': [0, 1], 'x': [0, 1], 'band': [0, 1]},
+            dims=['time', 'y', 'x', 'band'],
+            name='test',
+        )
+        da2 = xr.DataArray(
+            data=np.arange(27).reshape((3, 3, 3)),
+            coords={'y': [0, 1, 2], 'x': [0, 1, 2]},
+            dims=['y', 'x', 'other'],
+            name='test2'
+        )
+        self.ds1 = xr.Dataset(dict(foo=self.da))
+        self.ds2 = xr.Dataset(dict(foo=self.da, bar=da2))
 
     def tearDown(self):
         Store.options(val=self.store_copy)
         Store._custom_options = {k:{} for k in Store._custom_options.keys()}
-        super(TestOptions, self).tearDown()
+        super(TestXarrayTitle, self).tearDown()
 
-    def test_scatter_legend_position(self):
-        plot = self.df.hvplot.scatter('x', 'y', c='category', legend='left')
+    def test_dataarray_2d_with_title(self):
+        da_sel = self.da.sel(time=0, band=0)
+        plot = da_sel.hvplot()  # Image plot
         opts = Store.lookup_options('bokeh', plot, 'plot')
-        self.assertEqual(opts.kwargs['legend_position'], 'left')
+        self.assertEqual(opts.kwargs['title'], 'time = 0, band = 0')
 
-    def test_histogram_by_category_legend_position(self):
-        plot = self.df.hvplot.hist('y', by='category', legend='left')
+    def test_dataarray_1d_with_title(self):
+        da_sel = self.da.sel(time=0, band=0, x=0)
+        plot = da_sel.hvplot()  # Line plot
         opts = Store.lookup_options('bokeh', plot, 'plot')
-        self.assertEqual(opts.kwargs['legend_position'], 'left')
+        self.assertEqual(opts.kwargs['title'], 'time = 0, x = 0, band = 0')
 
-    @parameterized.expand(['scatter', 'points'])
-    def test_logz(self, kind):
-        plot = self.df.hvplot('x', 'y', c='x', logz=True, kind=kind)
+    def test_dataarray_1d_and_by_with_title(self):
+        da_sel = self.da.sel(time=0, band=0, x=[0, 1])
+        plot = da_sel.hvplot(by='x')  # Line plot with hue/by
         opts = Store.lookup_options('bokeh', plot, 'plot')
-        self.assertEqual(opts.kwargs['logz'], True)
+        self.assertEqual(opts.kwargs['title'], 'time = 0, band = 0')
 
-    @parameterized.expand(['scatter', 'points'])
-    def test_color_dim(self, kind):
-        plot = self.df.hvplot('x', 'y', c='number', kind=kind)
-        opts = Store.lookup_options('bokeh', plot, 'style')
-        self.assertEqual(opts.kwargs['color'], 'number')
-        self.assertIn('number', plot.vdims)
-
-    @parameterized.expand(['scatter', 'points'])
-    def test_size_dim(self, kind):
-        plot = self.df.hvplot('x', 'y', s='number', kind=kind)
-        opts = Store.lookup_options('bokeh', plot, 'style')
-        self.assertEqual(opts.kwargs['size'], 'number')
-        self.assertIn('number', plot.vdims)
-
-    @parameterized.expand(['scatter', 'points'])
-    def test_alpha_dim(self, kind):
-        plot = self.df.hvplot('x', 'y', alpha='number', kind=kind)
-        opts = Store.lookup_options('bokeh', plot, 'style')
-        self.assertEqual(opts.kwargs['alpha'], 'number')
-        self.assertIn('number', plot.vdims)
-
-    @parameterized.expand(['scatter', 'points'])
-    def test_marker_dim(self, kind):
-        plot = self.df.hvplot('x', 'y', marker='category', kind=kind)
-        opts = Store.lookup_options('bokeh', plot, 'style')
-        self.assertEqual(opts.kwargs['marker'], 'category')
-        self.assertIn('category', plot.vdims)
-
-    @parameterized.expand(['scatter', 'points'])
-    def test_color_dim_overlay(self, kind):
-        plot = self.df.hvplot('x', 'y', c='number', by='category', kind=kind)
-        opts = Store.lookup_options('bokeh', plot.last, 'style')
-        self.assertEqual(opts.kwargs['color'], 'number')
-        self.assertIn('number', plot.last.vdims)
-
-    @parameterized.expand(['scatter', 'points'])
-    def test_size_dim_overlay(self, kind):
-        plot = self.df.hvplot('x', 'y', s='number', by='category', kind=kind)
-        opts = Store.lookup_options('bokeh', plot.last, 'style')
-        self.assertEqual(opts.kwargs['size'], 'number')
-        self.assertIn('number', plot.last.vdims)
-
-    @parameterized.expand(['scatter', 'points'])
-    def test_alpha_dim_overlay(self, kind):
-        plot = self.df.hvplot('x', 'y', alpha='number', by='category', kind=kind)
-        opts = Store.lookup_options('bokeh', plot.last, 'style')
-        self.assertEqual(opts.kwargs['alpha'], 'number')
-        self.assertIn('number', plot.last.vdims)
-
-    def test_hvplot_defaults(self):
-        plot = self.df.hvplot.scatter('x', 'y', c='category')
+    def test_override_title(self):
+        da_sel = self.da.sel(time=0, band=0)
+        plot = da_sel.hvplot(title='title')  # Imege plot
         opts = Store.lookup_options('bokeh', plot, 'plot')
-        self.assertEqual(opts.kwargs['show_legend'], True)
-        self.assertEqual(opts.kwargs['legend_position'], 'right')
-        self.assertEqual(opts.kwargs['show_grid'], False)
-        self.assertEqual(opts.kwargs['responsive'], False)
-        self.assertEqual(opts.kwargs['shared_axes'], True)
-        self.assertEqual(opts.kwargs['height'], 300)
-        self.assertEqual(opts.kwargs['width'], 700)
-        self.assertEqual(opts.kwargs['logx'], False)
-        self.assertEqual(opts.kwargs['logy'], False)
-        self.assertEqual(opts.kwargs.get('logz'), None)
+        self.assertEqual(opts.kwargs['title'], 'title')
 
-    def test_holoviews_defined_default_opts(self):
-        hv.opts.defaults(hv.opts.Scatter( height=400, width=900 ,show_grid=True))
-        plot = self.df.hvplot.scatter('x', 'y', c='category')
+    def test_dataarray_4d_line_no_title(self):
+        plot = self.da.hvplot.line(dynamic=False)  # Line plot with widgets
+        opts = Store.lookup_options('bokeh', plot.last, 'plot')
+        self.assertNotIn('title', opts.kwargs)
+
+    def test_dataarray_3d_histogram_with_title(self):
+        da_sel = self.da.sel(time=0)
+        plot = da_sel.hvplot()  # Histogram and no widgets
         opts = Store.lookup_options('bokeh', plot, 'plot')
-        self.assertEqual(opts.kwargs['legend_position'], 'right')
-        self.assertEqual(opts.kwargs['show_grid'], True)
-        self.assertEqual(opts.kwargs['height'], 400)
-        self.assertEqual(opts.kwargs['width'], 900)
+        self.assertEqual(opts.kwargs['title'], 'time = 0')
 
-    def test_holoviews_defined_default_opts_overwritten_in_call(self):
-        hv.opts.defaults(hv.opts.Scatter(height=400, width=900, show_grid=True))
-        plot = self.df.hvplot.scatter('x', 'y', c='category', width=300, legend='left')
+    def test_dataset_empty_raises(self):
+        with self.assertRaisesRegex(ValueError, 'empty xarray.Dataset'):
+            self.ds1.drop('foo').hvplot()
+
+    def test_dataset_one_var_behaves_like_dataarray(self):
+        ds_sel = self.ds1.sel(time=0, band=0)
+        plot = ds_sel.hvplot()  # Image plot
         opts = Store.lookup_options('bokeh', plot, 'plot')
-        self.assertEqual(opts.kwargs['legend_position'], 'left')
-        self.assertEqual(opts.kwargs['show_grid'], True)
-        self.assertEqual(opts.kwargs['height'], 400)
-        self.assertEqual(opts.kwargs['width'], 300)
+        self.assertEqual(opts.kwargs['title'], 'time = 0, band = 0')
 
-    def test_holoviews_defined_default_opts_are_not_mutable(self):
-        hv.opts.defaults(hv.opts.Scatter(tools=['tap']))
-        plot = self.df.hvplot.scatter('x', 'y', c='category')
+    def test_dataset_scatter_with_title(self):
+        ds_sel = self.ds2.sel(time=0, band=0, x=0, y=0)
+        plot = ds_sel.hvplot.scatter(x='foo', y='bar')  # Image plot
         opts = Store.lookup_options('bokeh', plot, 'plot')
-        self.assertEqual(opts.kwargs['tools'], ['tap', 'hover'])
-        default_opts = Store.options(backend='bokeh')['Scatter'].groups['plot'].options
-        self.assertEqual(default_opts['tools'], ['tap'])
-
-    def test_axis_set_to_visible_by_default(self):
-        plot = self.df.hvplot.scatter('x', 'y', c='category')
-        opts = Store.lookup_options('bokeh', plot, 'plot')
-        assert 'xaxis' not in opts.kwargs
-        assert 'yaxis' not in opts.kwargs
-
-    def test_axis_set_to_none(self):
-        plot = self.df.hvplot.scatter('x', 'y', c='category', xaxis=None, yaxis=None)
-        opts = Store.lookup_options('bokeh', plot, 'plot')
-        self.assertEqual(opts.kwargs['xaxis'], None)
-        self.assertEqual(opts.kwargs['yaxis'], None)
-
-    def test_axis_set_to_false(self):
-        plot = self.df.hvplot.scatter('x', 'y', c='category', xaxis=False, yaxis=False)
-        opts = Store.lookup_options('bokeh', plot, 'plot')
-        self.assertEqual(opts.kwargs['xaxis'], None)
-        self.assertEqual(opts.kwargs['yaxis'], None)
-
-    def test_axis_set_to_none_in_holoviews_opts_default(self):
-        hv.opts.defaults(hv.opts.Scatter(xaxis=None, yaxis=None))
-        plot = self.df.hvplot.scatter('x', 'y', c='category')
-        opts = Store.lookup_options('bokeh', plot, 'plot')
-        self.assertEqual(opts.kwargs['xaxis'], None)
-        self.assertEqual(opts.kwargs['yaxis'], None)
-
-    @expectedFailure
-    def test_axis_set_to_none_in_holoviews_opts_default_overwrite_in_call(self):
-        hv.opts.defaults(hv.opts.Scatter(xaxis=None, yaxis=None))
-        plot = self.df.hvplot.scatter('x', 'y', c='category', xaxis=True, yaxis=True)
-        opts = Store.lookup_options('bokeh', plot, 'plot')
-        assert 'xaxis' not in opts.kwargs
-        assert 'yaxis' not in opts.kwargs
-
-    def test_loglog_opts(self):
-        plot = self.df.hvplot.scatter('x', 'y', c='category', loglog=True)
-        opts = Store.lookup_options('bokeh', plot, 'plot')
-        self.assertEqual(opts.kwargs['logx'], True)
-        self.assertEqual(opts.kwargs['logy'], True)
-        self.assertEqual(opts.kwargs.get('logz'), None)
-
-    def test_logy_opts(self):
-        plot = self.df.hvplot.scatter('x', 'y', c='category', logy=True)
-        opts = Store.lookup_options('bokeh', plot, 'plot')
-        self.assertEqual(opts.kwargs['logx'], False)
-        self.assertEqual(opts.kwargs['logy'], True)
-        self.assertEqual(opts.kwargs.get('logz'), None)
-
-    def test_holoviews_defined_default_opts_logx(self):
-        hv.opts.defaults(hv.opts.Scatter(logx=True))
-        plot = self.df.hvplot.scatter('x', 'y', c='category')
-        opts = Store.lookup_options('bokeh', plot, 'plot')
-        self.assertEqual(opts.kwargs['logx'], True)
-        self.assertEqual(opts.kwargs['logy'], False)
-        self.assertEqual(opts.kwargs.get('logz'), None)
-
-    def test_holoviews_defined_default_opts_logx_overwritten_in_call(self):
-        hv.opts.defaults(hv.opts.Scatter(logx=True))
-        plot = self.df.hvplot.scatter('x', 'y', c='category', logx=False)
-        opts = Store.lookup_options('bokeh', plot, 'plot')
-        self.assertEqual(opts.kwargs['logx'], False)
-        self.assertEqual(opts.kwargs['logy'], False)
-        self.assertEqual(opts.kwargs.get('logz'), None)
-
-    def test_hvplot_default_cat_cmap_opts(self):
-        import colorcet as cc
-        plot = self.df.hvplot.scatter('x', 'y', c='category')
-        opts = Store.lookup_options('bokeh', plot, 'style')
-        self.assertEqual(opts.kwargs['cmap'], cc.palette['glasbey_category10'])
-
-    def test_hvplot_default_num_cmap_opts(self):
-        plot = self.df.hvplot.scatter('x', 'y', c='number')
-        opts = Store.lookup_options('bokeh', plot, 'style')
-        self.assertEqual(opts.kwargs['cmap'], 'kbc_r')
-
-    def test_cmap_opts_by_type(self):
-        plot = self.df.hvplot.scatter('x', 'y', c='number', cmap='diverging')
-        opts = Store.lookup_options('bokeh', plot, 'style')
-        self.assertEqual(opts.kwargs['cmap'], 'coolwarm')
-
-    def test_cmap_opts_by_name(self):
-        plot = self.df.hvplot.scatter('x', 'y', c='number', cmap='fire')
-        opts = Store.lookup_options('bokeh', plot, 'style')
-        self.assertEqual(opts.kwargs['cmap'], 'fire')
-
-    def test_colormap_opts_by_name(self):
-        plot = self.df.hvplot.scatter('x', 'y', c='number', colormap='fire')
-        opts = Store.lookup_options('bokeh', plot, 'style')
-        self.assertEqual(opts.kwargs['cmap'], 'fire')
-
-    def test_cmap_opts_as_a_list(self):
-        plot = self.df.hvplot.scatter('x', 'y', c='number', cmap=['red', 'blue', 'green'])
-        opts = Store.lookup_options('bokeh', plot, 'style')
-        self.assertEqual(opts.kwargs['cmap'], ['red', 'blue', 'green'])
-
-    @parameterized.expand([('aspect',), ('data_aspect',)])
-    def test_aspect(self, opt):
-        plot = self.df.hvplot(x='x', y='y', **{opt: 2})
-        opts = Store.lookup_options('bokeh', plot, 'plot').kwargs
-        self.assertEqual(opts[opt], 2)
-        self.assertEqual(opts.get('width'), None)
-        self.assertEqual(opts.get('height'), None)
-
-    @parameterized.expand([('aspect',), ('data_aspect',)])
-    def test_aspect_and_width(self, opt):
-        plot = self.df.hvplot(x='x', y='y', width=150, **{opt: 2})
-        opts = hv.Store.lookup_options('bokeh', plot, 'plot').kwargs
-        self.assertEqual(opts[opt], 2)
-        self.assertEqual(opts.get('width'), 150)
-        self.assertEqual(opts.get('height'), None)
-
-    def test_symmetric_dataframe(self):
-        import pandas as pd
-        df = pd.DataFrame([[1, 2, -1], [3, 4, 0], [5, 6, 1]],
-                          columns=['x', 'y', 'number'])
-        plot = df.hvplot.scatter('x', 'y', c='number')
-        plot_opts = Store.lookup_options('bokeh', plot, 'plot')
-        self.assertEqual(plot_opts.kwargs['symmetric'], True)
-        style_opts = Store.lookup_options('bokeh', plot, 'style')
-        self.assertEqual(style_opts.kwargs['cmap'], 'coolwarm')
-
-    def test_symmetric_is_deduced_dataframe(self):
-        plot = self.symmetric_df.hvplot.scatter('x', 'y', c='number')
-        plot_opts = Store.lookup_options('bokeh', plot, 'plot')
-        self.assertEqual(plot_opts.kwargs['symmetric'], True)
-        style_opts = Store.lookup_options('bokeh', plot, 'style')
-        self.assertEqual(style_opts.kwargs['cmap'], 'coolwarm')
-
-    def test_symmetric_from_opts(self):
-        plot = self.df.hvplot.scatter('x', 'y', c='number', symmetric=True)
-        plot_opts = Store.lookup_options('bokeh', plot, 'plot')
-        self.assertEqual(plot_opts.kwargs['symmetric'], True)
-        style_opts = Store.lookup_options('bokeh', plot, 'style')
-        self.assertEqual(style_opts.kwargs['cmap'], 'coolwarm')
-
-    def test_symmetric_from_opts_does_not_deduce(self):
-        plot = self.symmetric_df.hvplot.scatter('x', 'y', c='number', symmetric=False)
-        plot_opts = Store.lookup_options('bokeh', plot, 'plot')
-        self.assertEqual(plot_opts.kwargs['symmetric'], False)
-        style_opts = Store.lookup_options('bokeh', plot, 'style')
-        self.assertEqual(style_opts.kwargs['cmap'], 'kbc_r')
-
-    def test_if_clim_is_set_symmetric_is_not_deduced(self):
-        plot = self.symmetric_df.hvplot.scatter('x', 'y', c='number', clim=(-1,1))
-        plot_opts = Store.lookup_options('bokeh', plot, 'plot')
-        self.assertEqual(plot_opts.kwargs.get('symmetric'), None)
-        style_opts = Store.lookup_options('bokeh', plot, 'style')
-        self.assertEqual(style_opts.kwargs['cmap'], 'kbc_r')
-
-    def test_bivariate_opts(self):
-        plot = self.df.hvplot.bivariate('x', 'y', bandwidth=0.2, cut=1, levels=5, filled=True)
-        opts = Store.lookup_options('bokeh', plot, 'plot')
-        self.assertEqual(opts.kwargs['bandwidth'], 0.2)
-        self.assertEqual(opts.kwargs['cut'], 1)
-        self.assertEqual(opts.kwargs['levels'], 5)
-        self.assertEqual(opts.kwargs['filled'], True)
-
-    def test_kde_opts(self):
-        plot = self.df.hvplot.kde('x', bandwidth=0.2, cut=1, filled=True)
-        opts = Store.lookup_options('bokeh', plot, 'plot')
-        self.assertEqual(opts.kwargs['bandwidth'], 0.2)
-        self.assertEqual(opts.kwargs['cut'], 1)
-        self.assertEqual(opts.kwargs['filled'], True)
+        self.assertEqual(opts.kwargs['title'], 'y = 0, x = 0, time = 0, band = 0')


### PR DESCRIPTION
Fixes #656 

Plots based on xarray objects that have scalar coords (e.g. `da.isel(lon=0)`) will get an informative title as one would get with xarray.plot() API. The generated title is equal to xarray's title since internally xarray's formatting utilities are used. This is part of their private API but this code hasn't changed in years.

There are a couple of differences with xarray:
1. If the data has more than two dimensions it will default to a histogram without providing it further hints. In that case xarray.plot() just sets `'Histogram'` as a title, while hvplot() will set the informative title (e.g. `lon = 250`).
2. Whenever widgets are generated to explore the data (groupby op) the title is not changed, it is a title generated by holoviews that is in sync with the widget's values and displays them ({label}: {value} {unit}, ...).

```python
import xarray as xr
import hvplot.xarray  # noqa

ds_air = xr.tutorial.open_dataset("air_temperature")

# DataArray

air = ds_air.air

# Same as before, the title reflects the widgets' state
air.isel().hvplot.line()

# New title: lat = 75.0, lon = 200.0
air.isel(lat=0, lon=0).hvplot.line()

# New title: lon = 285.0
air.sel(lat=[20, 40, 60], lon=285).plot.line(hue='lat')

# New title: time = 2013-06-01T12:00:00'
air.sel(time='2013-06-01 12:00').hvplot()

# New title: lon = 285.0
air.sel(lat=[25, 50, 75], lon=285).hvplot.kde('air', alpha=0.5)

# Dataset

# New title that includes already existing scalar coords and those
# obtained by the iselection 
ds_roms.isel(s_rho=0, ocean_time=0).hvplot.scatter(x='salt', y='zeta')
```
