### PR TITLE
Fix a broken test due to PROJ unexpectedly matching 'foo'

### DIFF
--- a/hvplot/tests/testgeo.py
+++ b/hvplot/tests/testgeo.py
@@ -63,8 +63,11 @@ class TestProjections(TestGeo):
         self.assertCRS(plot)
 
     def test_plot_with_crs_as_nonexistent_attr_str(self):
-        with self.assertRaisesRegex(ValueError, "'foo' must be"):
-            self.da.hvplot.image('x', 'y', crs='foo')
+        # Used to test crs='foo' but this is parsed under-the-hood
+        # by PROJ (projinfo) which matches a geographic projection named
+        # 'Amersfoort'
+        with self.assertRaisesRegex(ValueError, "'wrong' must be"):
+            self.da.hvplot.image('x', 'y', crs='wrong')
 
     def test_plot_with_geo_as_true_crs_no_crs_on_data_returns_default(self):
         da = self.da.copy()

--- a/hvplot/tests/testgeo.py
+++ b/hvplot/tests/testgeo.py
@@ -67,7 +67,7 @@ class TestProjections(TestGeo):
         # by PROJ (projinfo) which matches a geographic projection named
         # 'Amersfoort'
         with self.assertRaisesRegex(ValueError, "'name_of_some_invalid_projection' must be"):
-            self.da.hvplot.image('x', 'y', crs='wrong')
+            self.da.hvplot.image('x', 'y', crs='name_of_some_invalid_projection')
 
     def test_plot_with_geo_as_true_crs_no_crs_on_data_returns_default(self):
         da = self.da.copy()

--- a/hvplot/tests/testgeo.py
+++ b/hvplot/tests/testgeo.py
@@ -66,7 +66,7 @@ class TestProjections(TestGeo):
         # Used to test crs='foo' but this is parsed under-the-hood
         # by PROJ (projinfo) which matches a geographic projection named
         # 'Amersfoort'
-        with self.assertRaisesRegex(ValueError, "'wrong' must be"):
+        with self.assertRaisesRegex(ValueError, "'name_of_some_invalid_projection' must be"):
             self.da.hvplot.image('x', 'y', crs='wrong')
 
     def test_plot_with_geo_as_true_crs_no_crs_on_data_returns_default(self):


### PR DESCRIPTION
Fixes #657 

The code uses PROJ under the hood that matches `'foo'` with a projection named `'Amersfoort'`. Replaced by '`name_of_some_invalid_projection'` which doesn't match and should never match any projection in the future.