### PR TITLE
Improve Github Action caching

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -52,24 +52,32 @@ jobs:
       - name: Get Today's date for cache
         run: echo "TODAY=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
       - name: conda cache
+        if: matrix.python-version == '3.6'
         uses: actions/cache@v2
         with:
           path: ${{ matrix.path }}
-          key: ${{ runner.os }}-conda-${{ matrix.python-version }}-${{ hashFiles('setup.py') }}-${{ env.TODAY }}-${{ env.CACHE_VERSION }}
+          key: ${{ runner.os }}-conda-${{ matrix.python-version }}-${{ hashFiles('setup.py') }}-tests-${{ env.TODAY }}-${{ env.CACHE_VERSION }}
+        id: cache
+      - name: conda cache
+        if: matrix.python-version > '3.6'
+        uses: actions/cache@v2
+        with:
+          path: ${{ matrix.path }}
+          key: ${{ runner.os }}-conda-${{ matrix.python-version }}-${{ hashFiles('setup.py') }}-tests,examples-${{ env.TODAY }}-${{ env.CACHE_VERSION }}
         id: cache
       - name: conda setup
         if: steps.cache.outputs.cache-hit != 'true'
         run: |
           conda install "pyctdev>=0.5"
           doit env_create --python=${{ matrix.python-version }}
-      - name: doit develop_install py3
+      - name: doit develop_install py > 3.6
         if: steps.cache.outputs.cache-hit != 'true' && matrix.python-version != '3.6'
         run: |
           eval "$(conda shell.bash hook)"
           conda activate test-environment
           conda list
           doit develop_install -o examples -o tests
-      - name: doit develop_install py36
+      - name: doit develop_install py == 36
         if: steps.cache.outputs.cache-hit != 'true' && matrix.python-version == '3.6'
         run: |
           eval "$(conda shell.bash hook)"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -56,10 +56,7 @@ jobs:
         with:
           path: ${{ matrix.path }}
           key: ${{ runner.os }}-conda-${{ matrix.python-version }}-${{ hashFiles('setup.py') }}-${{ env.TODAY }}-${{ env.CACHE_VERSION }}
-          restore-keys: |
-           ${{ runner.os }}-conda-${{ matrix.python-version }}-${{ env.TODAY }}-${{ env.CACHE_VERSION }}
         id: cache
-
       - name: conda setup
         if: steps.cache.outputs.cache-hit != 'true'
         run: |


### PR DESCRIPTION
As discussed with @MridulS:
* Remove the restore key since the goal is to hit exactly the cache required
* Add the options (e.g. `tests`, `build`, `docs`...) used for `develop_install`. Without that there would be no way to distinguish between two caches used by two different workflows (e.g. tests and docs). It's not perfect though, since sometimes there are some packages that are installed without `develop_install` (e.g. some packages only available with pip). Maybe it'd be a good idea to have the hash of the workflow itself part of the cache key.