### PR TITLE
CI fixes

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -87,7 +87,7 @@ jobs:
         run: |
           eval "$(conda shell.bash hook)"
           conda activate test-environment
-          doit develop_install $CHANS_DEV -o unit_tests
+          doit develop_install $CHANS_DEV -o tests
           doit pip_on_conda
       - name: pip build
         run: |

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -54,9 +54,6 @@ jobs:
           conda activate test-environment
           conda list
           doit develop_install -o doc -o examples --conda-mode=mamba
-          conda remove nbconvert-core --force
-          conda remove nbconvert --force
-          mamba install "nbconvert<6" --no-deps
       - name: doit env_capture
         run: |
           eval "$(conda shell.bash hook)"


### PR DESCRIPTION
* The docs build had a special handling of nbconvert that was required last week, when the recipe from conda-forge was wrong
* The pip build wasn't declaring the right options group