### PR TITLE
Separate plotly extension calls

### DIFF
--- a/examples/user_guide/Plotting_Extensions.ipynb
+++ b/examples/user_guide/Plotting_Extensions.ipynb
@@ -26,7 +26,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import hvplot.pandas  # This import automatically loads the Bokeh extension.\n",
+    "import hvplot.pandas  # This import automatically loads the Bokeh extension."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "hvplot.extension('matplotlib', 'plotly')  # This call loads the Matplotlib (the active one) and Plotly extensions."
    ]
   },

--- a/examples/user_guide/Plotting_with_Plotly.ipynb
+++ b/examples/user_guide/Plotting_with_Plotly.ipynb
@@ -17,8 +17,15 @@
    "source": [
     "import numpy as np\n",
     "import hvplot.pandas  # noqa\n",
-    "import hvplot.dask  # noqa\n",
-    "\n",
+    "import hvplot.dask  # noqa"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "hvplot.extension('plotly')"
    ]
   },


### PR DESCRIPTION
To workaround an issue in HoloViews whereby the `load_nb` method of the renderer is not called when the extension is loaded multiple times within a single cell, effectively not loading setting up the Panel Plotly pane correctly.