### PR TITLE
Make the explorer easier to use

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -124,3 +124,6 @@ hvplot/.version
 
 # MacOS
 .DS_Store
+
+# Examples artefacts
+examples/user_guide/plot.html

--- a/doc/user_guide/index.rst
+++ b/doc/user_guide/index.rst
@@ -62,6 +62,9 @@ rather than Matplotlib.
 * `Plotting Extensions <Plotting_Extensions.html>`_
   Changing the plotting extension.
 
+* `Exploring data <Explorer.html>`_
+  Exploring data with user interface.
+
 * `Viewing <Viewing.html>`_
   Displaying and saving plots in the notebook, at the command prompt, or in scripts.
 
@@ -102,6 +105,7 @@ rather than Matplotlib.
     Interactive <Interactive>
     Widgets <Widgets>
     Plotting Extensions <Plotting_Extensions>
+    Exploring data <Explorer>
     Viewing <Viewing>
     Subplots <Subplots>
     Streaming <Streaming>

--- a/examples/user_guide/Explorer.ipynb
+++ b/examples/user_guide/Explorer.ipynb
@@ -51,7 +51,7 @@
     "\n",
     "* `save(filename, **kwargs)` to save the plot to file\n",
     "* `settings()` to obtain a dictionary of your customized settings\n",
-    "* `repr(var_name)` to obtain a formatted string to copy/paste that includes your customized settings\n",
+    "* `plot_code(var_name)` to obtain a formatted string to copy/paste that includes your customized settings\n",
     "* `hvplot()` to get a handle on the displayed HoloViews plot"
    ]
   },
@@ -150,7 +150,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Another practical way to obtain create a plot from the recorded options is to use the `repr` method that generates a string that is ready to be executed after a copy/paste into a notebook code cell. `repr` assumes that you data variable is named `'df'`, you can change that by passing e.g. `var_name='df_othername'`."
+    "Another practical way to obtain create a plot from the recorded options is to use the `plot_code` method that generates a string that is ready to be executed after a copy/paste into a notebook code cell. `plot_code` assumes that you data variable is named `'df'`, you can change that by passing e.g. `var_name='df_othername'`."
    ]
   },
   {
@@ -159,7 +159,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "hvexplorer.repr()"
+    "hvexplorer.plot_code()"
    ]
   },
   {

--- a/examples/user_guide/Explorer.ipynb
+++ b/examples/user_guide/Explorer.ipynb
@@ -8,17 +8,15 @@
    "source": [
     "import hvplot.pandas\n",
     "\n",
-    "from bokeh.sampledata import penguins\n",
-    "\n",
-    "df = penguins.data"
+    "from bokeh.sampledata.penguins import data as df"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<div class=\"alert alert-warning\" role=\"alert\">\n",
-    "    The Explorer has been added in hvPlot 0.8.0 and improved and documented in 0.8.1. It is a relatively new feature that is already useful but may have some rough edges, please report any issue or feature request <a href='https://github.com/holoviz/hvplot/'>on GitHub</a>.\n",
+    "<div class=\"alert alert-info\" role=\"info\">\n",
+    "    The Explorer has been added to hvPlot in version <code>0.8.0</code>, and improved and documented in version <code>0.8.1</code>. It does not yet support all the data structures supported by hvPlot, for now it works best with Pandas DataFrame objects. Please report any issue or feature request <a href='https://github.com/holoviz/hvplot/'>on GitHub</a>.\n",
     "</div>"
    ]
   },
@@ -26,11 +24,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "hvPlot API provides a simple and intuitive way to create plots. However when you are exploring data you don't always know in advance the best way to display it, or even what kind of plot would be best to visualize the data. You will very likely embark in an iterative process that implies choosing a kind of plot, setting various options, running some code, and repeat until you're satisfied with the output and the insights you get. `hvPlotExplorer` is a *Graphical User Interface* that allows you to easily generate customized plots, which in practice gives you the possibility to **explore** both your data and hvPlot's extensive API.\n",
+    "hvPlot API provides a simple and intuitive way to create plots. However when you are exploring data you don't always know in advance the best way to display it, or even what kind of plot would be best to visualize the data. You will very likely embark in an iterative process that implies choosing a kind of plot, setting various options, running some code, and repeat until you're satisfied with the output and the insights you get. The *Explorer* is a *Graphical User Interface* that allows you to easily generate customized plots, which in practice gives you the possibility to **explore** both your data and hvPlot's extensive API.\n",
     "\n",
-    "To create an `hvPlotExplorer` instance you pass your data to the high-level `hvplot.explorer` function which returns a [Panel](https://panel.holoviz.org/) interactive object that can be displayed in a notebook or served in a web application. This object displays on the right-hand side a preview of the plot you are building, and on the left-hand side the various options that you can set to customize the plot.\n",
+    "To create an *Explorer* you pass your data to the high-level `hvplot.explorer` function which returns a [Panel](https://panel.holoviz.org/) layout that can be displayed in a notebook or served in a web application. This object displays on the right-hand side a preview of the plot you are building, and on the left-hand side the various options that you can set to customize the plot.\n",
     "\n",
-    "Note that for the explorer to be displayed in a notebook you need to load the hvPlot extension, which happens automatically when you execute `import hvplot.pandas`. If instead of building Bokeh plots you would rather build Matplotlib or Plotly plot, simply execute once `hvplot.extension('matplotlib')` before displaying the explorer."
+    "Note that for the explorer to be displayed in a notebook you need to load the hvPlot extension, which happens automatically when you execute `import hvplot.pandas`. If instead of building Bokeh plots you would rather build Matplotlib or Plotly plot, simply execute once `hvplot.extension('matplotlib')` or `hvplot.extension('matplotlib')` before displaying the explorer."
    ]
   },
   {
@@ -47,7 +45,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The explorer has a few useful methods:\n",
+    "The *Explorer* has a few useful methods:\n",
     "\n",
     "* `save(filename, **kwargs)` to save the plot to file\n",
     "* `settings()` to obtain a dictionary of your customized settings\n",
@@ -59,9 +57,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "You will now see a workflow how to use these methods to d\n",
+    "You will now see how to use the *Explorer* in combination with these methods.\n",
     "\n",
-    "First we will update the explorer as the default configuration doesn't preview a very interesting plot. We will do so programmatically for the purpose of building this website but you would never have to do such thing, so just assume you've changed a few options directly in the explorer with your mouse and keyboard."
+    "First we will update the *Explorer* as the default configuration doesn't lead to a very interesting preview for this dataset. We will do so programmatically for the purpose of building this website but you would never have to do such thing, so just assume you've changed a few options directly in the explorer with your mouse and keyboard."
    ]
   },
   {
@@ -70,12 +68,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# hvexplorer.param.set_param(\n",
-    "#     kind='scatter',\n",
-    "#     x='bill_length_mm',\n",
-    "#     y_multi=['bill_depth_mm'],\n",
-    "#     by=['species'],\n",
-    "# )\n",
+    "hvexplorer.param.set_param(kind='scatter', x='bill_length_mm', y_multi=['bill_depth_mm'], by=['species'])\n",
     "hvexplorer.labels.title = 'Penguins Scatter'"
    ]
   },
@@ -99,24 +92,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can make sure the file has correctly been saved and display it using some `Ipython` utility."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from IPython.core.display import HTML\n",
-    "HTML(open('plot.html').read())"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "The options we have changed in the explorer can obtained as a dictionary from the `settings()` method and be passed as kwargs to `hvplot.explorer` to initialize another explorer, or to the `.hvplot()` data accessor. It means you can create temporarily create explorers in your exploration workflow, use them to quickly iterate on building new plots, record their settings, and finally replace the explorers by shorter `.hvplot()` calls. You can also save these options in JSON files for instance."
+    "The options we have changed in the *Explorer* can obtained as a dictionary from the `settings()` method and be passed as kwargs to `hvplot.explorer` to initialize another *Explorer*, or directly to the `.hvplot()` data accessor. It means that in your workflow you can temporarily create *Explorers*, use them to quickly iterate on building new plots, record their settings, and finally replace the *Explorers* by shorter `.hvplot()` calls."
    ]
   },
   {
@@ -142,15 +118,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "plot1 = df.hvplot(**settings)\n",
-    "plot1"
+    "df.hvplot(**settings)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Another practical way to obtain create a plot from the recorded options is to use the `plot_code` method that generates a string that is ready to be executed after a copy/paste into a notebook code cell. `plot_code` assumes that you data variable is named `'df'`, you can change that by passing e.g. `var_name='df_othername'`."
+    "Another practical way to create a plot from the recorded options is to use the `plot_code` method that generates a string ready to be executed after a copy/paste into a notebook code cell. `plot_code` assumes that you data variable is named `'df'`, you can change that by passing e.g. `var_name='df_othername'`."
    ]
   },
   {
@@ -163,12 +138,26 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Copy/pasting this string without the outer quotes into the next cell is all you need to recreate the exact same plot."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "df.hvplot(by=['species'], kind='scatter', title='Penguins Scatter', x='bill_length_mm', y=['bill_depth_mm'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The *Explorer* makes it very easy to quickly spin up a small application in a notebook with which you can explore your data, generate the visualization that you want, record it in a simple way, and keep going with your analysis."
    ]
   }
  ],

--- a/examples/user_guide/Explorer.ipynb
+++ b/examples/user_guide/Explorer.ipynb
@@ -6,7 +6,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import hvplot\n",
+    "import hvplot.pandas\n",
     "\n",
     "from bokeh.sampledata import penguins\n",
     "\n",
@@ -17,9 +17,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "hvPlot API provides a simple and intuitive way to create plots. However when you are exploring data you don't always know in advance the best way to display it, and even what kind of plot you should pick. You will very likely embark in an iterative process that implies choosing a kind of plot, setting various options, running some code, and repeat until you're satisfied with the output and the insights you get. `hvPlotExplorer` is a *Graphical User Interface* that allows you to easily generate customized plots, which in practice gives you the possibility to **explore** both your data and hvPlot's API.\n",
+    "hvPlot API provides a simple and intuitive way to create plots. However when you are exploring data you don't always know in advance the best way to display it, or even what kind of plot would be best to visualize the data. You will very likely embark in an iterative process that implies choosing a kind of plot, setting various options, running some code, and repeat until you're satisfied with the output and the insights you get. `hvPlotExplorer` is a *Graphical User Interface* that allows you to easily generate customized plots, which in practice gives you the possibility to **explore** both your data and hvPlot's extensive API.\n",
     "\n",
-    "To create an `hvPlotExplorer` instance your should pass your data to the high-level `hvplot.explorer` function which returns a [Panel](https://panel.holoviz.org/) interactive object that can be displayed in a notebook or served in a web application. This object displays on the right-hand side a preview of the plot you are building, and on the left-hand side the various options that you can set to customize the plot. Bokeh is the default plotting extension set up by the explorer, you can instead build Maplotlib or Plotly plots by passing e.g. `backend='matplotlib'` to the `hvplot.explorer` function."
+    "To create an `hvPlotExplorer` instance you pass your data to the high-level `hvplot.explorer` function which returns a [Panel](https://panel.holoviz.org/) interactive object that can be displayed in a notebook or served in a web application. This object displays on the right-hand side a preview of the plot you are building, and on the left-hand side the various options that you can set to customize the plot.\n",
+    "\n",
+    "Note that for the explorer to be displayed in a notebook you need to load the hvPlot extension, which happens automatically when you execute `import hvplot.pandas`. If instead of building Bokeh plots you would rather build Matplotlib or Plotly plot, simply execute once `hvplot.extension('matplotlib')` before displaying the explorer."
    ]
   },
   {

--- a/examples/user_guide/Explorer.ipynb
+++ b/examples/user_guide/Explorer.ipynb
@@ -1,0 +1,174 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import hvplot\n",
+    "\n",
+    "from bokeh.sampledata import penguins\n",
+    "\n",
+    "df = penguins.data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "hvPlot API provides a simple and intuitive way to create plots. However when you are exploring data you don't always know in advance the best way to display it, and even what kind of plot you should pick. You will very likely embark in an iterative process that implies choosing a kind of plot, setting various options, running some code, and repeat until you're satisfied with the output and the insights you get. `hvPlotExplorer` is a *Graphical User Interface* that allows you to easily generate customized plots, which in practice gives you the possibility to **explore** both your data and hvPlot's API.\n",
+    "\n",
+    "To create an `hvPlotExplorer` instance your should pass your data to the high-level `hvplot.explorer` function which returns a [Panel](https://panel.holoviz.org/) interactive object that can be displayed in a notebook or served in a web application. This object displays on the right-hand side a preview of the plot you are building, and on the left-hand side the various options that you can set to customize the plot. Bokeh is the default plotting extension set up by the explorer, you can instead build Maplotlib or Plotly plots by passing e.g. `backend='matplotlib'` to the `hvplot.explorer` function."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "hvexplorer = hvplot.explorer(df)\n",
+    "hvexplorer"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The explorer has a few useful methods:\n",
+    "\n",
+    "* `save(filename, **kwargs)` to save the plot to file\n",
+    "* `settings()` to obtain a dictionary of your customized settings\n",
+    "* `repr(var_name)` to obtain a formatted string to copy/paste that includes your customized settings\n",
+    "* `hvplot()` to get a handle on the displayed HoloViews plot\n",
+    "* `panel()` to get a Panel HoloViews pane that wraps the plot\n",
+    "* `widgets()` to get the widgets in their Panel Tabs layout"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You will now see a workflow how to use these methods to d\n",
+    "\n",
+    "First we will update the explorer as the default configuration doesn't preview a very interesting plot. We will do so programmatically for the purpose of building this website but you would never have to do such thing, so just assume you've changed a few options directly in the explorer with your mouse and keyboard."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "hvexplorer.param.set_param(\n",
+    "    kind='scatter',\n",
+    "    x='bill_length_mm',\n",
+    "    y_multi=['bill_depth_mm'],\n",
+    "    by=['species'],\n",
+    ")\n",
+    "hvexplorer.labels.title = 'Penguins Scatter'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We may already be satisfied with the plot as is and decide to save a copy, in this case in an HTML file as we have created a Bokeh plot and would like to preserve its interactivity."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "hvexplorer.save('plot.html')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can make sure the file has correctly been saved and display it using some `Ipython` utility."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from IPython.core.display import HTML\n",
+    "HTML(open('plot.html').read())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The options we have changed in the explorer can obtained as a dictionary from the `settings()` method and be passed as kwargs to `hvplot.explorer` to initialize another explorer, or to the `.hvplot()` data accessor. It means you can create temporarily create explorers in your exploration workflow, use them to quickly iterate on building new plots, record their settings, and finally replace the explorers by shorter `.hvplot()` calls. You can also save these options in JSON files for instance."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "settings = hvexplorer.settings()\n",
+    "settings"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note that you do not have to register the `hvplot` accessor on your data structure by e.g. running `import hvplot.pandas` as the `hvplot.explorer` function takes care of that by default, you can deactivate this behaviour by calling `hvplot.explorer` with `set_accessor=False`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot1 = df.hvplot(**settings)\n",
+    "plot1"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Another practical way to obtain create a plot from the recorded options is to use the `repr` method that generates a string that is ready to be executed after a copy/paste into a notebook code cell. `repr` assumes that you data variable is named `'df'`, you can change that by passing e.g. `var_name='df_othername'`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "hvexplorer.repr()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df.hvplot(by=['species'], kind='scatter', title='Penguins Scatter', x='bill_length_mm', y=['bill_depth_mm'])"
+   ]
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "name": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/user_guide/Explorer.ipynb
+++ b/examples/user_guide/Explorer.ipynb
@@ -17,6 +17,15 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "<div class=\"alert alert-warning\" role=\"alert\">\n",
+    "    The Explorer has been added in hvPlot 0.8.0 and improved and documented in 0.8.1. It is a relatively new feature that is already useful but may have some rough edges, please report any issue or feature request <a href='https://github.com/holoviz/hvplot/'>on GitHub</a>.\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "hvPlot API provides a simple and intuitive way to create plots. However when you are exploring data you don't always know in advance the best way to display it, or even what kind of plot would be best to visualize the data. You will very likely embark in an iterative process that implies choosing a kind of plot, setting various options, running some code, and repeat until you're satisfied with the output and the insights you get. `hvPlotExplorer` is a *Graphical User Interface* that allows you to easily generate customized plots, which in practice gives you the possibility to **explore** both your data and hvPlot's extensive API.\n",
     "\n",
     "To create an `hvPlotExplorer` instance you pass your data to the high-level `hvplot.explorer` function which returns a [Panel](https://panel.holoviz.org/) interactive object that can be displayed in a notebook or served in a web application. This object displays on the right-hand side a preview of the plot you are building, and on the left-hand side the various options that you can set to customize the plot.\n",

--- a/examples/user_guide/Explorer.ipynb
+++ b/examples/user_guide/Explorer.ipynb
@@ -52,9 +52,7 @@
     "* `save(filename, **kwargs)` to save the plot to file\n",
     "* `settings()` to obtain a dictionary of your customized settings\n",
     "* `repr(var_name)` to obtain a formatted string to copy/paste that includes your customized settings\n",
-    "* `hvplot()` to get a handle on the displayed HoloViews plot\n",
-    "* `panel()` to get a Panel HoloViews pane that wraps the plot\n",
-    "* `widgets()` to get the widgets in their Panel Tabs layout"
+    "* `hvplot()` to get a handle on the displayed HoloViews plot"
    ]
   },
   {
@@ -72,12 +70,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "hvexplorer.param.set_param(\n",
-    "    kind='scatter',\n",
-    "    x='bill_length_mm',\n",
-    "    y_multi=['bill_depth_mm'],\n",
-    "    by=['species'],\n",
-    ")\n",
+    "# hvexplorer.param.set_param(\n",
+    "#     kind='scatter',\n",
+    "#     x='bill_length_mm',\n",
+    "#     y_multi=['bill_depth_mm'],\n",
+    "#     by=['species'],\n",
+    "# )\n",
     "hvexplorer.labels.title = 'Penguins Scatter'"
    ]
   },

--- a/hvplot/__init__.py
+++ b/hvplot/__init__.py
@@ -11,6 +11,7 @@ from holoviews import Store, render  # noqa
 
 from .converter import HoloViewsConverter
 from .interactive import Interactive
+from .ui import explorer  # noqa
 from .utilities import hvplot_extension, output, save, show # noqa
 from .plotting import (hvPlot, hvPlotTabular,  # noqa
                        andrews_curves, lag_plot,

--- a/hvplot/tests/testui.py
+++ b/hvplot/tests/testui.py
@@ -1,0 +1,87 @@
+import holoviews as hv
+import hvplot.pandas
+
+from bokeh.sampledata import penguins
+from hvplot.ui import hvDataFrameExplorer
+
+df = penguins.data
+
+
+def test_explorer_basic():
+    explorer = hvplot.explorer(df)
+
+    assert isinstance(explorer, hvDataFrameExplorer)
+    assert explorer.kind == 'line'
+    assert explorer.x is None
+    assert explorer.y is None
+
+
+def test_explorer_settings():
+    explorer = hvplot.explorer(df)
+
+    explorer.param.set_param(
+        kind='scatter',
+        x='bill_length_mm',
+        y_multi=['bill_depth_mm'],
+        by=['species'],
+    )
+
+    settings = explorer.settings()
+
+    assert settings == dict(
+        by=['species'],
+        kind='scatter',
+        x='bill_length_mm',
+        y=['bill_depth_mm'],
+    )
+
+
+def test_explorer_repr():
+    explorer = hvplot.explorer(df)
+
+    explorer.param.set_param(
+        kind='scatter',
+        x='bill_length_mm',
+        y_multi=['bill_depth_mm'],
+        by=['species'],
+    )
+
+    hvrepr = explorer.repr()
+
+    assert hvrepr == "df.hvplot(by=['species'], kind='scatter', x='bill_length_mm', y=['bill_depth_mm'])"
+    
+    hvrepr = explorer.repr(var_name='othername')
+
+    assert hvrepr == "othername.hvplot(by=['species'], kind='scatter', x='bill_length_mm', y=['bill_depth_mm'])"
+
+
+def test_explorer_hvplot():
+    explorer = hvplot.explorer(df)
+
+    explorer.param.set_param(
+        kind='scatter',
+        x='bill_length_mm',
+        y_multi=['bill_depth_mm'],
+    )
+
+    plot = explorer.hvplot()
+
+    assert isinstance(plot, hv.Scatter)
+    assert plot.kdims[0].name == 'bill_length_mm'
+    assert plot.vdims[0].name == 'bill_depth_mm'
+
+
+def test_explorer_save(tmp_path):
+    explorer = hvplot.explorer(df)
+
+    explorer.param.set_param(
+        kind='scatter',
+        x='bill_length_mm',
+        y_multi=['bill_depth_mm'],
+    )
+
+    outfile = tmp_path / 'plot.html'
+
+    explorer.save(outfile)
+
+    assert outfile.exists()

--- a/hvplot/tests/testui.py
+++ b/hvplot/tests/testui.py
@@ -22,8 +22,8 @@ def test_explorer_basic():
 
     assert isinstance(explorer, hvDataFrameExplorer)
     assert explorer.kind == 'line'
-    assert explorer.x is None
-    assert explorer.y is None
+    assert explorer.x == 'index'
+    assert explorer.y == 'species'
 
 
 def test_explorer_settings():

--- a/hvplot/tests/testui.py
+++ b/hvplot/tests/testui.py
@@ -1,8 +1,16 @@
+import sys
+
 import holoviews as hv
 import hvplot.pandas
+import pytest
 
 from bokeh.sampledata import penguins
 from hvplot.ui import hvDataFrameExplorer
+
+pytestmark = pytest.mark.skipif(
+    sys.version_info < (3, 7),
+    reason='Penguins dataset not available on Python 3.6',
+)
 
 df = penguins.data
 

--- a/hvplot/tests/testui.py
+++ b/hvplot/tests/testui.py
@@ -5,7 +5,7 @@ import pytest
 try:
     from bokeh.sampledata import penguins
 except ImportError:
-    penguions = None
+    penguins = None
 
 from hvplot.ui import hvDataFrameExplorer
 

--- a/hvplot/tests/testui.py
+++ b/hvplot/tests/testui.py
@@ -14,7 +14,7 @@ pytestmark = pytest.mark.skipif(
     reason='Penguins dataset not available on Python 3.6',
 )
 
-df = penguins.data
+df = penguins.data if penguins is not None else None
 
 
 def test_explorer_basic():

--- a/hvplot/tests/testui.py
+++ b/hvplot/tests/testui.py
@@ -1,14 +1,16 @@
-import sys
-
 import holoviews as hv
 import hvplot.pandas
 import pytest
 
-from bokeh.sampledata import penguins
+try:
+    from bokeh.sampledata import penguins
+except ImportError:
+    penguions = None
+
 from hvplot.ui import hvDataFrameExplorer
 
 pytestmark = pytest.mark.skipif(
-    sys.version_info < (3, 7),
+    penguins is None,
     reason='Penguins dataset not available on Python 3.6',
 )
 

--- a/hvplot/tests/testui.py
+++ b/hvplot/tests/testui.py
@@ -46,7 +46,7 @@ def test_explorer_settings():
     )
 
 
-def test_explorer_repr():
+def test_explorer_plot_code():
     explorer = hvplot.explorer(df)
 
     explorer.param.set_param(
@@ -56,13 +56,13 @@ def test_explorer_repr():
         by=['species'],
     )
 
-    hvrepr = explorer.repr()
+    hvplot_code = explorer.plot_code()
 
-    assert hvrepr == "df.hvplot(by=['species'], kind='scatter', x='bill_length_mm', y=['bill_depth_mm'])"
+    assert hvplot_code == "df.hvplot(by=['species'], kind='scatter', x='bill_length_mm', y=['bill_depth_mm'])"
     
-    hvrepr = explorer.repr(var_name='othername')
+    hvplot_code = explorer.plot_code(var_name='othername')
 
-    assert hvrepr == "othername.hvplot(by=['species'], kind='scatter', x='bill_length_mm', y=['bill_depth_mm'])"
+    assert hvplot_code == "othername.hvplot(by=['species'], kind='scatter', x='bill_length_mm', y=['bill_depth_mm'])"
 
 
 def test_explorer_hvplot():

--- a/hvplot/ui.py
+++ b/hvplot/ui.py
@@ -480,11 +480,6 @@ class hvPlotExplorer(Viewer):
         """
         return self._hvplot.clone()
 
-    def panel(self):
-        """Return the plot wrapped in a Panel HoloViews Pane.
-        """
-        return self._hvpane
-    
     def repr(self, var_name='df'):
         """Return a string representation that can be easily copy-pasted
         in a notebook cell to create a plot from a call to the `.hvplot`
@@ -514,8 +509,8 @@ class hvPlotExplorer(Viewer):
 
         Parameters
         ----------
-        filename: string or IO object
-            The filename or BytesIO/StringIO object to save to
+        filename: string, pathlib.Path or IO object
+            The path or BytesIO/StringIO object to save to
         """
         _hv.save(self._hvplot, filename, **kwargs)
 
@@ -543,11 +538,6 @@ class hvPlotExplorer(Viewer):
             settings['y'] = settings.pop('y_multi')
         settings = {k: v for k, v in sorted(list(settings.items()))}
         return settings
-
-    def widgets(self):
-        """Return the widgets in their Panel Tabs layout.
-        """
-        return self._tabs
 
 
 class hvGeomExplorer(hvPlotExplorer):

--- a/hvplot/ui.py
+++ b/hvplot/ui.py
@@ -1,3 +1,4 @@
+import holoviews as _hv
 import numpy as np
 import panel as pn
 import param
@@ -26,6 +27,27 @@ GEO_FEATURES = [
 GEO_TILES = list(tile_sources)
 AGGREGATORS = [None, 'count', 'min', 'max', 'mean', 'sum', 'any']
 MAX_ROWS = 10000
+
+
+def explorer(data, backend='bokeh', **kwargs):
+    """Explore your data by building a plot in a Panel UI component.
+
+    Parameters
+    ----------
+    data : pandas.DataFrame, geopandas.DataFrame
+        Data structure to explore.
+    backend: str, optional
+        Plotting backend; one of 'bokeh', 'matplotlib' and 'plotly'. By default 'bokeh'.
+
+    Returns
+    -------
+    hvplotExporer
+        Panel component to explore a dataset.
+    """
+    if not getattr(_hv.extension, '_loaded', False) or _hv.Store.current_backend != backend:
+        from .utilities import hvplot_extension
+        hvplot_extension(backend, logo=False)
+    return hvPlotExplorer.from_data(data, **kwargs)
 
 
 class Controls(Viewer):

--- a/hvplot/ui.py
+++ b/hvplot/ui.py
@@ -308,7 +308,10 @@ class hvPlotExplorer(Viewer):
         x, y = params.get('x'), params.get('y')
         if 'y' in params:
             params['y_multi'] = params.pop('y') if isinstance(params['y'], list) else [params['y']]
-        converter = _hvConverter(df, x, y, **{k: v for k, v in params.items() if k not in ('x', 'y')})
+        converter = _hvConverter(
+            df, x, y,
+            **{k: v for k, v in params.items() if k not in ('x', 'y', 'y_multi')}
+        )
         controller_params = {}
         for cls in param.concrete_descendents(Controls).values():
             controller_params[cls] = {

--- a/hvplot/ui.py
+++ b/hvplot/ui.py
@@ -378,8 +378,8 @@ class hvPlotExplorer(Viewer):
             pn.layout.HSpacer(),
             sizing_mode='stretch_both'
         )
-        self._plot()
         self._toggle_controls()
+        self._plot()
 
     def _populate(self):
         variables = self._converter.variables

--- a/hvplot/ui.py
+++ b/hvplot/ui.py
@@ -1,5 +1,3 @@
-import importlib
-
 import holoviews as _hv
 import numpy as np
 import panel as pn
@@ -31,7 +29,7 @@ AGGREGATORS = [None, 'count', 'min', 'max', 'mean', 'sum', 'any']
 MAX_ROWS = 10000
 
 
-def explorer(data, backend='bokeh', set_accessor=True, **kwargs):
+def explorer(data, **kwargs):
     """Explore your data by building a plot in a Panel UI component.
 
     This function returns a Panel component that has on the right-side
@@ -42,27 +40,13 @@ def explorer(data, backend='bokeh', set_accessor=True, **kwargs):
     ----------
     data : pandas.DataFrame, geopandas.DataFrame
         Data structure to explore.
-    backend: str, optional
-        Plotting backend; one of 'bokeh', 'matplotlib' and 'plotly'. By default 'bokeh'.
-    set_accessor: bool, optional
-        Set the accessor for the data type. By default True.
 
     Returns
     -------
     hvplotExporer
         Panel component to explore a dataset.
     """
-    if backend and (
-        not getattr(_hv.extension, "_loaded", False)
-        or _hv.Store.current_backend != backend
-    ):
-        from .utilities import hvplot_extension
-        hvplot_extension(backend, logo=False)
-    explorer = hvPlotExplorer.from_data(data, **kwargs)
-    if set_accessor:
-        accessor = accessors_mapping[type(explorer)]
-        importlib.import_module(f'hvplot.{accessor}')
-    return explorer
+    return hvPlotExplorer.from_data(data, **kwargs)
 
 
 class Controls(Viewer):

--- a/hvplot/ui.py
+++ b/hvplot/ui.py
@@ -356,7 +356,7 @@ class hvPlotExplorer(Viewer):
         self._converter = converter
         self._controls = pn.Param(
             self.param, parameters=['kind', 'x', 'y', 'by', 'groupby'],
-            sizing_mode='stretch_width', max_width=300
+            sizing_mode='stretch_width', max_width=300, show_name=False,
         )
         self.param.watch(self._toggle_controls, 'kind')
         self.param.watch(self._check_y, 'y_multi')
@@ -472,10 +472,10 @@ class hvPlotExplorer(Viewer):
                 ('Axes', pn.Param(self.axes, widgets={
                     'xlim': {'throttled': True},
                     'ylim': {'throttled': True}
-                })),
+                }, show_name=False)),
                 ('Labels', pn.Param(self.labels, widgets={
                     'rot': {'throttled': True}
-                })),
+                }, show_name=False)),
                 ('Style', self.style),
                 ('Operations', self.operations),
                 # ('Geo', self.geo)

--- a/hvplot/ui.py
+++ b/hvplot/ui.py
@@ -44,7 +44,10 @@ def explorer(data, backend='bokeh', **kwargs):
     hvplotExporer
         Panel component to explore a dataset.
     """
-    if not getattr(_hv.extension, '_loaded', False) or _hv.Store.current_backend != backend:
+    if backend and (
+        not getattr(_hv.extension, "_loaded", False)
+        or _hv.Store.current_backend != backend
+    ):
         from .utilities import hvplot_extension
         hvplot_extension(backend, logo=False)
     return hvPlotExplorer.from_data(data, **kwargs)

--- a/hvplot/ui.py
+++ b/hvplot/ui.py
@@ -535,6 +535,7 @@ class hvPlotExplorer(Viewer):
                 settings[p] = value
         if 'y_multi' in settings:
             settings['y'] = settings.pop('y_multi')
+        settings = {k: v for k, v in sorted(list(settings.items()))}
         return settings
 
     def widgets(self):

--- a/hvplot/ui.py
+++ b/hvplot/ui.py
@@ -7,18 +7,18 @@ from holoviews.element import tile_sources
 from holoviews.plotting.util import list_cmaps
 from panel.viewable import Viewer
 
-from .converter import HoloViewsConverter as hvConverter
+from .converter import HoloViewsConverter as _hvConverter
 from .plotting import hvPlot as _hvPlot
 from .util import is_geodataframe, is_xarray
 
 # Defaults
-DATAFRAME_KINDS = sorted(set(hvConverter._kind_mapping) - set(hvConverter._gridded_types))
-GRIDDED_KINDS = sorted(hvConverter._kind_mapping)
+DATAFRAME_KINDS = sorted(set(_hvConverter._kind_mapping) - set(_hvConverter._gridded_types))
+GRIDDED_KINDS = sorted(_hvConverter._kind_mapping)
 GEOM_KINDS = ['paths', 'polygons', 'points']
 STATS_KINDS = ['hist', 'kde', 'boxwhisker', 'violin', 'heatmap', 'bar', 'barh']
 TWOD_KINDS = ['bivariate', 'heatmap', 'hexbin', 'labels', 'vectorfield'] + GEOM_KINDS
 CMAPS = [cm for cm in list_cmaps() if not cm.endswith('_r_r')]
-DEFAULT_CMAPS = hvConverter._default_cmaps
+DEFAULT_CMAPS = _hvConverter._default_cmaps
 GEO_FEATURES = [
     'borders', 'coastline', 'land', 'lakes', 'ocean', 'rivers',
     'states', 'grid'
@@ -80,7 +80,7 @@ class Colormapping(Controls):
 
     @property
     def colormapped(self):
-        if self.explorer.kind in hvConverter._colorbar_types:
+        if self.explorer.kind in _hvConverter._colorbar_types:
             return True
         return self.color is not None and self.color in self._data
 
@@ -88,7 +88,7 @@ class Colormapping(Controls):
     def _update_coloropts(self):
         if not self.colormapped or self.cmap not in list(DEFAULT_CMAPS.values()):
             return
-        if self.explorer.kind in hvConverter._colorbar_types:
+        if self.explorer.kind in _hvConverter._colorbar_types:
             key = 'diverging' if self.symmetric else 'linear'
             self.colorbar = True
         elif self.color in self._data:
@@ -113,7 +113,7 @@ class Style(Controls):
 
 class Axes(Controls):
 
-    legend = param.Selector(default='right', objects=hvConverter._legend_positions)
+    legend = param.Selector(default='right', objects=_hvConverter._legend_positions)
 
     logx = param.Boolean(default=False)
 
@@ -308,7 +308,7 @@ class hvPlotExplorer(Viewer):
         x, y = params.get('x'), params.get('y')
         if 'y' in params:
             params['y_multi'] = params.pop('y') if isinstance(params['y'], list) else [params['y']]
-        converter = hvConverter(df, x, y, **{k: v for k, v in params.items() if k not in ('x', 'y')})
+        converter = _hvConverter(df, x, y, **{k: v for k, v in params.items() if k not in ('x', 'y')})
         controller_params = {}
         for cls in param.concrete_descendents(Controls).values():
             controller_params[cls] = {

--- a/hvplot/ui.py
+++ b/hvplot/ui.py
@@ -652,10 +652,3 @@ class hvDataFrameExplorer(hvPlotExplorer):
         if not len(values):
             return (np.nan, np.nan)
         return max_range([(np.nanmin(vs), np.nanmax(vs)) for vs in values])
-
-
-accessors_mapping = {
-    hvDataFrameExplorer: 'pandas',
-    hvGeomExplorer: 'pandas',
-    hvGridExplorer: 'xarray',
-}

--- a/hvplot/ui.py
+++ b/hvplot/ui.py
@@ -514,9 +514,9 @@ class hvPlotExplorer(Viewer):
         _hv.save(self._hvplot, filename, **kwargs)
 
     def settings(self):
-        """Return a dictionnary of the changed settings.
+        """Return a dictionary of the changed settings.
         
-        This dictionnary can be reused as input to the `explorer` or
+        This dictionary can be reused as input to the `explorer` or
         a call to the `hvplot` accessor.
 
         >>> hvplot.explorer(df, **settings)

--- a/hvplot/ui.py
+++ b/hvplot/ui.py
@@ -1,3 +1,5 @@
+import importlib
+
 import holoviews as _hv
 import numpy as np
 import panel as pn
@@ -29,8 +31,12 @@ AGGREGATORS = [None, 'count', 'min', 'max', 'mean', 'sum', 'any']
 MAX_ROWS = 10000
 
 
-def explorer(data, backend='bokeh', **kwargs):
+def explorer(data, backend='bokeh', set_accessor=True, **kwargs):
     """Explore your data by building a plot in a Panel UI component.
+
+    This function returns a Panel component that has on the right-side
+    hand a plot view and on the left-side hand a number of widgets that
+    control the plot.
 
     Parameters
     ----------
@@ -38,6 +44,8 @@ def explorer(data, backend='bokeh', **kwargs):
         Data structure to explore.
     backend: str, optional
         Plotting backend; one of 'bokeh', 'matplotlib' and 'plotly'. By default 'bokeh'.
+    set_accessor: bool, optional
+        Set the accessor for the data type. By default True.
 
     Returns
     -------
@@ -50,7 +58,11 @@ def explorer(data, backend='bokeh', **kwargs):
     ):
         from .utilities import hvplot_extension
         hvplot_extension(backend, logo=False)
-    return hvPlotExplorer.from_data(data, **kwargs)
+    explorer = hvPlotExplorer.from_data(data, **kwargs)
+    if set_accessor:
+        accessor = accessors_mapping[type(explorer)]
+        importlib.import_module(f'hvplot.{accessor}')
+    return explorer
 
 
 class Controls(Viewer):
@@ -588,3 +600,10 @@ class hvDataFrameExplorer(hvPlotExplorer):
         if not len(values):
             return (np.nan, np.nan)
         return max_range([(np.nanmin(vs), np.nanmax(vs)) for vs in values])
+
+
+accessors_mapping = {
+    hvDataFrameExplorer: 'pandas',
+    hvGeomExplorer: 'pandas',
+    hvGridExplorer: 'xarray',
+}

--- a/hvplot/ui.py
+++ b/hvplot/ui.py
@@ -525,7 +525,8 @@ class hvPlotExplorer(Viewer):
     def save(self, filename, **kwargs):
         """Save the plot to file.
         
-        Uses holoviews.save, refer to its documentation for a full description.
+        Calls the `holoviews.save` utility, refer to its documentation
+        for a full description of the available kwargs.
 
         Parameters
         ----------
@@ -535,10 +536,10 @@ class hvPlotExplorer(Viewer):
         _hv.save(self._hvplot, filename, **kwargs)
 
     def settings(self):
-        """Return a dictionary of the changed settings.
+        """Return a dictionary of the customized settings.
         
-        This dictionary can be reused as input to the `explorer` or
-        a call to the `hvplot` accessor.
+        This dictionary can be reused as an unpacked input to the explorer or
+        a call to the `.hvplot` accessor.
 
         >>> hvplot.explorer(df, **settings)
         >>> df.hvplot(**settings)

--- a/hvplot/ui.py
+++ b/hvplot/ui.py
@@ -8,6 +8,7 @@ from holoviews.plotting.util import list_cmaps
 from panel.viewable import Viewer
 
 from .converter import HoloViewsConverter as hvConverter
+from .plotting import hvPlot as _hvPlot
 from .util import is_geodataframe, is_xarray
 
 # Defaults
@@ -381,7 +382,7 @@ class hvPlotExplorer(Viewer):
         if len(df) > MAX_ROWS and not (self.kind in STATS_KINDS or kwargs.get('rasterize') or kwargs.get('datashade')):
             df = df.sample(n=MAX_ROWS)
         try:
-            plot = df.hvplot(
+            plot = _hvPlot(df)(
                 kind=self.kind, x=self.x, y=y, by=self.by, groupby=self.groupby, **kwargs
             )
             hvplot = pn.pane.HoloViews(

--- a/hvplot/ui.py
+++ b/hvplot/ui.py
@@ -489,12 +489,12 @@ class hvPlotExplorer(Viewer):
         """
         return self._hvplot.clone()
 
-    def repr(self, var_name='df'):
+    def plot_code(self, var_name='df'):
         """Return a string representation that can be easily copy-pasted
         in a notebook cell to create a plot from a call to the `.hvplot`
         accessor, and that includes all the customized settings of the explorer.
 
-        >>> hvexplorer(var_name='data')
+        >>> hvexplorer.plot_code(var_name='data')
         "data.hvplot(x='time', y='value')"
 
         Parameters

--- a/hvplot/ui.py
+++ b/hvplot/ui.py
@@ -491,7 +491,7 @@ class hvPlotExplorer(Viewer):
     # Public API
     #----------------------------------------------------------------
 
-    def holoviews(self):
+    def hvplot(self):
         """Return the plot as a HoloViews object.
         """
         return self._hvplot.clone()

--- a/hvplot/ui.py
+++ b/hvplot/ui.py
@@ -354,7 +354,7 @@ class hvPlotExplorer(Viewer):
             sizing_mode='stretch_both'
         )
         self._plot()
-        self.param.trigger('kind')
+        self._toggle_controls()
 
     def _populate(self):
         variables = self._converter.variables
@@ -408,15 +408,15 @@ class hvPlotExplorer(Viewer):
             return True
         return False
 
-    def _toggle_controls(self, event):
+    def _toggle_controls(self, event=None):
         # Control high-level parameters
         visible = True
-        if event.new in ('table', 'dataset'):
+        if event and event.new in ('table', 'dataset'):
             parameters = ['kind', 'columns']
             visible = False
-        elif event.new in TWOD_KINDS:
+        elif event and event.new in TWOD_KINDS:
             parameters = ['kind', 'x', 'y', 'by', 'groupby']
-        elif event.new in ('hist', 'kde', 'density'):
+        elif event and event.new in ('hist', 'kde', 'density'):
             self.x = None
             parameters = ['kind', 'y_multi', 'by', 'groupby']
         else:
@@ -438,7 +438,7 @@ class hvPlotExplorer(Viewer):
                 ('Operations', self.operations),
                 ('Geo', self.geo)
             ]
-            if event.new not in ('area', 'kde', 'line', 'ohlc', 'rgb', 'step'):
+            if event and event.new not in ('area', 'kde', 'line', 'ohlc', 'rgb', 'step'):
                 tabs.insert(5, ('Colormapping', self.colormapping))
         self._tabs[:] = tabs
 

--- a/hvplot/ui.py
+++ b/hvplot/ui.py
@@ -300,6 +300,8 @@ class hvPlotExplorer(Viewer):
 
     groupby = param.ListSelector(default=[])
 
+    # Controls that will show up as new tabs, must be ClassSelector
+
     axes = param.ClassSelector(class_=Axes)
 
     colormapping = param.ClassSelector(class_=Colormapping)
@@ -337,7 +339,14 @@ class hvPlotExplorer(Viewer):
             **{k: v for k, v in params.items() if k not in ('x', 'y', 'y_multi')}
         )
         controller_params = {}
-        for cls in param.concrete_descendents(Controls).values():
+        # Assumes the controls aren't passed on instantiation.
+        controls = [
+            p.class_
+            for p in self.param.params().values()
+            if isinstance(p, param.ClassSelector)
+            and issubclass(p.class_, Controls)
+        ]
+        for cls in controls:
             controller_params[cls] = {
                 k: params.pop(k) for k, v in dict(params).items()
                 if k in cls.param

--- a/hvplot/ui.py
+++ b/hvplot/ui.py
@@ -501,6 +501,27 @@ class hvPlotExplorer(Viewer):
         """
         return self._hvpane
     
+    def repr(self, var_name='df'):
+        """Return a string representation that can be easily copy-pasted
+        in a notebook cell to create a plot from a call to the `.hvplot`
+        accessor, and that includes all the customized settings of the explorer.
+
+        >>> hvexplorer(var_name='data')
+        "data.hvplot(x='time', y='value')"
+
+        Parameters
+        ----------
+        var_name: string
+            Data variable name by which the returned string will start.
+        """
+        settings = self.settings()
+        args = ''
+        if settings:
+            for k, v in settings.items():
+                args += f'{k}={v!r}, '
+            args = args[:-2]
+        return f'{var_name}.hvplot({args})'
+    
     def save(self, filename, **kwargs):
         """Save the plot to file.
         

--- a/hvplot/ui.py
+++ b/hvplot/ui.py
@@ -469,7 +469,7 @@ class hvPlotExplorer(Viewer):
                 })),
                 ('Style', self.style),
                 ('Operations', self.operations),
-                ('Geo', self.geo)
+                # ('Geo', self.geo)
             ]
             if event and event.new not in ('area', 'kde', 'line', 'ohlc', 'rgb', 'step'):
                 tabs.insert(5, ('Colormapping', self.colormapping))

--- a/hvplot/ui.py
+++ b/hvplot/ui.py
@@ -291,7 +291,8 @@ class hvPlotExplorer(Viewer):
 
     style = param.ClassSelector(class_=Style)
 
-    def __new__(cls, data, **params):
+    @classmethod
+    def from_data(cls, data, **params):
         if is_geodataframe(data):
             cls = hvGeomExplorer
         elif is_xarray(data):
@@ -451,9 +452,6 @@ class hvGeomExplorer(hvPlotExplorer):
 
     kind = param.Selector(default=None, objects=sorted(GEOM_KINDS))
 
-    def __new__(cls, data, **params):
-        return super(hvPlotExplorer, cls).__new__(cls)
-
     @property
     def _single_y(self):
         return True
@@ -478,9 +476,6 @@ class hvGeomExplorer(hvPlotExplorer):
 class hvGridExplorer(hvPlotExplorer):
 
     kind = param.Selector(default=None, objects=sorted(GRIDDED_KINDS))
-
-    def __new__(cls, data, **params):
-        return super(hvPlotExplorer, cls).__new__(cls)
 
     @property
     def _x(self):
@@ -517,9 +512,6 @@ class hvDataFrameExplorer(hvPlotExplorer):
     z = param.Selector()
 
     kind = param.Selector(default='line', objects=sorted(DATAFRAME_KINDS))
-
-    def __new__(cls, data, **params):
-        return super(hvPlotExplorer, cls).__new__(cls)
 
     @property
     def xcat(self):

--- a/hvplot/ui.py
+++ b/hvplot/ui.py
@@ -391,7 +391,6 @@ class hvPlotExplorer(Viewer):
                 p.objects = variables
 
     def _plot(self, *events):
-        self._layout.loading = True
         y = self.y_multi if 'y_multi' in self._controls.parameters else self.y
         if isinstance(y, list) and len(y) == 1:
             y = y[0]
@@ -410,6 +409,7 @@ class hvPlotExplorer(Viewer):
         df = self._data
         if len(df) > MAX_ROWS and not (self.kind in STATS_KINDS or kwargs.get('rasterize') or kwargs.get('datashade')):
             df = df.sample(n=MAX_ROWS)
+        self._layout.loading = True
         try:
             plot = _hvPlot(df)(
                 kind=self.kind, x=self.x, y=y, by=self.by, groupby=self.groupby, **kwargs

--- a/hvplot/ui.py
+++ b/hvplot/ui.py
@@ -499,7 +499,7 @@ class hvPlotExplorer(Viewer):
     def panel(self):
         """Return the plot wrapped in a Panel HoloViews Pane.
         """
-        return self._hvpane.clone()
+        return self._hvpane
     
     def save(self, filename, **kwargs):
         """Save the plot to file.

--- a/hvplot/ui.py
+++ b/hvplot/ui.py
@@ -38,7 +38,7 @@ def explorer(data, **kwargs):
 
     Parameters
     ----------
-    data : pandas.DataFrame, geopandas.DataFrame
+    data : pandas.DataFrame
         Data structure to explore.
 
     Returns
@@ -306,7 +306,8 @@ class hvPlotExplorer(Viewer):
 
     labels = param.ClassSelector(class_=Labels)
 
-    geo = param.ClassSelector(class_=Geo)
+    # Hide the geo tab until it's better supported
+    # geo = param.ClassSelector(class_=Geo)
 
     operations = param.ClassSelector(class_=Operations)
 
@@ -315,9 +316,11 @@ class hvPlotExplorer(Viewer):
     @classmethod
     def from_data(cls, data, **params):
         if is_geodataframe(data):
-            cls = hvGeomExplorer
+            # cls = hvGeomExplorer
+            raise TypeError('GeoDataFrame objects not yet supported.')
         elif is_xarray(data):
-            cls = hvGridExplorer
+            # cls = hvGridExplorer
+            raise TypeError('Xarray objects not yet supported.')
         else:
             cls = hvDataFrameExplorer
         return cls(data, **params)

--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,7 @@ commands = pytest -v hvplot --cov=./hvplot --cov-append
 [_examples]
 description = Test that default examples run
 deps = .[examples, tests]
-commands = pytest --nbsmoke-run -k ".ipynb"
+commands = pytest --nbsmoke-run -k ".ipynb" --ignore-nbsmoke-skip-run
 
 [_all]
 description = Run all tests
@@ -59,7 +59,7 @@ norecursedirs = doc .git dist build _build .ipynb_checkpoints
 ; to collect files like `test_geo.py`. This setting allows
 ; to avoid renaming all the test files.
 python_files = test*.py
-
+nbsmoke_skip_run = ^.*Explorer\.ipynb$
 
 [flake8]
 include = *.py

--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,7 @@ commands = pytest -v hvplot --cov=./hvplot --cov-append
 [_examples]
 description = Test that default examples run
 deps = .[examples, tests]
-commands = pytest --nbsmoke-run -k ".ipynb" --ignore-nbsmoke-skip-run
+commands = pytest --nbsmoke-run -k ".ipynb"
 
 [_all]
 description = Run all tests


### PR DESCRIPTION
Fixes https://github.com/holoviz/hvplot/issues/764 
Fixes #787

- [x] ~~Should the accessors be patched by default when `hvplot.explorer` is called? I think so.~~ I changed my mind, less side effects are better, at least for a start.
- [x] ~~Should the explorer allow to switch the plotting backend? I'm not sure.~~ Let's keep it simple for now.
- [x] Discuss and extend the API
- [x] Add tests
- [x] Add docs. I suggest marking the explorer as **experimental** on its doc page.

![image](https://user-images.githubusercontent.com/35924738/181118286-a627f09c-449f-464a-879b-4c09b6ed9df7.png)

@philippjfr  in https://github.com/holoviz/hvplot/commit/87b07b424067c4a413edbf4ab46360915c6a51e3 I've removed the `__new__` methods. They were causing `__init__` to be called twice, which wasn't really an issue as far as I could tell but was for sure undesired. I found no way to fix that by keeping them, so replaced them by a factory class method `from_data` that I use in the `explorer` function. This is a breaking change, which might be fine given that the explorer has been released recently and never documented. If this breaking change is unwanted, I could add a warning when an explorer isn't instantiated with `from_data`, or keep digging to try to fix the issue with `__new__`.