### PR TITLE
Update the default internal value of `clim` to support Matplotlib

### DIFF
--- a/hvplot/converter.py
+++ b/hvplot/converter.py
@@ -529,7 +529,7 @@ class HoloViewsConverter(object):
         # Process dimensions and labels
         self.label = label
         self._relabel = {'label': label} if label else {}
-        self._dim_ranges = {'c': clim or (np.nan, np.nan)}
+        self._dim_ranges = {'c': clim or (None, None)}
 
         # High-level options
         self._validate_kwds(kwds)

--- a/hvplot/converter.py
+++ b/hvplot/converter.py
@@ -1949,7 +1949,8 @@ class HoloViewsConverter(object):
         levels = self.kwds.get('levels', 5)
         if isinstance(levels, int):
             opts['color_levels'] = levels
-        opts['clim'] = self._dim_ranges['c']
+        if self._dim_ranges['c'] != (None, None):
+            opts['clim'] = self._dim_ranges['c']
         return contours(qmesh, filled=filled, levels=levels).opts(**opts)
 
     def contourf(self, x=None, y=None, z=None, data=None):

--- a/hvplot/converter.py
+++ b/hvplot/converter.py
@@ -529,7 +529,7 @@ class HoloViewsConverter(object):
         # Process dimensions and labels
         self.label = label
         self._relabel = {'label': label} if label else {}
-        self._dim_ranges = {'c': clim or (None, None)}
+        self._dim_ranges = {'c': clim or (np.nan, np.nan)}
 
         # High-level options
         self._validate_kwds(kwds)


### PR DESCRIPTION
PR in preparation of the upcoming support of Matplotlib and Plotly.

`self._dim_ranges['c']` was set to either `clim` if not None or to `(None, None)`. This caused no issue with the Bokeh backend of holoviews, which accepts a `param.Tuple` for `clim` and handles properly when it includes `None`. However both the Matplotlib and Plotly backends accept a `param.NumericTuple` only.

The Bokeh backend used to accept a `param.NumericTuple` only as well, but that was changed in https://github.com/holoviz/holoviews/pull/4383. The right fix might be to add support to whatever the Bokeh backend supports to Matplotlib & Plotly with allowing them to accept a non-numeric tuple for `clim`, but since I don't know what exactly this PR was about I went for the simpler, and hopefully correct, solution.

An important question here would be, does the bokeh backend behave the same way when `clim` is set to `(None, None)`  compared to `(np.nan, np.nan)`?

@jlstevens pinging you since we talked about it briefly already 🙃 