### PR TITLE
Docs - Remove link to 'getting_started'.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Several of these libraries have the concept of a high-level plotting API that le
 
 hvPlot provides a high-level plotting API built on HoloViews that provides a general and consistent API for plotting data in all the abovementioned formats. hvPlot can integrate neatly with the individual libraries if an extension mechanism for the native plot APIs is offered, or it can be used as a standalone component.
 
-To start using hvplot have a look at the [Getting Started Guide](https://hvplot.holoviz.org/getting_started/index.html) and check out the current functionality in the [User Guide.](https://hvplot.holoviz.org/user_guide/index.html)
+To start using hvplot have a look at the [installation instructions](https://hvplot.holoviz.org/index.html#installation) and check out the current functionality in the [User Guide.](https://hvplot.holoviz.org/user_guide/index.html)
 
 <img src="http://blog.holoviz.org/images/hvplot_collage.png">
 

--- a/examples/homepage.ipynb
+++ b/examples/homepage.ipynb
@@ -21,7 +21,7 @@
     "\n",
     "Several of these libraries have the concept of a high-level plotting API that lets a user generate common plot types very easily. The native plotting APIs are generally built on [Matplotlib](http://matplotlib.org), which provides a solid foundation, but it means that users miss out on the benefits of modern, interactive plotting libraries built for the web like [Bokeh](http://bokeh.pydata.org) and [HoloViews](http://holoviews.org).\n",
     "\n",
-    "hvPlot provides a high-level plotting API built on HoloViews that provides a general and consistent API for plotting data in all the abovementioned formats. hvPlot can integrate neatly with the individual libraries if an extension mechanism for the native plot APIs is offered, or it can be used as a standalone component. To get started jump straight into the [Getting Started Guide](getting_started/index.html) and check out the current functionality in the [User Guide.](user_guide/index.html)"
+    "hvPlot provides a high-level plotting API built on HoloViews that provides a general and consistent API for plotting data in all the abovementioned formats. hvPlot can integrate neatly with the individual libraries if an extension mechanism for the native plot APIs is offered, or it can be used as a standalone component. To get started jump straight into the [installation instructions](#installation) and check out the current functionality in the [User Guide.](user_guide/index.html)"
    ]
   },
   {


### PR DESCRIPTION
Guide was previously removed. The content provided installation instructions to which I am changing the wording and link to.

The commit that removed the guide: https://github.com/holoviz/hvplot/commit/8d3c7ecbc0ba296ea34d799cc1b069839df7ec56