### PR TITLE
Display the Plotly figure without Panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Version 0.8.0
 
-**May 6, 2022**
+**May 8, 2022**
 
 The 0.8.0 release is a minor release with some exciting new features and a large number of bug fixes and enhancements. Many thanks to @FabianHofmann, @jomey, @ablythed, @jlstevens, @Hoxbro, @michaelaye, @MridulS, @ppwadhwa, @maximlt, @philippjfr for contributing!
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -23,6 +23,11 @@ html_css_files = [
     'custom.css'
 ]
 
+# Use require.js vendored by nbsite to display the Plotly figure
+# add the end of the Plotting_Extensions notebook. require.js is normally
+# loaded automatically by nbconvert but that happens not to be the case
+# when a notebook converted via nbsite. Other HoloViews-Plotly plots
+# are rendered via Panel, in a way that doesn't require require.js.
 html_js_files = ['require.js']
 
 html_theme_options.update({

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -23,6 +23,8 @@ html_css_files = [
     'custom.css'
 ]
 
+html_js_files = ['require.js']
+
 html_theme_options.update({
     "github_url": "https://github.com/holoviz/hvplot",
     "icon_links": [

--- a/doc/releases.md
+++ b/doc/releases.md
@@ -2,7 +2,7 @@
 
 ## Version 0.8.0
 
-**May 6, 2022**
+**May 8, 2022**
 
 The 0.8.0 release is a minor release with some exciting new features and a large number of bug fixes and enhancements. Many thanks to @FabianHofmann, @jomey, @ablythed, @jlstevens, @Hoxbro, @michaelaye, @MridulS, @ppwadhwa, @maximlt, @philippjfr for contributing!
 

--- a/examples/user_guide/Plotting_Extensions.ipynb
+++ b/examples/user_guide/Plotting_Extensions.ipynb
@@ -195,11 +195,10 @@
    "outputs": [],
    "source": [
     "from plotly.graph_objects import Figure\n",
-    "import plotly.offline as py\n",
     "\n",
     "plotly_fig = hvplot.render(violent_crime, backend='plotly')\n",
     "fig = Figure(plotly_fig).update_layout(title='Violent crime')\n",
-    "py.iplot(fig)"
+    "fig"
    ]
   },
   {

--- a/examples/user_guide/Plotting_with_Matplotlib.ipynb
+++ b/examples/user_guide/Plotting_with_Matplotlib.ipynb
@@ -260,7 +260,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "crime.hvplot.bar(x='Year', y='Violent Crime rate', rot=90)"
+    "crime.hvplot.bar(x='Year', y='Violent Crime rate', rot=90, width=900)"
    ]
   },
   {
@@ -277,7 +277,7 @@
    "outputs": [],
    "source": [
     "crime.hvplot.bar(x='Year', y=['Violent crime total', 'Property crime total'],\n",
-    "                 stacked=True, rot=90, width=800, legend='top_left')"
+    "                 stacked=True, rot=90, width=900, legend='top_left')"
    ]
   },
   {
@@ -338,7 +338,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "flights.hvplot.hexbin(x='airtime', y='arrdelay', width=600, height=500, logz=True)"
+    "flights.hvplot.hexbin(x='airtime', y='arrdelay', width=600, height=500, logz=True);"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<div class=\"alert alert-warning\" role=\"alert\">\n",
+    "Output suppressed as this is <a href='https://github.com/holoviz/hvplot/pull/653#issuecomment-964056881'>not currently supported</a> with the Matplotlib backend and doesn't display any plot.\n",
+    "</div>"
    ]
   },
   {
@@ -374,7 +383,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "flights.compute().hvplot.heatmap(x='day', y='carrier', C='depdelay', reduce_function=np.mean, colorbar=True)"
+    "flights.compute().hvplot.heatmap(x='day', y='carrier', C='depdelay', reduce_function=np.mean, colorbar=True).opts(show_values=False)"
    ]
   },
   {


### PR DESCRIPTION
Use `require.js` vendored by nbsite to display the Plotly figure add the end of the Plotting_Extensions notebook. `require.js` is normally loaded automatically by nbconvert but that happens not to be the case when a notebook is converted via nbsite. Other HoloViews-Plotly plots are rendered via Panel, in a way that doesn't seem to require `require.js`.