### PR TITLE
Update the expected DataSet plot title after xarray `2022.6.0`

### DIFF
--- a/hvplot/tests/testoptions.py
+++ b/hvplot/tests/testoptions.py
@@ -5,6 +5,7 @@ import pytest
 
 from holoviews import Store
 from holoviews.core.options import Options, OptionTree
+from packaging.version import Version
 
 try:
     import pandas as pd
@@ -553,4 +554,8 @@ class TestXarrayTitle:
         ds_sel = ds2.sel(time=0, band=0, x=0, y=0)
         plot = ds_sel.hvplot.scatter(x='foo', y='bar')  # Image plot
         opts = Store.lookup_options(backend, plot, 'plot')
-        assert opts.kwargs['title'] == 'y = 0, x = 0, time = 0, band = 0'
+        # First assertion to remove when support for Python 3.7 is dropped.
+        if Version(xr.__version__) < Version('2022.6.0'):
+            assert opts.kwargs['title'] == 'y = 0, x = 0, time = 0, band = 0'
+        else:
+            assert opts.kwargs['title'] == 'time = 0, y = 0, x = 0, band = 0'


### PR DESCRIPTION
One test started to fail after the release of xarray 2022.6.0 a couple of days ago. The title set to a plot made from an xarray object is defined by relying on an internal xarray function, this was added in https://github.com/holoviz/hvplot/pull/659. Apparently something changed in xarray, I actually didn't see any obvious change in the particular function that was called so that may be at another level, anyway the scalar coords displayed in the title are not ordered in the same way after the last release. In the failing test `'y = 0, x = 0, time = 0, band = 0'` was replaced by `'time = 0, y = 0, x = 0, band = 0'`. The former, i.e. the newer title, appears to be more accurate as respecting the order of the coords declared in one of the original DataArray:

https://github.com/holoviz/hvplot/blob/912b70fb403d6a04651ec14e3b76f054f4b725b9/hvplot/tests/testoptions.py#L478

I've simply updated the test to not fail with the newest releases of xarray, and still pass with the older ones.