### PR TITLE
Fix the CI on Python 3.6

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -77,10 +77,12 @@ jobs:
           conda list
           conda install "pip <22"
           doit develop_install -o tests
-          # Pin panel on Python 3.6 because one or more dev releases on the 0.13.* series
+          # - Pin panel on Python 3.6 because one or more dev releases on the 0.13.* series
           # can be installed on Python 3.6 but are actually not compatible with Python 3.6
           # Panel 0.13 will support Python >= 3.7 only so the pin here can stay indefinitely.
-          conda install "panel=0.12"
+          # - Install importlib_resources to fix tqdm that missed adding it as a dependency
+          # for 3.6 (https://github.com/conda-forge/tqdm-feedstock/pull/114) 
+          conda install "panel=0.12" "importlib_resources "
       - name: pygraphviz
         if: steps.cache.outputs.cache-hit != 'true' && ((contains(matrix.os, 'ubuntu') || contains(matrix.os, 'macos')) && matrix.python-version != '3.6')
         run: |


### PR DESCRIPTION
By installing importlib_resources, dependency required by the latest tqdm but not declared in its recipe (https://github.com/conda-forge/tqdm-feedstock/pull/114).