### PR TITLE
Update developer install instructions

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -67,11 +67,11 @@ jobs:
           conda install -n base -c defaults "conda>=4.12"
           conda install -n base -c conda-forge "mamba>=0.23" --no-update-deps
           conda install -c conda-forge "nodejs=15.3.0" --no-update-deps
-          conda config --prepend channels nodefaults
-          conda config --prepend channels conda-forge
-          conda config --prepend channels pyviz/label/dev
-          conda config --remove channels defaults
-          conda create -n test-environment python=${{ matrix.python-version }} pyctdev
+          conda create -n test-environment
+          conda activate test-environment
+          conda config --env --append channels pyviz/label/dev --append channels conda-forge --append channels nodefaults
+          conda config --env --remove channels defaults
+          conda install python=${{ matrix.python-version }} pyctdev
       - name: doit develop_install py
         if: steps.cache.outputs.cache-hit != 'true'
         run: |

--- a/doc/developer_guide/index.rst
+++ b/doc/developer_guide/index.rst
@@ -63,35 +63,44 @@ Installing Dependencies
 -----------------------
 
 hvPlot requires many additional packages for development and
-testing. Many of these are on the main Anaconda default channel.
+testing.
 
 Conda Environments
 ~~~~~~~~~~~~~~~~~~
 
+Create an empty conda environment with the name that you prefer, here we've
+chosen hvplot_dev. Activate and configure its channels to only use
+``pyviz/label/dev`` and ``conda-forge``. The former is used to install the
+development versions of the other HoloViz packages, such as HoloViews or Panel.
+
+.. code-block:: sh
+
+    conda create -n hvplot_dev
+    conda activate hvplot_dev
+    conda config --env --append channels pyviz/label/dev --append channels conda-forge --append channels nodefaults
+    conda config --env --remove channels defaults
+
 Since hvPlot interfaces with a large range of different libraries the
 full test suite requires a wide range of dependencies. To make it
 easier to install and run different parts of the test suite across
-different platforms hvPlot uses a library called pyctdev to make things
-more consistent and general.
+different platforms hvPlot uses a library called ``pyctdev`` to make things
+more consistent and general. Specify also the desired Python version you want
+to base your environment on. It is advised to choose the minimum version
+currently supported by hvPlot on the main development branch.
 
 .. code-block:: sh
 
-    conda create -n hvplot_dev -c pyviz pyctdev python=3.6
-
-Specify the desired Python version, currently hvPlot officially
-supports Python 3.6 and 3.7. Once the environment has been
-created you can activate it with:
-
-.. code-block:: sh
-
-    conda activate hvplot_dev
+    conda install python=3.x pyctdev
 
 Finally to install the dependencies required to run the full unit test
 suite and all the examples:
 
 .. code-block:: sh
 
-    doit develop_install -c pyviz/label/dev -o all
+    doit develop_install -o tests -o examples
+
+Add ``-o doc`` if you want to install the dependencies required to build
+the website.
 
 .. _devguide_python_setup:
 


### PR DESCRIPTION
Fixes #790 

Trying a slightly new approach that consists in creating a totally empty conda environment, then setting the channels of this environment only and not globally, and then simply calling `doit/pyctdev` and pure `conda` commands without providing any channels as `-c channel`, just relying on the ones defined at the environment level.