### PR TITLE
Remove the marker styling option of the explorer

### DIFF
--- a/hvplot/ui.py
+++ b/hvplot/ui.py
@@ -109,8 +109,6 @@ class Style(Controls):
 
     alpha = param.Magnitude(default=1)
 
-    marker = param.Selector()
-
 
 class Axes(Controls):
 


### PR DESCRIPTION
Sort of fixes https://github.com/holoviz/hvplot/issues/786

The explorer had a `marker` styling option available that in practice wasn't useful as it was not listing the markers available, in light of the upcoming release this PR simply removes this option.

Handling the styling options is a lot trickier than the other plot options:

- they vary given the selected backend
- they vary given the select kind of plot
- hvPlot for sure doesn't know anything about the values a styling option like `marker` can accept. I don't think HoloViews does either, @jlstevens do you confirm?. And I don't know if the plotting backends have APIs that expose their allowed values.
- there can be many many options to set, in particular for the interactive backends

It seems like there's more thinking and work required before exposing styling options to the explorer. My take is that for a first release the explorer is already useful enough without the styling options, hence this PR.