### PR TITLE
Add 3.10 in the test matrix and fix it on 3.6 and 3.7

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -19,8 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
-        python-version: ['3.10']
-        # python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
         include:
         - os: ubuntu-latest
           path: /usr/share/miniconda3/envs/
@@ -85,12 +84,12 @@ jobs:
           # for 3.6 (https://github.com/conda-forge/tqdm-feedstock/pull/114) 
           conda install "panel=0.12" "importlib_resources "
       - name: Pin tifffile on 3.6 and 3.7
-        if: matrix.python-version == '3.6'  || matrix.python-version == '3.7'
+        if: steps.cache.outputs.cache-hit != 'true' && (matrix.python-version == '3.6'  || matrix.python-version == '3.7')
         run: |
           eval "$(conda shell.bash hook)"
           conda activate test-environment
           conda install "tifffile<2022.4.22"
-      - name: pygraphviz
+      - name: pygraphviz on ubuntu and macos
         if: steps.cache.outputs.cache-hit != 'true' && ((contains(matrix.os, 'ubuntu') || contains(matrix.os, 'macos')) && matrix.python-version != '3.6')
         run: |
           eval "$(conda shell.bash hook)"
@@ -112,7 +111,7 @@ jobs:
           eval "$(conda shell.bash hook)"
           conda activate test-environment
           doit test_unit
-      - name: test examples ubuntu
+      - name: test examples ubuntu / macos
         if: (contains(matrix.os, 'ubuntu') || contains(matrix.os, 'macos')) && matrix.python-version != '3.6'
         run: |
           eval "$(conda shell.bash hook)"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -61,8 +61,7 @@ jobs:
       - name: conda setup
         if: steps.cache.outputs.cache-hit != 'true'
         run: |
-          conda install "pyctdev>=0.5"
-          doit env_create --python=${{ matrix.python-version }}
+          conda create -n test-environment python=${{ matrix.python-version }} pyctdev "typing_extensions<4.2.0"
       - name: doit develop_install py > 3.6
         if: steps.cache.outputs.cache-hit != 'true' && matrix.python-version != '3.6'
         run: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -18,9 +18,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ['ubuntu-latest']
-        # os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
-        python-version: [3.6, 3.7]
+        os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
+        python-version: ['3.6', '3.7']
         # python-version: [3.6, 3.7, 3.8, 3.9]
         include:
         - os: ubuntu-latest

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
-        python-version: ['3.6', '3.7']
+        python-version: ['3.10']
         # python-version: [3.6, 3.7, 3.8, 3.9]
         include:
         - os: ubuntu-latest

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -27,7 +27,7 @@ jobs:
           path: /Users/runner/miniconda3/envs/
         - os: windows-latest
           path: C:\Miniconda3\envs\
-    timeout-minutes: 60
+    timeout-minutes: 90
     defaults:
       run:
         shell: bash -l {0} 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -83,6 +83,9 @@ jobs:
           # - Install importlib_resources to fix tqdm that missed adding it as a dependency
           # for 3.6 (https://github.com/conda-forge/tqdm-feedstock/pull/114) 
           conda install "panel=0.12" "importlib_resources "
+      - name: Pin tifffile on 3.6 and 3.7
+        if: matrix.python-version == '3.6'  || matrix.python-version == '3.7'
+        run: conda install "tifffile<2022.4.22"
       - name: pygraphviz
         if: steps.cache.outputs.cache-hit != 'true' && ((contains(matrix.os, 'ubuntu') || contains(matrix.os, 'macos')) && matrix.python-version != '3.6')
         run: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -87,7 +87,10 @@ jobs:
           conda install "panel=0.12" "importlib_resources "
       - name: Pin tifffile on 3.6 and 3.7
         if: matrix.python-version == '3.6'  || matrix.python-version == '3.7'
-        run: conda install "tifffile<2022.4.22"
+        run: |
+          eval "$(conda shell.bash hook)"
+          conda activate test-environment
+          conda install "tifffile<2022.4.22"
       - name: pygraphviz
         if: steps.cache.outputs.cache-hit != 'true' && ((contains(matrix.os, 'ubuntu') || contains(matrix.os, 'macos')) && matrix.python-version != '3.6')
         run: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -18,8 +18,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        os: ['ubuntu-latest']
+        # os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
+        python-version: [3.6, 3.7]
+        # python-version: [3.6, 3.7, 3.8, 3.9]
         include:
         - os: ubuntu-latest
           path: /usr/share/miniconda3/envs/

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ To start using hvplot have a look at the [installation instructions](https://hvp
 
 ## Installation
 
-hvPlot supports Python 3.6, 3.7, 3.8 and 3.9 on Linux, Windows, or Mac and can be installed with ``conda``:
+hvPlot supports Python 3.6, 3.7, 3.8, 3.9 and 3.10 on Linux, Windows, or Mac and can be installed with ``conda``:
 
 ```
 conda install -c pyviz hvplot

--- a/setup.py
+++ b/setup.py
@@ -129,6 +129,7 @@ setup_args = dict(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
         "Operating System :: OS Independent",
         "Intended Audience :: Science/Research",
         "Intended Audience :: Developers",

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@
 
 [tox]
 #          python version             test group                    extra envs  extra commands
-envlist = {py36,py37,py38,py39}-{flakes,unit,examples,examples_extra,all}-{default}-{dev,pkg}
+envlist = {py36,py37,py38,py39,py310}-{flakes,unit,examples,examples_extra,all}-{default}-{dev,pkg}
 
 [_flakes]
 description = Flake check python and notebooks


### PR DESCRIPTION
I've tried again to add `3.10` in the test matrix, and this time it worked! Installing `pygraphviz` is pretty slow on Mac so I've had to increase the timeout but besides that all is well. This PR also fixes the CI on Python 3.6 and 3.7 by pinning `tifffile`, whose latest recipe isn't correct.