### PR TITLE
Add xarray to the tests extras dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -82,6 +82,7 @@ extras_require = {
         'numpy >=1.7',
         'matplotlib',
         'plotly',
+        'xarray',
     ],
     'examples': _examples,
     'examples_extra': _examples_extra,


### PR DESCRIPTION
New tests have been added that rely on xarray being installed, and xarray is indeed an important interface to test part of the test suite. This PR adds it to the `tests` extras.