### PR TITLE
Enhancement to Fields tab in explorer

### DIFF
--- a/hvplot/ui.py
+++ b/hvplot/ui.py
@@ -353,12 +353,21 @@ class hvPlotExplorer(Viewer):
 
     def _populate(self):
         variables = self._converter.variables
+        indexes = getattr(self._converter, "indexes", [])
+        variables_no_index = [v for v in variables if v not in indexes]
         for pname in self.param:
             if pname == 'kind':
                 continue
             p = self.param[pname]
             if isinstance(p, param.Selector):
-                p.objects = variables
+                if pname == "x":
+                    p.objects = variables
+                else:
+                    p.objects = variables_no_index
+
+                # Setting the default value
+                if pname == "x" or pname == "y":
+                    setattr(self, pname, p.objects[0])
 
     def _plot(self, *events):
         self._layout.loading = True

--- a/hvplot/ui.py
+++ b/hvplot/ui.py
@@ -1,4 +1,3 @@
-import holoviews as hv
 import numpy as np
 import panel as pn
 import param
@@ -26,18 +25,6 @@ GEO_FEATURES = [
 GEO_TILES = list(tile_sources)
 AGGREGATORS = [None, 'count', 'min', 'max', 'mean', 'sum', 'any']
 MAX_ROWS = 10000
-
-
-def _no_axis_hook(plot, element):
-    backend = hv.Store.current_backend
-    if backend == "bokeh":
-        plot.state.axis.visible = False
-        plot.state.grid.visible = False
-
-
-EMPTY_PLOT = pn.pane.HoloViews(
-    hv.Curve(None).opts(hooks=[_no_axis_hook]), sizing_mode='stretch_width', margin=(0, 20, 0, 20)
-)
 
 
 class Controls(Viewer):
@@ -411,7 +398,6 @@ class hvPlotExplorer(Viewer):
             self._layout[1][1] = hvplot
             self._alert.visible = False
         except Exception as e:
-            self._layout[1][1] = EMPTY_PLOT
             self._alert.param.set_param(
                 object=f'**Rendering failed with following error**: {e}',
                 visible=True

--- a/hvplot/ui.py
+++ b/hvplot/ui.py
@@ -348,7 +348,6 @@ class hvPlotExplorer(Viewer):
             pn.layout.HSpacer(),
             sizing_mode='stretch_both'
         )
-        self._plot()
         self.param.trigger('kind')
 
     def _populate(self):

--- a/hvplot/ui.py
+++ b/hvplot/ui.py
@@ -1,3 +1,4 @@
+import holoviews as hv
 import numpy as np
 import panel as pn
 import param
@@ -25,6 +26,18 @@ GEO_FEATURES = [
 GEO_TILES = list(tile_sources)
 AGGREGATORS = [None, 'count', 'min', 'max', 'mean', 'sum', 'any']
 MAX_ROWS = 10000
+
+
+def _no_axis_hook(plot, element):
+    backend = hv.Store.current_backend
+    if backend == "bokeh":
+        plot.state.axis.visible = False
+        plot.state.grid.visible = False
+
+
+EMPTY_PLOT = pn.pane.HoloViews(
+    hv.Curve(None).opts(hooks=[_no_axis_hook]), sizing_mode='stretch_width', margin=(0, 20, 0, 20)
+)
 
 
 class Controls(Viewer):
@@ -398,6 +411,7 @@ class hvPlotExplorer(Viewer):
             self._layout[1][1] = hvplot
             self._alert.visible = False
         except Exception as e:
+            self._layout[1][1] = EMPTY_PLOT
             self._alert.param.set_param(
                 object=f'**Rendering failed with following error**: {e}',
                 visible=True


### PR DESCRIPTION
Partially fixes #785 (2 and 4)

Indexes are now only added to `x`. For `x` and `y` because they are `param.Selector` needs to have the first value in the object specified, else they are None, which can give problem later on, e.g., when plotting.  

`self._plot` was removed because it is called when triggering `kind` on the next line.

<s>I have added the empty plot. Because when something fails, I think it is wrong to show the last working plot. The current configuration of settings does not output that plot. If people disagree with this, I could remove it from this PR and open another issue/PR to discuss it in. </s>