### PR TITLE
Display a color bar when rasterize is enabled

### DIFF
--- a/hvplot/converter.py
+++ b/hvplot/converter.py
@@ -526,6 +526,8 @@ class HoloViewsConverter:
             plot_opts['colorbar'] = colorbar
         elif self.kind in self._colorbar_types:
             plot_opts['colorbar'] = True
+        elif self.rasterize or self.datashade:
+            plot_opts['colorbar'] = plot_opts.get('colorbar', True)
         if 'logz' in kwds and 'logz' in self._kind_options.get(self.kind, {}):
             plot_opts['logz'] = kwds.pop('logz')
         if invert:
@@ -1008,8 +1010,6 @@ class HoloViewsConverter:
 
         if cmap is not None:
             style_opts['cmap'] = cmap
-        elif self.rasterize or self.datashade:
-            plot_opts['colorbar'] = plot_opts.get('colorbar', True)
 
         if 'color' in style_opts:
             color = style_opts['color']

--- a/hvplot/converter.py
+++ b/hvplot/converter.py
@@ -526,7 +526,7 @@ class HoloViewsConverter:
             plot_opts['colorbar'] = colorbar
         elif self.kind in self._colorbar_types:
             plot_opts['colorbar'] = True
-        elif self.rasterize or self.datashade:
+        elif self.rasterize:
             plot_opts['colorbar'] = plot_opts.get('colorbar', True)
         if 'logz' in kwds and 'logz' in self._kind_options.get(self.kind, {}):
             plot_opts['logz'] = kwds.pop('logz')

--- a/hvplot/tests/testoperations.py
+++ b/hvplot/tests/testoperations.py
@@ -67,6 +67,19 @@ class TestDatashader(ComparisonTestCase):
         opts = Store.lookup_options('bokeh', plot, 'style').kwargs
         self.assertEqual(opts.get('cmap'), 'kbc_r')
 
+    def test_rasterize_default_colorbar(self):
+        plot = self.df.hvplot.scatter('x', 'y', dynamic=False, rasterize=True)
+        opts = Store.lookup_options('bokeh', plot, 'plot').kwargs
+        self.assertTrue(opts.get('colorbar'))
+
+    def test_rasterize_default_colorbar_with_cmap(self):
+        cmap = 'Reds'
+        plot = self.df.hvplot.scatter('x', 'y', dynamic=False, rasterize=True, cmap=cmap)
+        opts = Store.lookup_options('bokeh', plot, 'style').kwargs
+        self.assertEqual(opts.get('cmap'), cmap)
+        opts = Store.lookup_options('bokeh', plot, 'plot').kwargs
+        self.assertTrue(opts.get('colorbar'))
+
     def test_rasterize_set_clim(self):
         plot = self.df.hvplot.scatter('x', 'y', dynamic=False, rasterize=True, clim=(1, 4))
         opts = Store.lookup_options('bokeh', plot, 'plot').kwargs


### PR DESCRIPTION
Fixes https://github.com/holoviz/hvplot/issues/777

Before https://github.com/holoviz/hvplot/pull/206 the `cmap` style was handled as follows, i.e. when datashader was involved it was set to the default linear colormap:

```python
        if cmap is not None:
            style_opts['cmap'] = cmap
        elif self.rasterize or self.datashade:
            style_opts['cmap'] = self._default_cmaps['linear']
```

https://github.com/holoviz/hvplot/pull/206 made hvplot behave more closely to `xarray.plot()` by using a symmetric colormap if the data is found to be divergent. https://github.com/holoviz/hvplot/pull/206 replaced the code that set the colormap to linear, by setting the color bar, to `True` by default:

```python
        if cmap is not None:
            style_opts['cmap'] = cmap
        elif self.rasterize or self.datashade:
            plot_opts['colorbar'] = plot_opts.get('colorbar', True)
```

This PR:
* moves up the logic that handles the datashaded path, as it seems it could be set up-front
* sets the color bar to `True` by default when `rasterize=True`, whatever the value of `cmap`. This fixes the related issue. I'm not entirely sure this is the correct behavior for all plot kinds.
* doesn't set the color bar when `datashade=True` as a color bar isn't relevant with this option.