### PR TITLE
Ensure bokeh/panel extension is loaded only once

### DIFF
--- a/hvplot/__init__.py
+++ b/hvplot/__init__.py
@@ -5,6 +5,7 @@ import inspect
 import textwrap
 
 import param
+import panel as _pn
 import holoviews as _hv
 
 from holoviews import Store
@@ -109,7 +110,12 @@ def help(kind=None, docstring=True, generic=True, style=True):
 
 def post_patch(extension='bokeh', logo=False):
     if extension and not getattr(_hv.extension, '_loaded', False):
-        _hv.extension(extension, logo=logo)
+        if getattr(_pn.extension, '_loaded', False):
+            ext = _hv.extension._backends[extension]
+            __import__('holoviews.plotting.%s' % ext)
+            _hv.Store.set_current_backend(extension)
+        else:
+            _hv.extension(extension, logo=logo)
 
 
 def _patch_doc(cls, kind):


### PR DESCRIPTION
If the panel extension is already loaded do not load it a second time, instead simply initialize the selected HoloViews backend.