### PR TITLE
Update datasets.yaml

### DIFF
--- a/examples/datasets.yaml
+++ b/examples/datasets.yaml
@@ -4,7 +4,7 @@ sources:
     driver: parquet
     cache:
       - argkey: urlpath
-        regex: 'airline_flights'
+        regex: 'assets.holoviews.org/data/'
         type: file
     args:
       urlpath: 's3://assets.holoviews.org/data/airline_flights.parq'


### PR DESCRIPTION
What is defined in regex is removed from the filename not kept.
Before: `/home/shh/.intake/cache/7f9708758ba435683113a36d5d76f3db/assets.holoviews.org/data/.parq`
After: `/home/shh/.intake/cache/032a8a7804d6ce7538724a8e4880f80e/airline_flights.parq`