### PR TITLE
Add ability to call interactive on bound functions

### DIFF
--- a/examples/user_guide/Interactive.ipynb
+++ b/examples/user_guide/Interactive.ipynb
@@ -131,7 +131,7 @@
     "\n",
     "In some cases your starting point for your interactive pipeline may not simply be a DataFrame or xarray Dataset but a function that fetches some data or applies some initial processing on your data. In such a case you can use the `hvplot.bind` function to bind static AND dynamic arguments to your function. Binding dynamic arguments such as a widget or parameter means that whenever the widget/parameter value changes the output of the function will change as well. This makes it possible to construct functions as the input to your interactive pipeline that themselves represent some data pipeline.\n",
     "\n",
-    "In the example below we will explicitly declare a `Select` widget to select between multiple stock tickers and a function that loads dataframes containing data for each of those stocks. Using the `hvplot.bind` function we then bind the `ticker` select widget to the `ticker`  argument of the `stock_df` function and call `.interactive` on the resulting bound function:"
+    "In the example below we will explicitly declare a `Select` widget to select between multiple stock tickers and a function that loads dataframes containing data for each of those stocks. Using the `hvplot.bind` function we then bind the `ticker` select widget to the `ticker` argument of the `stock_df` function and call `.interactive` on the resulting bound function:"
    ]
   },
   {

--- a/examples/user_guide/Interactive.ipynb
+++ b/examples/user_guide/Interactive.ipynb
@@ -6,12 +6,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import xarray as xr\n",
+    "import ipywidgets as ipw\n",
     "import hvplot.xarray # noqa\n",
     "import hvplot.pandas # noqa\n",
     "import panel as pn\n",
+    "import pandas as pd\n",
     "import panel.widgets as pnw\n",
-    "import ipywidgets as ipw"
+    "import xarray as xr"
    ]
   },
   {
@@ -31,6 +32,18 @@
    "source": [
     "ds = xr.tutorial.load_dataset('air_temperature')\n",
     "ds"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from bokeh.sampledata.stocks import IBM\n",
+    "\n",
+    "df = pd.DataFrame(IBM)\n",
+    "df['date'] = pd.to_datetime(df.date)"
    ]
   },
   {
@@ -80,6 +93,24 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "Note that this works just as well for DataFrame objects whether they are Pandas, Dask or cuDF dataframes:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nrows = pn.widgets.IntSlider(start=1, end=100, value=10)\n",
+    "\n",
+    "df.interactive(width=500).head(nrows)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "For Panel widgets, we can let .interactive automatically configure the widget, which is particularly convenient when working with `DiscreteSlider` widgets:"
    ]
   },
@@ -90,6 +121,68 @@
    "outputs": [],
    "source": [
     "ds.air.interactive(width=800).sel(time=pnw.DiscreteSlider)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Functions as inputs\n",
+    "\n",
+    "In some cases your starting point for your interactive pipeline may not simply be a DataFrame or xarray Dataset but a function that fetches some data or applies some initial processing on your data. In such a case you can use the `hvplot.bind` function to bind static AND dynamic arguments to your function. Binding dynamic arguments such as a widget or parameter means that whenever the widget/parameter value changes the output of the function will change as well. This makes it possible to construct functions as the input to your interactive pipeline that themselves represent some data pipeline.\n",
+    "\n",
+    "In the example below we will explicitly declare a `Select` widget to select between multiple stock tickers and a function that loads dataframes containing data for each of those stocks. Using the `hvplot.bind` function we then bind the `ticker` select widget to the `ticker`  argument of the `stock_df` function and call `.interactive` on the resulting bound function:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from bokeh import sampledata\n",
+    "\n",
+    "ticker = pn.widgets.Select(options=['AAPL', 'IBM', 'GOOG', 'MSFT'], name='Ticker')\n",
+    "\n",
+    "def stock_df(ticker):\n",
+    "    df = pd.DataFrame(getattr(sampledata.stocks, ticker))\n",
+    "    df['date'] = pd.to_datetime(df.date)\n",
+    "    return df\n",
+    "\n",
+    "stock_dfi = hvplot.bind(stock_df, ticker).interactive(width=600)\n",
+    "\n",
+    "stock_dfi.head(10)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "As you can see this `interactive` component behaves just like any other, allowing us to chain `.head` on it and updating when the `ticker` widget changes.\n",
+    "\n",
+    "Just like any other `interactive` component you may also chain it further:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from bokeh import sampledata\n",
+    "\n",
+    "ticker = pn.widgets.Select(options=['AAPL', 'IBM', 'GOOG', 'MSFT'], name='Ticker')\n",
+    "\n",
+    "def stock_df(ticker):\n",
+    "    df = pd.DataFrame(getattr(sampledata.stocks, ticker))\n",
+    "    df['date'] = pd.to_datetime(df.date)\n",
+    "    return df\n",
+    "\n",
+    "stock_dfi = hvplot.bind(stock_df, ticker).interactive()\n",
+    "\n",
+    "dt_range = pn.widgets.DateRangeSlider(start=df.date.iloc[-1000], end=df.date.max(), value=(df.date.iloc[-100], df.date.max()))\n",
+    "\n",
+    "stock_dfi[(stock_dfi.date>=dt_range.param.value_start) & (stock_dfi.date<=dt_range.param.value_end)].hvplot(kind='ohlc', grid=True, title=ticker)"
    ]
   },
   {

--- a/examples/user_guide/Interactive.ipynb
+++ b/examples/user_guide/Interactive.ipynb
@@ -169,8 +169,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from bokeh import sampledata\n",
-    "\n",
     "ticker = pn.widgets.Select(options=['AAPL', 'IBM', 'GOOG', 'MSFT'], name='Ticker')\n",
     "\n",
     "def stock_df(ticker):\n",

--- a/hvplot/__init__.py
+++ b/hvplot/__init__.py
@@ -1,6 +1,8 @@
 import inspect
 import textwrap
 
+from functools import wraps as _wraps
+
 import param
 import panel as _pn
 import holoviews as _hv
@@ -8,6 +10,7 @@ import holoviews as _hv
 from holoviews import Store, render  # noqa
 
 from .converter import HoloViewsConverter
+from .interactive import Interactive
 from .utilities import hvplot_extension, output, save, show # noqa
 from .plotting import (hvPlot, hvPlotTabular,  # noqa
                        andrews_curves, lag_plot,
@@ -151,3 +154,9 @@ def _hook_patch_docstrings(backend):
 Store._backend_switch_hooks.append(_hook_patch_docstrings)
 
 extension = hvplot_extension
+
+@_wraps(_pn.bind)
+def bind(function, *args, **kwargs):
+    bound = _pn.bind(function, *args, **kwargs)
+    bound.interactive = lambda **kwargs: Interactive(bound, **kwargs)
+    return bound

--- a/hvplot/dask.py
+++ b/hvplot/dask.py
@@ -1,6 +1,15 @@
+import sys
+
 from .interactive import Interactive
 
 class DaskInteractive(Interactive):
+
+    @classmethod
+    def applies(cls, obj):
+        if 'dask.dataframe' in sys.modules:
+            import dask.dataframe as dd
+            return isinstance(obj, (dd.Series, dd.DataFrame))
+        return False
 
     def compute(self):
         self._method = 'compute'

--- a/hvplot/interactive.py
+++ b/hvplot/interactive.py
@@ -117,19 +117,6 @@ class Interactive():
     def _update_obj(self, *args):
         self._obj = self._fn.eval(self._fn.object)
 
-    @classmethod
-    def bind(cls, function, *args, **kwargs):
-        """
-        Given a function, returns an Interactive object that binds the
-        values of some or all arguments to parameter or widget values
-        and expresses Param dependencies on those values. The
-        resulting Interactive object will update whenever one of the
-        parameter values change.
-
-        For more details see panel.bind documentation.
-        """
-        return cls(pn.bind(function, *args, **kwargs))
-
     @property
     def _fn_params(self):
         if self._fn is None:

--- a/hvplot/interactive.py
+++ b/hvplot/interactive.py
@@ -215,7 +215,7 @@ class Interactive():
             new = self._resolve_accessor()
             new._method = name
             try:
-                new.__call__.__doc__ = getattr(new, name).__doc__
+                new.__doc__ = getattr(current, name).__doc__
             except Exception:
                 pass
             return new

--- a/hvplot/tests/testinteractive.py
+++ b/hvplot/tests/testinteractive.py
@@ -1,0 +1,88 @@
+import pandas as pd
+import panel as pn
+
+from holoviews.util.transform import dim
+
+from hvplot import bind
+from hvplot.interactive import Interactive
+from hvplot.xarray import XArrayInteractive
+
+
+def test_interactive_pandas_dataframe():
+    df = pd._testing.makeMixedDataFrame()
+
+    dfi = Interactive(df)
+
+    assert type(dfi) is Interactive
+    assert dfi._obj is df
+    assert dfi._fn is None
+    assert dfi._transform == dim('*')
+
+def test_interactive_pandas_series():
+    df = pd._testing.makeMixedDataFrame()
+
+    dfi = Interactive(df.A)
+
+    assert type(dfi) is Interactive
+    assert dfi._obj is df.A
+    assert dfi._fn is None
+    assert dfi._transform == dim('*')
+
+def test_interactive_xarray_dataarray():
+    import xarray as xr
+    ds = xr.tutorial.load_dataset('air_temperature')
+
+    dsi = Interactive(ds.air)
+
+    assert type(dsi) is XArrayInteractive
+    assert (dsi._obj == ds.air).all()
+    assert dsi._fn is None
+    assert dsi._transform == dim('air')
+
+def test_interactive_xarray_dataset():
+    import xarray as xr
+    ds = xr.tutorial.load_dataset('air_temperature')
+
+    dsi = Interactive(ds)
+
+    assert type(dsi) is XArrayInteractive
+    assert dsi._obj is ds
+    assert dsi._fn is None
+    assert dsi._transform == dim('*')
+
+def test_interactive_pandas_function():
+    df = pd._testing.makeMixedDataFrame()
+
+    select = pn.widgets.Select(options=list(df.columns))
+    
+    def sel_col(col):
+        return df[col]
+
+    dfi = Interactive(bind(sel_col, select))
+    assert type(dfi) is Interactive
+    assert dfi._obj is df.A
+    assert isinstance(dfi._fn, pn.param.ParamFunction)
+    assert dfi._transform == dim('*')
+
+    select.value = 'B'
+    assert dfi._obj is df.B
+
+def test_interactive_xarray_function():
+    import xarray as xr
+    ds = xr.tutorial.load_dataset('air_temperature')
+    ds['air2'] = ds.air*2
+
+    select = pn.widgets.Select(options=list(ds))
+    
+    def sel_col(sel):
+        return ds[sel]
+
+    dsi = Interactive(bind(sel_col, select))
+
+    assert type(dsi) is XArrayInteractive
+    assert isinstance(dsi._fn, pn.param.ParamFunction)
+    assert dsi._transform == dim('air')
+
+    select.value = 'air2'
+    assert (dsi._obj == ds.air2).all()
+    assert dsi._transform == dim('air2')

--- a/hvplot/xarray.py
+++ b/hvplot/xarray.py
@@ -7,6 +7,10 @@ from .interactive import Interactive
 
 class XArrayInteractive(Interactive):
 
+    @classmethod
+    def applies(cls, obj):
+        return isinstance(obj, (xr.DataArray, xr.Dataset))
+
     def sel(self, **kwargs):
         processed = {}
         for k, v in kwargs.items():


### PR DESCRIPTION
Implements functionality requested in https://github.com/holoviz/hvplot/issues/673

```python
from bokeh import sampledata

ticker = pn.widgets.Select(options=['AAPL', 'IBM', 'GOOG', 'MSFT'], name='Ticker')

def stock_df(ticker):
    df = pd.DataFrame(getattr(sampledata.stocks, ticker))
    df['date'] = pd.to_datetime(df.date)
    return df

stock_dfi = hvplot.bind(stock_df, ticker).interactive(width=600)

stock_dfi.head(10)
```

![interactive_df_select](https://user-images.githubusercontent.com/1550771/159768870-eed8f63a-5c40-49c7-8302-cd09f736d589.gif)

- [x] Add tests
- [x] Automatically detect whether to use DataFrameInteractive or XArrayInteractive object