### PR TITLE
Add flatten utility function

### DIFF
--- a/hvplot/interactive.py
+++ b/hvplot/interactive.py
@@ -17,13 +17,13 @@ from panel.layout import Column, Row, VSpacer, HSpacer
 from panel.util import get_method_owner, full_groupby
 from panel.widgets.base import Widget
 
-from .util import is_tabular, is_xarray, is_xarray_dataarray
+from .util import _flatten, is_tabular, is_xarray, is_xarray_dataarray
 
 
 def _find_widgets(op):
     widgets = []
     op_args = list(op['args'])+list(op['kwargs'].values())
-    op_args = hv.core.util.flatten(op_args)
+    op_args = _flatten(op_args)
     for op_arg in op_args:
         if 'panel' in sys.modules:
             if isinstance(op_arg, Widget) and op_arg not in widgets:

--- a/hvplot/util.py
+++ b/hvplot/util.py
@@ -514,3 +514,30 @@ def filter_opts(eltype, options, backend='bokeh'):
                for k in list(g.allowed_keywords)]
     opts = {k: v for k, v in options.items() if k in allowed}
     return opts
+
+
+def _flatten(line):
+    """
+    Flatten an arbitrarily nested sequence.
+
+    Inspired by: pd.core.common.flatten
+
+    Parameters
+    ----------
+    line : sequence
+        The sequence to flatten
+
+    Notes
+    -----
+    This only flattens list, tuple, and dict sequences.
+
+    Returns
+    -------
+    flattened : generator
+    """
+
+    for element in line:
+        if any(isinstance(element, tp) for tp in (list, tuple, dict)):
+            yield from _flatten(element)
+        else:
+            yield element


### PR DESCRIPTION
Fixes https://github.com/holoviz/hvplot/issues/797

Instead of bumping the HoloViews pin to a quite recent version, this PR just copies the `flatten` utility from HoloViews to hvPlot.