### PR TITLE
Use nbval and nbqa for managing notebooks

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -75,8 +75,9 @@ extras_require = {
         'parameterized',
         'pytest',
         'pytest-cov',
-        'nbsmoke >=0.2.0',
-        'numpy >=1.7'
+        'numpy >=1.7',
+        'nbqa',
+        'nbval',
     ],
     'examples': _examples,
     'examples_extra': _examples_extra,

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ envlist = {py36,py37,py38,py39}-{flakes,unit,examples,examples_extra,all}-{defau
 description = Flake check python and notebooks
 deps = .[tests]
 commands = flake8
-           pytest --nbsmoke-lint -k ".ipynb" --ignore-nbsmoke-skip-run
+           nbqa pylint examples
 
 [_unit]
 description = Run unit tests with coverage
@@ -19,12 +19,12 @@ commands = pytest -v hvplot --cov=./hvplot --cov-append
 [_examples]
 description = Test that default examples run
 deps = .[examples, tests]
-commands = pytest --nbsmoke-run -k ".ipynb"
+commands = pytest --nbval-lax
 
 [_examples_extra]
 description = Test that default examples run
 deps = .[examples_extra, tests]
-commands = pytest --nbsmoke-run -k ".ipynb" --ignore-nbsmoke-skip-run
+commands = pytest --nbval-lax
 
 [_all]
 description = Run all tests
@@ -61,7 +61,7 @@ deps = unit: {[_unit]deps}
 [pytest]
 addopts = -v --pyargs
 norecursedirs = doc .git dist build _build .ipynb_checkpoints
-nbsmoke_skip_run = ^.*NetworkX\.ipynb$
+; nbsmoke_skip_run = ^.*NetworkX\.ipynb$
 ; The test suite used to be run with nosetests which collected
 ; by default files like `testgeo.py` while pytest's default is
 ; to collect files like `test_geo.py`. This setting allows

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ envlist = {py36,py37,py38,py39}-{flakes,unit,examples,examples_extra,all}-{defau
 description = Flake check python and notebooks
 deps = .[tests]
 commands = flake8
-           nbqa pylint examples
+           nbqa flake8 .
 
 [_unit]
 description = Run unit tests with coverage
@@ -19,7 +19,7 @@ commands = pytest -v hvplot --cov=./hvplot --cov-append
 [_examples]
 description = Test that default examples run
 deps = .[examples, tests]
-commands = pytest --nbval-lax
+commands = pytest --nbval-lax --ignore-glob="^.*NetworkX\.ipynb$"
 
 [_examples_extra]
 description = Test that default examples run


### PR DESCRIPTION
Update: Moved to use the `flake8` linter instead, it respects `# noqa`and it's passing the CI without complaining. For`nbsmoke_skip_run`, I've used a `pytest` setting `ignore-glob`.

 ----------------------------------------------------
Currently the `pylint` module for `nbqa` complains a lot as `pylint` checks for many more things as compared to `pyflakes`.
We can also turn on other linters like `black`, `isort`, `pyupgrade` for the notebooks.

One thing that doesn't directly translate from `nbsmoke` to `nbval` is the the `nbsmoke_skip_run` pytest setting. We can use the explicit `ignore` while executing `pytest --nbval-lax` but it won't accept regex (I think?)