### PR TITLE
State that the data cannot be symmetric if it's empty

### DIFF
--- a/hvplot/converter.py
+++ b/hvplot/converter.py
@@ -559,6 +559,9 @@ class HoloViewsConverter(object):
         else:
             return
 
+        if data.size == 0:
+            return False
+        
         cmin = np.nanquantile(data, 0.05)
         cmax = np.nanquantile(data, 0.95)
 


### PR DESCRIPTION
A RuntimeWarning was emitted by numpy with the following snippet. It was trying to calculate `np.nanquantile` on an empty series in this case.
```
import pandas as pd
import hvplot.pandas

df = pd.DataFrame({'x': [], 'y': [], 'color': []})
df.hvplot(kind='scatter', x='x', y='y', color='color')
```

The only thing I'm unsure of is whether the data variable always has a `size` parameter. In other words, what type of object could `data` possibly be in this function?