### PR TITLE
Show the right style options with the help function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ nosetests.xml
 coverage.xml
 *.cover
 .hypothesis/
+.pytest_cache
 
 # Translations
 *.mo

--- a/hvplot/__init__.py
+++ b/hvplot/__init__.py
@@ -42,7 +42,7 @@ def _get_doc_and_signature(
         formatter += "{options}"
 
     # Bokeh is the default backend
-    backend = hvplot_extension.compatibility or 'bokeh'
+    backend = hvplot_extension.compatibility or Store.current_backend
     if eltype in Store.registry[backend]:
         valid_opts = Store.registry[backend][eltype].style_opts
         if style:

--- a/hvplot/tests/testhelp.py
+++ b/hvplot/tests/testhelp.py
@@ -6,13 +6,13 @@ from holoviews.element import Curve
 
 
 @pytest.fixture
-def reset_backend():
+def reset_default_backend():
     yield
     hvplot.extension('bokeh')
     hvplot.extension.compatibility = None
 
 
-def test_help_style_extension_output(reset_backend):
+def test_help_style_extension_output(reset_default_backend):
     # default, after e.g. import hvplot.pandas
     docstring, signature = hvplot._get_doc_and_signature(
         cls=hvplot.hvPlot,
@@ -51,7 +51,7 @@ def test_help_style_extension_output(reset_backend):
     )
     assert docstring == '\nStyle options\n-------------\n\n' + '\n'.join(sorted(Store.registry['plotly'][Curve].style_opts))
 
-def test_help_style_compatibility(reset_backend):
+def test_help_style_compatibility(reset_default_backend):
     # The current backend is plotly but the style options are those of matplotlib
     hvplot.extension('plotly', 'matplotlib', compatibility='matplotlib')
     docstring, signature = hvplot._get_doc_and_signature(

--- a/hvplot/tests/testhelp.py
+++ b/hvplot/tests/testhelp.py
@@ -1,0 +1,57 @@
+import hvplot.pandas
+
+from holoviews.core import Store
+from holoviews.element import Curve
+
+def test_help_style_extension_output():
+    # default, after e.g. import hvplot.pandas
+    docstring, signature = hvplot._get_doc_and_signature(
+        cls=hvplot.hvPlot,
+        kind='line',
+        completions=False,
+        docstring=False,
+        generic=False,
+        style=True,
+        signature=None,
+    )
+    assert docstring == '\nStyle options\n-------------\n\n' + '\n'.join(sorted(Store.registry['bokeh'][Curve].style_opts))
+
+    # The current backend becomes matplotlib
+    hvplot.extension('matplotlib', 'plotly')
+    docstring, signature = hvplot._get_doc_and_signature(
+        cls=hvplot.hvPlot,
+        kind='line',
+        completions=False,
+        docstring=False,
+        generic=False,
+        style=True,
+        signature=None,
+    )
+    assert docstring == '\nStyle options\n-------------\n\n' + '\n'.join(sorted(Store.registry['matplotlib'][Curve].style_opts))
+
+    # The current backend becomes plotly
+    hvplot.output(backend='plotly')
+    docstring, signature = hvplot._get_doc_and_signature(
+        cls=hvplot.hvPlot,
+        kind='line',
+        completions=False,
+        docstring=False,
+        generic=False,
+        style=True,
+        signature=None,
+    )
+    assert docstring == '\nStyle options\n-------------\n\n' + '\n'.join(sorted(Store.registry['plotly'][Curve].style_opts))
+
+def test_help_style_compatibility():
+    # The current backend is plotly but the style options are those of matplotlib
+    hvplot.extension('plotly', 'matplotlib', compatibility='matplotlib')
+    docstring, signature = hvplot._get_doc_and_signature(
+        cls=hvplot.hvPlot,
+        kind='line',
+        completions=False,
+        docstring=False,
+        generic=False,
+        style=True,
+        signature=None,
+    )
+    assert docstring == '\nStyle options\n-------------\n\n' + '\n'.join(sorted(Store.registry['matplotlib'][Curve].style_opts))

--- a/hvplot/tests/testhelp.py
+++ b/hvplot/tests/testhelp.py
@@ -1,9 +1,18 @@
 import hvplot.pandas
+import pytest
 
 from holoviews.core import Store
 from holoviews.element import Curve
 
-def test_help_style_extension_output():
+
+@pytest.fixture
+def reset_backend():
+    yield
+    hvplot.extension('bokeh')
+    hvplot.extension.compatibility = None
+
+
+def test_help_style_extension_output(reset_backend):
     # default, after e.g. import hvplot.pandas
     docstring, signature = hvplot._get_doc_and_signature(
         cls=hvplot.hvPlot,
@@ -42,7 +51,7 @@ def test_help_style_extension_output():
     )
     assert docstring == '\nStyle options\n-------------\n\n' + '\n'.join(sorted(Store.registry['plotly'][Curve].style_opts))
 
-def test_help_style_compatibility():
+def test_help_style_compatibility(reset_backend):
     # The current backend is plotly but the style options are those of matplotlib
     hvplot.extension('plotly', 'matplotlib', compatibility='matplotlib')
     docstring, signature = hvplot._get_doc_and_signature(


### PR DESCRIPTION
The help function was not showing the style options of the current backend when `compatibility` wasn't set, instead it was always showing the Bokeh style options.