### PR TITLE
Fix application of the scale argument for geoviews features

### DIFF
--- a/hvplot/converter.py
+++ b/hvplot/converter.py
@@ -1314,6 +1314,8 @@ class HoloViewsConverter:
                             "Feature scale of %r not recognized, "
                             "must be one of '10m', '50m' or '110m'." %
                         scale)
+                    else:
+                        feature_obj = feature_obj.opts(scale=scale)
                 obj = feature_obj * obj
 
         if self.tiles:


### PR DESCRIPTION
When creating a figure with `geo=True`, the `scale` argument for `geoviews`-features is currently ignored. According to the documentation and docstrings, this should be supported via setting the `feature` argument to a dictionary in the form of {feature: scale}. 

With this change, the scale argument is forwarded to the `opts` function of the `geoviews` feature class.

# Test with 

```
import hvplot.pandas  # noqa
from bokeh.sampledata.airport_routes import airports

plot = airports.hvplot.points(
    "Longitude",
    "Latitude",
    geo=True,
    color="red",
    alpha=0.2,
    xlim=(-180, -30),
    ylim=(0, 72),
    tiles="ESRI",
    features={"states": "10m"},
)

hvplot.show(plot)
```
