### PR TITLE
Add scatter matrix reference

### DIFF
--- a/examples/reference/pandas/scattermatrix.ipynb
+++ b/examples/reference/pandas/scattermatrix.ipynb
@@ -1,0 +1,196 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "from hvplot.plotting import scatter_matrix"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`scatter_matrix` shows all the pairwise relationships between the columns. Each non-diagonal plots the corresponding columns against each other, while the diagonal plot shows the distribution of each individual column.\n",
+    "\n",
+    "This function is closely modelled on [pandas.plotting.scatter_matrix](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.plotting.scatter_matrix.html)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Parameters:\n",
+    "\n",
+    "* **`data`** (`DataFrame`): The data to plot. Every column is compared to every other column.\n",
+    "* **`c`** (`str`, optional): Column to color by\n",
+    "* **`chart`** (`str`, optional): Chart type for the off-diagonal plots (one of 'scatter', 'bivariate', 'hexbin')\n",
+    "* **`diagonal`**: (`str`, optional): Chart type for the diagonal plots (one of 'hist', 'kde')\n",
+    "* **`alpha`** (`float`, optional): Transparency level for the off-diagonal plots\n",
+    "* **`nonselection_alpha`** (`float`, optional): Transparency level for nonselected object in the off-diagonal plots\n",
+    "* **`tools`** (`list` of `str`, optional) Interaction tools to include. Defaults are 'box_select' and 'lasso_select'\n",
+    "* **`cmap`/`colormap`**: (`str` or colormap object, optional): Colormap to use for off-diagonal plots.  Default is [Category10](https://github.com/d3/d3-3.x-api-reference/blob/master/Ordinal-Scales.md#category10).\n",
+    "* **`diagonal_kwds`/`hist_kwds`/`density_kwds`** (`dict`, optional): Keyword options for the diagonal plots\n",
+    "* **`datashade`**(default=False):  Whether to apply rasterization and shading (colormapping) using the Datashader library, returning an RGB object instead of \n",
+    "    individual points\n",
+    "* **`rasterize`**(default=False): Whether to apply rasterization using the Datashader library, returning an aggregated Image (to be colormapped by the \n",
+    "    plotting backend) instead of individual points\n",
+    "* **`dynspread`**(default=False): For plots generated with datashade=True or rasterize=True,  automatically increase the point size when the data is sparse\n",
+    "    so that individual points become more visible. kwds supported include ``max_px``, ``threshold``,  ``shape``, ``how`` and ``mask``.\n",
+    "* **`spread`**(default=False): Make plots generated with datashade=True or rasterize=True increase the point size to make points more visible, by applying a fixed spreading of a certain number of cells/pixels. kwds\n",
+    "    supported include: ``px``, ``shape``, ``how`` and ``mask``.\n",
+    "* **`kwds`** : Keyword options for the off-diagonal plots and datashader's spreading , optional\n",
+    "\n",
+    "___"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = pd.DataFrame(np.random.randn(1000, 4), columns=['A','B','C','D'])\n",
+    "\n",
+    "scatter_matrix(df, alpha=0.2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_sub = df[['A', 'B']].copy()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The `chart` parameter allows to change the type of the *off-diagonal* plots."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "scatter_matrix(df_sub, chart='bivariate') + scatter_matrix(df_sub, chart='hexbin')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The `diagonal` parameter allows to change the type of the *diagonal* plots."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "scatter_matrix(df_sub, diagonal='kde')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Setting `tools` to include a selection tool like `box_select` and an inspection tool like `hover` permits further analysis."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "scatter_matrix(df_sub, tools=['box_select', 'hover'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_sub['CAT'] = np.random.choice(['X', 'Y', 'Z'], len(df_sub))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The `c` parameter allows to colorize the data by a given column, here by `'CAT'`. Note also that the `diagonal_kwds` parameter (equivalent to `hist_kwds` in this case or `density_kwds` for *kde* plots) allow to customize the diagonal plots."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "scatter_matrix(df_sub, c='CAT', diagonal_kwds=dict(alpha=0.3))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = pd.DataFrame(np.random.randn(100_000, 4), columns=['A','B','C','D'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Scatter matrix plots may end up with a large number of points having to be rendered which can be challenging for the browser or even just crash it. In that case you should consider setting to `True` the `rasterize` (or `datashade`) parameter that uses [Datashader](https://datashader.org/) to render the off-diagonal plots on the backend and then send more efficient image-based representations to the browser.\n",
+    "\n",
+    "The following scatter matrix plot has 1,200,00 (12x100,000) points that are rendered efficiently by `datashader`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "scatter_matrix(df, rasterize=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "When `rasterize` (or `datashade`) is toggled it's possible to make individual points more visible by setting `dynspread=True` or `spread=True`. Head over to the [Working with large data using datashader](https://holoviews.org/user_guide/Large_Data.html) guide of [HoloViews](https://holoviews.org/index.html) to learn more about these operations and what parameters they accept (which can be passed as `kwds` to `scatter_matrix`)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "scatter_matrix(df, rasterize=True, dynspread=True)"
+   ]
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "name": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/reference/pandas/scattermatrix.ipynb
+++ b/examples/reference/pandas/scattermatrix.ipynb
@@ -15,37 +15,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "`scatter_matrix` shows all the pairwise relationships between the columns. Each non-diagonal plots the corresponding columns against each other, while the diagonal plot shows the distribution of each individual column.\n",
+    "`scatter_matrix` shows all the pairwise relationships between the columns of your data. Each non-diagonal entry plots the corresponding columns against another, while the diagonal plot shows the distribution of the data within each individual column.\n",
     "\n",
     "This function is closely modelled on [pandas.plotting.scatter_matrix](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.plotting.scatter_matrix.html)."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Parameters:\n",
-    "\n",
-    "* **`data`** (`DataFrame`): The data to plot. Every column is compared to every other column.\n",
-    "* **`c`** (`str`, optional): Column to color by\n",
-    "* **`chart`** (`str`, optional): Chart type for the off-diagonal plots (one of 'scatter', 'bivariate', 'hexbin')\n",
-    "* **`diagonal`**: (`str`, optional): Chart type for the diagonal plots (one of 'hist', 'kde')\n",
-    "* **`alpha`** (`float`, optional): Transparency level for the off-diagonal plots\n",
-    "* **`nonselection_alpha`** (`float`, optional): Transparency level for nonselected object in the off-diagonal plots\n",
-    "* **`tools`** (`list` of `str`, optional) Interaction tools to include. Defaults are 'box_select' and 'lasso_select'\n",
-    "* **`cmap`/`colormap`**: (`str` or colormap object, optional): Colormap to use for off-diagonal plots.  Default is [Category10](https://github.com/d3/d3-3.x-api-reference/blob/master/Ordinal-Scales.md#category10).\n",
-    "* **`diagonal_kwds`/`hist_kwds`/`density_kwds`** (`dict`, optional): Keyword options for the diagonal plots\n",
-    "* **`datashade`**(default=False):  Whether to apply rasterization and shading (colormapping) using the Datashader library, returning an RGB object instead of \n",
-    "    individual points\n",
-    "* **`rasterize`**(default=False): Whether to apply rasterization using the Datashader library, returning an aggregated Image (to be colormapped by the \n",
-    "    plotting backend) instead of individual points\n",
-    "* **`dynspread`**(default=False): For plots generated with datashade=True or rasterize=True,  automatically increase the point size when the data is sparse\n",
-    "    so that individual points become more visible. kwds supported include ``max_px``, ``threshold``,  ``shape``, ``how`` and ``mask``.\n",
-    "* **`spread`**(default=False): Make plots generated with datashade=True or rasterize=True increase the point size to make points more visible, by applying a fixed spreading of a certain number of cells/pixels. kwds\n",
-    "    supported include: ``px``, ``shape``, ``how`` and ``mask``.\n",
-    "* **`kwds`** : Keyword options for the off-diagonal plots and datashader's spreading , optional\n",
-    "\n",
-    "___"
    ]
   },
   {

--- a/hvplot/plotting/scatter_matrix.py
+++ b/hvplot/plotting/scatter_matrix.py
@@ -38,7 +38,7 @@ def scatter_matrix(data, c=None, chart='scatter', diagonal='hist',
         Transparency level for the off-diagonal plots
     nonselection_alpha: float, optional
         Transparency level for nonselected object in the off-diagonal plots
-    tools: str or list of str, optional
+    tools: list of str, optional
         Interaction tools to include
         Defaults are 'box_select' and 'lasso_select'
     cmap/colormap: str or colormap object, optional


### PR DESCRIPTION
This PR adds a reference page for the `scatter_matrix` plots. It also fixes to docstring of this function to reflect the fact that `tools` only support a `list` of tools.