### PR TITLE
Add more tests to `Interactive` and some comments

### DIFF
--- a/hvplot/interactive.py
+++ b/hvplot/interactive.py
@@ -23,21 +23,25 @@ from .util import _flatten, is_tabular, is_xarray, is_xarray_dataarray
 
 def _find_widgets(op):
     widgets = []
-    op_args = list(op['args'])+list(op['kwargs'].values())
+    op_args = list(op['args']) + list(op['kwargs'].values())
     op_args = _flatten(op_args)
     for op_arg in op_args:
+        # Find widgets introduced as `widget` in an expression
         if 'panel' in sys.modules:
             if isinstance(op_arg, Widget) and op_arg not in widgets:
                 widgets.append(op_arg)
+        # TODO: Find how to execute this path?
         if isinstance(op_arg, hv.dim):
             for nested_op in op_arg.ops:
                 for widget in _find_widgets(nested_op):
                     if widget not in widgets:
                         widgets.append(widget)
+        # Find Ipywidgets
         if 'ipywidgets' in sys.modules:
             from ipywidgets import Widget as IPyWidget
             if isinstance(op_arg, IPyWidget) and op_arg not in widgets:
                 widgets.append(op_arg)
+        # Find widgets introduced as `widget.param.value` in an expression
         if (isinstance(op_arg, param.Parameter) and
             isinstance(op_arg.owner, pn.widgets.Widget) and
             op_arg.owner not in widgets):
@@ -47,17 +51,99 @@ def _find_widgets(op):
 
 class Interactive:
     """
-    Interactive is a wrapper around a Python object that lets users create
-    interactive pipelines by calling existing APIs on an object with
-    dynamic parameters or widgets.
+    `Interactive` is a wrapper around a Python object that lets users create
+    interactive pipelines by calling existing APIs on an object with dynamic
+    parameters or widgets.
+
+    `Interactive` can be instantiated with an object:
+    
+    >>> dfi = Interactive(df)
+
+    However the recommended approach is to instantiate it via the
+    `.interactive` accessor that is available on a data structure when it has
+    been patched, e.g. after executing `import hvplot.pandas`.
+
+    >>> dfi = df.interactive
+
+    The `.interactive` accessor can also be called which allows to pass kwargs.
+
+    >>> dfi = df.interactive()
+
+    How it works
+    ------------
+
+    An `Interactive` instance watches what operations are applied to the object.
+
+    To do so, each operation returns a new `Interactive` instance - the creation
+    of a new instance being taken care of by the `_clone` method - which allows
+    the next operation to be recorded, and so on and so forth. E.g. `dfi.head()`
+    first records that the `'head'` attribute is accessed, this is achieved
+    by overriding `__getattribute__`. A new interactive object is returned,
+    which will then record that it is being called, and that will be called as
+    `Interactive` implements `__call__`, which itself returns an `Interactive`
+    instance.
+
+    Note that under the hood even more `Interactive` instances may be created,
+    but this is the gist of it.
+
+    To be able to watch all the potential operations that may be applied to an
+    object, `Interactive` implements on top of `__getattribute__` and
+    `__call__`:
+    
+    - operators such as `__gt__`, `__add__`, etc.
+    - the builtin functions `__abs__` and `__round__`
+    - `__getitem__`
+    - `__array_ufunc__`
+
+    The `_depth` attribute starts at 0 and is incremented by 1 everytime
+    a new `Interactive` instance is created part of a chain.
+    The root instance in an expression has a `_depth` of 0. An expression can
+    consist of multiple chains, such as `dfi[dfi.A > 1]`, as the `Interactive`
+    instance is referenced twice in the expression. As a consequence `_depth`
+    is not the total count of `Interactive` instance creations of a pipeline,
+    it is the count of instances created in outer chain. In the example, that
+    would be `dfi[]`. `Interactive` instances don't have references about
+    the instances that created them or that they create, they just know their
+    current location in a chain thanks to `_depth`. However, as some parameters
+    need to be passed down the whole pipeline, they do have to propagate. E.g.
+    in `dfi.interactive(width=200)`, `width=200` will be propagated as `kwargs`.
+
+    
+    Recording the operations applied to an object in a pipeline is done
+    by gradually building a so-called "dim expression", or "dim transform",
+    which is an expression language provided by HoloViews. dim transform
+    objects are a way to express transforms on `Dataset`s, a `Dataset` being
+    another HoloViews object that is a wrapper around common data structures
+    such as Pandas/Dask/... Dataframes/Series, Xarray Dataset/DataArray, etc.
+    For instance a Python expression such as `(series + 2).head()` can be
+    expressed with a dim transform whose repr will be `(dim('*').pd+2).head(2)`,
+    effectively showing that the dim transfom has recorded the different
+    operations that are meant to be applied to the data.
+    The `_transform` attribute stores the dim transform.
+
+    The `_obj` attribute holds the original data structure that feeds the
+    pipeline. All the `Interactive` instances created while parsing the
+    pipeline share the same `_obj` object. And they all wrap it in a `Dataset`
+    instance, and all apply the current dim transform they are aware of to
+    the original data structure to compute the intermediate state of the data,
+    that is stored it in the `_current` attribute. Doing so is particularly
+    useful in Notebook sessions, as this allows to inspect the transformed
+    object at any point of the pipeline, and as such provide correct
+    auto-completion and docstrings. E.g. executing `dfi.A.max?` in a Notebook
+    will correctly return the docstring of the Pandas Series `.max()` method,
+    as the pipeline evaluates `dfi.A` to hold a current object `_current` that
+    is a Pandas Series, and no longer and DataFrame.
     """
 
+    # TODO: Why?
     __metaclass__ = abc.ABCMeta
 
+    # Hackery to support calls to the classic `.plot` API, see `_get_ax_fn`
+    # for more hacks!
     _fig = None
 
     def __new__(cls, obj, **kwargs):
-        # __new__ implemented to support functions as input, i.e. 
+        # __new__ implemented to support functions as input, e.g. 
         # hvplot.find(foo, widget).interactive().max()
         if 'fn' in kwargs:
             fn = kwargs.pop('fn')
@@ -77,11 +163,17 @@ class Interactive:
 
     @classmethod
     def applies(cls, obj):
+        """
+        Subclasses must implement applies and return a boolean to indicates
+        wheter the subclass should apply or not to the obj.
+        """
         return True
 
     def __init__(self, obj, transform=None, fn=None, plot=False, depth=0,
                  loc='top_left', center=False, dmap=False, inherit_kwargs={},
                  max_rows=100, method=None, **kwargs):
+        # _init is used to prevent to __getattribute__ to execute its
+        # specialized code.
         self._init = False
         if self._fn is not None:
             for _, params in full_groupby(self._fn_params, lambda x: id(x.owner)):
@@ -109,6 +201,8 @@ class Interactive:
         self._loc = loc
         self._center = center
         self._dmap = dmap
+        # TODO: What's the real use of inherit_kwargs? So far I've only seen
+        # it containing 'ax'
         self._inherit_kwargs = inherit_kwargs
         self._max_rows = max_rows
         self._kwargs = kwargs
@@ -128,6 +222,7 @@ class Interactive:
             dinfo = getattr(self._fn.object, '_dinfo', {})
             deps = list(dinfo.get('dependencies', [])) + list(dinfo.get('kw', {}).values())
         else:
+            # TODO: Find how to execute that path?
             parameterized = get_method_owner(self._fn.object)
             deps = parameterized.param.method_dependencies(self._fn.object.__name__)
         return deps
@@ -152,6 +247,7 @@ class Interactive:
                 transform = transform.clone(obj.name)
             obj = transform.apply(ds, keep_index=True, compute=False)
             if self._method:
+                # E.g. `pi = dfi.A` leads to `pi._method` equal to `'A'`.
                 obj = getattr(obj, self._method, obj)
             if self._plot:
                 return Interactive._fig
@@ -168,7 +264,7 @@ class Interactive:
         loc = self._loc if loc is None else loc
         center = self._center if center is None else center
         dmap = self._dmap if dmap is None else dmap
-        depth = self._depth+1
+        depth = self._depth + 1
         if copy:
             kwargs = dict(self._kwargs, inherit_kwargs=self._inherit_kwargs, method=self._method, **kwargs)
         else:
@@ -193,7 +289,11 @@ class Interactive:
 
     def _resolve_accessor(self):
         if not self._method:
+            # No method is yet set, as in `dfi.A`, so return a copied clone.
             return self._clone(copy=True)
+        # This is executed when one runs e.g. `dfi.A > 1`, in which case after
+        # dfi.A the _method 'A' is set (in __getattribute__) which allows
+        # _resolve_accessor to keep building the transform dim expression.
         transform = type(self._transform)(self._transform, self._method, accessor=True)
         transform._ns = self._current
         inherit_kwargs = {}
@@ -202,6 +302,8 @@ class Interactive:
         try:
             new = self._clone(transform, inherit_kwargs=inherit_kwargs)
         finally:
+            # Reset _method for whatever happens after the accessor has been
+            # fully resolved, e.g. whatever happens `dfi.A > 1`.
             self._method = None
         return new
 
@@ -214,9 +316,13 @@ class Interactive:
         method = self_dict['_method']
         if method:
             current = getattr(current, method)
+        # Getting all the public attributes available on the current object,
+        # e.g. `sum`, `head`, etc.
         extras = [d for d in dir(current) if not d.startswith('_')]
         if name in extras and name not in super().__dir__():
             new = self._resolve_accessor()
+            # Setting the method name for a potential use later by e.g. an
+            # operator or method, as in `dfi.A > 2`. or `dfi.A.max()`
             new._method = name
             try:
                 new.__doc__ = getattr(current, name).__doc__
@@ -239,9 +345,16 @@ class Interactive:
     def __call__(self, *args, **kwargs):
         if self._method is None:
             if self._depth == 0:
+                # This code path is entered when initializing an interactive
+                # class from the accessor, e.g. with df.interactive(). As
+                # calling the accessor df.interactive already returns an
+                # Interactive instance.
                 return self._clone(*args, **kwargs)
+            # TODO: When is this error raised?
             raise AttributeError
         elif self._method == 'plot':
+            # This - {ax: get_ax} - is passed as kwargs to the plot method in
+            # the dim expression.
             kwargs['ax'] = self._get_ax_fn()
         new = self._clone(copy=True)
         try:
@@ -249,6 +362,8 @@ class Interactive:
             kwargs = dict(new._inherit_kwargs, **kwargs)
             clone = new._clone(method(*args, **kwargs), plot=new._method == 'plot')
         finally:
+            # If an error occurs reset _method anyway so that, e.g. the next
+            # attempt in a Notebook, is set appropriately.
             new._method = None
         return clone
 
@@ -257,6 +372,7 @@ class Interactive:
     #----------------------------------------------------------------
 
     def __array_ufunc__(self, *args, **kwargs):
+        # TODO: How to trigger this method?
         new = self._resolve_accessor()
         transform = new._transform
         transform = args[0](transform, *args[3:], **kwargs)
@@ -294,6 +410,7 @@ class Interactive:
         other = other._transform if isinstance(other, Interactive) else other
         return self._apply_operator(operator.and_, other)
     def __div__(self, other):
+        # TODO: operator.div is only available in Python 2, to be removed.
         other = other._transform if isinstance(other, Interactive) else other
         return self._apply_operator(operator.div, other)
     def __eq__(self, other):
@@ -385,6 +502,7 @@ class Interactive:
         return self._apply_operator(operator.getitem, other)
 
     def _plot(self, *args, **kwargs):
+        # TODO: Seems totally unused to me, as self._plot is set to a boolean in __init__
         @pn.depends()
         def get_ax():
             from matplotlib.backends.backend_agg import FigureCanvas
@@ -411,7 +529,7 @@ class Interactive:
 
     def eval(self):
         """
-        Returns the currrent state of the interactive expression. The
+        Returns the current state of the interactive expression. The
         returned object is no longer interactive.
         """
         obj = self._current
@@ -440,6 +558,7 @@ class Interactive:
             widgets = Column(widget_box, VSpacer())
         elif loc in ('left_bottom', 'right_bottom'):
             widgets = Column(VSpacer(), widget_box)
+        # TODO: add else and raise error
         center = self._center
         if not widgets:
             if center:

--- a/hvplot/interactive.py
+++ b/hvplot/interactive.py
@@ -57,6 +57,8 @@ class Interactive:
     _fig = None
 
     def __new__(cls, obj, **kwargs):
+        # __new__ implemented to support functions as input, i.e. 
+        # hvplot.find(foo, widget).interactive().max()
         if 'fn' in kwargs:
             fn = kwargs.pop('fn')
         elif isinstance(obj, (FunctionType, MethodType)):

--- a/hvplot/tests/testinteractive.py
+++ b/hvplot/tests/testinteractive.py
@@ -470,7 +470,7 @@ def test_interactive_pandas_frame_chained_attrs(df, clone_spy):
 
     assert dfi._obj is df
     assert isinstance(dfi._current, float)
-    assert pytest.approx(dfi._current, df.A.max())
+    assert dfi._current == pytest.approx(df.A.max())
     # This is a weird repr! Bug?
     assert repr(dfi._transform) == "dim('*').pd.A).max("
     assert dfi._depth == 4
@@ -498,7 +498,7 @@ def test_interactive_pandas_out_repr(series):
 
     assert isinstance(si, Interactive)
     assert isinstance(si._current, pd.Series)
-    assert pytest.approx(si._current.A, series.max())
+    assert si._current.A == pytest.approx(series.max())
     assert si._obj is series
     assert repr(si._transform) == "dim('*').pd.max()"
     # One _clone from _resolve_accessor, two from _clone
@@ -508,7 +508,7 @@ def test_interactive_pandas_out_repr(series):
     out = si._callback()
 
     assert isinstance(out, pd.Series)
-    assert pytest.approx(out.A, series.max())
+    assert out.A == pytest.approx(series.max())
 
 
 def test_interactive_pandas_out_frame(series):

--- a/hvplot/tests/testinteractive.py
+++ b/hvplot/tests/testinteractive.py
@@ -115,6 +115,12 @@ def test_interactive_xarray_dataarray(dataarray):
     assert dai._transform == dim('air')
 
 
+def test_interactive_xarray_dataarray_no_name():
+    dataarray = xr.DataArray(np.random.rand(2, 2))
+    with pytest.raises(ValueError, match='Cannot use interactive API on DataArray without name'):
+        Interactive(dataarray)
+
+
 def test_interactive_xarray_dataset(dataset):
     dsi = Interactive(dataset)
 

--- a/hvplot/tests/testinteractive.py
+++ b/hvplot/tests/testinteractive.py
@@ -366,7 +366,7 @@ def test_interactive_pandas_series_operator_and_method_widget(series):
     assert si._params[1] is w2.param.value
 
 
-def test_interactive_pandas_series_operator_ipywidget(series):
+def test_interactive_pandas_series_operator_ipywidgets(series):
     ipywidgets = pytest.importorskip("ipywidgets")
 
     w = ipywidgets.FloatSlider(value=2., min=1., max=5.)
@@ -384,6 +384,13 @@ def test_interactive_pandas_series_operator_ipywidget(series):
 
     # TODO: Isn't that a bug?
     assert len(si._params) == 0
+
+    widgets = si.widgets()
+
+    assert isinstance(widgets, pn.Column)
+    assert len(widgets) == 1
+    assert isinstance(widgets[0], pn.pane.IPyWidget)
+    assert widgets[0].object is w
 
 
 def test_interactive_pandas_series_operator_out_widgets(series):

--- a/hvplot/tests/testinteractive.py
+++ b/hvplot/tests/testinteractive.py
@@ -635,3 +635,27 @@ def test_interactive_pandas_series_operator_reverse_binary(op):
     val_repr = '2.0' if isinstance(val, float) else 'True'
     assert repr(si._transform) == f"{val_repr}{op}dim('*')"
     assert si._depth == 2
+
+
+def test_interactive_pandas_series_operator_abs(series):
+    si = Interactive(series)
+    si = abs(si)
+
+    assert isinstance(si, Interactive)
+    assert isinstance(si._current, pd.DataFrame)
+    pd.testing.assert_series_equal(si._current.A, abs(series))
+    assert si._obj is series
+    assert repr(si._transform) == "absdim('*')"
+    assert si._depth == 2
+
+
+def test_interactive_pandas_series_operator_round(series):
+    si = Interactive(series)
+    si = round(si)
+
+    assert isinstance(si, Interactive)
+    assert isinstance(si._current, pd.DataFrame)
+    pd.testing.assert_series_equal(si._current.A, round(series))
+    assert si._obj is series
+    assert repr(si._transform) == "dim('*', round)"
+    assert si._depth == 2

--- a/hvplot/tests/testinteractive.py
+++ b/hvplot/tests/testinteractive.py
@@ -1,5 +1,6 @@
 import hvplot.pandas  # noqa
 import hvplot.xarray  # noqa
+import matplotlib
 import numpy as np
 import pandas as pd
 import panel as pn
@@ -760,3 +761,31 @@ def test_interactive_pandas_series_operator_round(series):
     assert si._obj is series
     assert repr(si._transform) == "dim('*', round)"
     assert si._depth == 2
+
+
+def test_interactive_pandas_series_plot(series, clone_spy):
+    si = Interactive(series)
+
+    si = si.plot()
+
+    assert isinstance(si, Interactive)
+
+    assert clone_spy.count == 3
+
+    assert not clone_spy.calls[0].args
+    assert clone_spy.calls[0].kwargs == {'copy': True}
+
+    assert not clone_spy.calls[1].args
+    assert clone_spy.calls[1].kwargs == {'copy': True}
+
+    assert len(clone_spy.calls[2].args) == 1
+    # Not the complete repr as the function doesn't have a nice repr,
+    # its repr displays  the memory address.
+    assert "dim('*').pd.plot(ax=<function Interactive._get_ax_fn.<locals>.get_ax" in repr(clone_spy.calls[2].args[0])
+    assert clone_spy.calls[2].kwargs == {'plot': True}
+
+    assert not si._dmap
+    assert isinstance(si._fig, matplotlib.figure.Figure)
+
+    # Just test that it doesn't raise any error.
+    si.output()

--- a/hvplot/tests/testinteractive.py
+++ b/hvplot/tests/testinteractive.py
@@ -1,11 +1,11 @@
+import numpy as np
 import pandas as pd
 import panel as pn
 import pytest
 
 from holoviews.util.transform import dim
 
-import hvplot.pandas  # noqa
-from hvplot import bind
+from hvplot import bind, hvPlotTabular
 from hvplot.interactive import Interactive
 from hvplot.xarray import XArrayInteractive
 
@@ -17,6 +17,101 @@ except ImportError:
 
 xr_available = pytest.mark.skipif(xr is None, reason="requires xarray")
 
+
+@pytest.fixture(scope='module')
+def series():
+    return pd.Series(np.arange(5.0), name='A')
+
+
+@pytest.fixture(scope='module')
+def df():
+    return pd._testing.makeMixedDataFrame()
+
+
+class CallArgs:
+    def __init__(self, args, kwargs):
+        self.args = args
+        self.kwargs = kwargs
+
+    def __repr__(self):
+        return f'CallArgs(args={self.args!r}, kwargs={self.kwargs!r})'
+
+    def is_empty(self):
+        return not self.args and not self.kwargs
+
+
+class Spy:
+    def __init__(self):
+        self.count = 0
+        self.calls = {}
+
+    def __repr__(self):
+        return f'Spy(count={self.count!r}, calls={self.calls!r})'
+
+    def register_call(self, args, kwargs):
+        self.calls[self.count] = CallArgs(args, kwargs)
+        self.count += 1
+
+
+@pytest.fixture
+def clone_spy():
+    spy = Spy()
+
+    _clone = Interactive._clone
+
+    def clone_bis(inst, *args, **kwargs):
+        spy.register_call(args, kwargs)
+        return _clone(inst, *args, **kwargs)
+
+    Interactive._clone = clone_bis
+
+    yield spy
+
+    Interactive._clone = _clone
+
+
+@pytest.fixture
+def pandas_patch_interactive():
+    _patch_interactive = lambda self: Interactive(self)
+    _patch_interactive.__doc__ = Interactive.__call__.__doc__
+    interactive_prop = property(_patch_interactive)
+    setattr(pd.DataFrame, 'interactive', interactive_prop)
+    setattr(pd.Series, 'interactive', interactive_prop)
+
+    yield
+
+    delattr(pd.DataFrame, 'interactive')
+    delattr(pd.Series, 'interactive')
+
+
+@pytest.fixture
+def pandas_patch_hvplot():
+    _patch_plot = lambda self: hvPlotTabular(self)
+    _patch_plot.__doc__ = hvPlotTabular.__call__.__doc__
+    plot_prop = property(_patch_plot)
+    setattr(pd.DataFrame, 'hvplot', plot_prop)
+    setattr(pd.Series, 'hvplot', plot_prop)
+
+    yield
+
+    delattr(pd.DataFrame, 'hvplot')
+    delattr(pd.Series, 'hvplot')
+
+
+def test_spy(clone_spy, series):
+    si = Interactive(series)
+    si._clone()
+
+    assert clone_spy.count == 1
+    assert clone_spy.calls[0].is_empty()
+
+    si._clone(x='X')
+    
+    assert clone_spy.count == 2
+    assert not clone_spy.calls[1].is_empty()
+    assert clone_spy.calls[1].kwargs == dict(x='X')
+
+
 def test_interactive_pandas_dataframe():
     df = pd._testing.makeMixedDataFrame()
 
@@ -27,6 +122,7 @@ def test_interactive_pandas_dataframe():
     assert dfi._fn is None
     assert dfi._transform == dim('*')
 
+
 def test_interactive_pandas_series():
     df = pd._testing.makeMixedDataFrame()
 
@@ -36,6 +132,7 @@ def test_interactive_pandas_series():
     assert dfi._obj is df.A
     assert dfi._fn is None
     assert dfi._transform == dim('*')
+
 
 @xr_available
 def test_interactive_xarray_dataarray():
@@ -48,6 +145,7 @@ def test_interactive_xarray_dataarray():
     assert dsi._fn is None
     assert dsi._transform == dim('air')
 
+
 @xr_available
 def test_interactive_xarray_dataset():
     ds = xr.tutorial.load_dataset('air_temperature')
@@ -58,6 +156,7 @@ def test_interactive_xarray_dataset():
     assert dsi._obj is ds
     assert dsi._fn is None
     assert dsi._transform == dim('*')
+
 
 def test_interactive_pandas_function():
     df = pd._testing.makeMixedDataFrame()
@@ -75,6 +174,7 @@ def test_interactive_pandas_function():
 
     select.value = 'B'
     assert dfi._obj is df.B
+
 
 @xr_available
 def test_interactive_xarray_function():
@@ -97,6 +197,7 @@ def test_interactive_xarray_function():
     assert dsi._transform == dim('air2')
 
 
+@pytest.mark.usefixtures("pandas_patch_interactive", "pandas_patch_hvplot")
 def test_interactive_pandas_dataframe_accessor():
     df = pd._testing.makeMixedDataFrame()
     dfi = df.interactive()
@@ -139,3 +240,440 @@ def test_interactive_with_bound_function_calls():
 
     # w_species.value = 2
     # assert load_data.COUNT == 2
+
+
+def test_interactive_pandas_series_init(series, clone_spy):
+    si = Interactive(series)
+
+    assert clone_spy.count == 0
+
+    assert si._obj is series
+    assert repr(si._transform) == "dim('*')"
+    assert isinstance(si._current, pd.DataFrame)
+    pd.testing.assert_series_equal(si._current.A, series)
+    assert si._depth == 0
+
+
+@pytest.mark.usefixtures("pandas_patch_interactive")
+def test_interactive_pandas_series_accessor(series, clone_spy):
+
+    si = series.interactive()
+
+    assert isinstance(si, Interactive)
+    assert clone_spy.count == 1
+    assert clone_spy.calls[0].is_empty()
+
+    assert si._obj is series
+    assert repr(si._transform) == "dim('*')"
+    assert isinstance(si._current, pd.DataFrame)
+    pd.testing.assert_series_equal(si._current.A, series)
+    assert si._depth == 1
+
+
+def test_interactive_pandas_series_operator(series, clone_spy):
+    si = Interactive(series)
+    si = si + 2
+
+    assert isinstance(si, Interactive)
+    assert isinstance(si._current, pd.DataFrame)
+    pd.testing.assert_series_equal(si._current.A, series + 2)
+    assert si._obj is series
+    assert repr(si._transform) == "dim('*').pd+2"
+    assert si._depth == 2
+
+    assert clone_spy.count == 2
+
+    assert not clone_spy.calls[0].args
+    assert clone_spy.calls[0].kwargs == {'copy': True}
+
+    assert len(clone_spy.calls[1].args) == 1
+    assert repr(clone_spy.calls[1].args[0]) == "dim('*').pd+2"
+    assert not clone_spy.calls[1].kwargs
+
+
+def test_interactive_pandas_series_method(series, clone_spy):
+    si = Interactive(series)
+    si = si.head(2)
+
+    assert isinstance(si, Interactive)
+    assert isinstance(si._current, pd.DataFrame)
+    pd.testing.assert_series_equal(si._current.A, series.head(2))
+    assert si._obj is series
+    assert repr(si._transform) == "dim('*').pd.head(2)"
+    assert si._depth == 3
+
+    assert clone_spy.count == 3
+
+    assert not clone_spy.calls[0].args
+    assert clone_spy.calls[0].kwargs == {'copy': True}
+
+    assert not clone_spy.calls[1].args
+    assert clone_spy.calls[1].kwargs == {'copy': True}
+
+    assert len(clone_spy.calls[2].args) == 1
+    assert repr(clone_spy.calls[2].args[0]) == "dim('*').pd.head(2)"
+    assert clone_spy.calls[2].kwargs == {'plot': False}
+
+
+def test_interactive_pandas_series_operator_and_method(series, clone_spy):
+    si = Interactive(series)
+
+    assert isinstance(si, Interactive)
+    
+    si = (si + 2).head(2)
+
+    assert isinstance(si, Interactive)
+    assert isinstance(si._current, pd.DataFrame)
+    pd.testing.assert_series_equal(si._current.A, (series + 2).head(2))
+    assert si._obj is series
+    assert repr(si._transform) == "(dim('*').pd+2).head(2)"
+    assert si._depth == 5
+
+    assert clone_spy.count == 5
+
+    assert not clone_spy.calls[0].args
+    assert clone_spy.calls[0].kwargs == {'copy': True}
+
+    assert len(clone_spy.calls[1].args) == 1
+    assert repr(clone_spy.calls[1].args[0]) == "dim('*').pd+2"
+    assert not clone_spy.calls[1].kwargs
+
+    assert not clone_spy.calls[2].args
+    assert clone_spy.calls[2].kwargs == {'copy': True}
+
+    assert not clone_spy.calls[3].args
+    assert clone_spy.calls[3].kwargs == {'copy': True}
+
+    assert len(clone_spy.calls[4].args) == 1
+    assert repr(clone_spy.calls[4].args[0]) == "(dim('*').pd+2).head(2)"
+    assert clone_spy.calls[4].kwargs == {'plot': False}
+
+
+def test_interactive_pandas_series_operator_widget(series):
+    w = pn.widgets.FloatSlider(value=2., start=1., end=5.)
+
+    si = Interactive(series)
+
+    si = si + w
+
+    assert isinstance(si, Interactive)
+    assert isinstance(si._current, pd.DataFrame)
+    pd.testing.assert_series_equal(si._current.A, series + w.value)
+    assert si._obj is series
+    assert repr(si._transform) == "dim('*').pd+FloatSlider(end=5.0, start=1.0, value=2.0)"
+    assert si._depth == 2
+
+    assert len(si._params) == 1
+    assert si._params[0] is w.param.value
+
+
+def test_interactive_pandas_series_method_widget(series):
+    w = pn.widgets.IntSlider(value=2, start=1, end=5)
+
+    si = Interactive(series)
+
+    si = si.head(w)
+
+    assert isinstance(si, Interactive)
+    assert isinstance(si._current, pd.DataFrame)
+    pd.testing.assert_series_equal(si._current.A, series.head(w.value))
+    assert si._obj is series
+    assert repr(si._transform) == "dim('*').pd.head(IntSlider(end=5, start=1, value=2))"
+    assert si._depth == 3
+
+    assert len(si._params) == 1
+    assert si._params[0] is w.param.value
+
+
+def test_interactive_pandas_series_operator_and_method_widget(series):
+    w1 = pn.widgets.FloatSlider(value=2., start=1., end=5.)
+    w2 = pn.widgets.IntSlider(value=2, start=1, end=5)
+
+    si = Interactive(series)
+
+    assert isinstance(si, Interactive)
+    
+    si = (si + w1).head(w2)
+
+    assert isinstance(si, Interactive)
+    assert isinstance(si._current, pd.DataFrame)
+    pd.testing.assert_series_equal(si._current.A, (series + w1.value).head(w2.value))
+    assert si._obj is series
+    assert repr(si._transform) == "(dim('*').pd+FloatSlider(end=5.0, start=1.0, value=2.0)).head(IntSlider(end=5, start=1, value=2))"
+    assert si._depth == 5
+
+    assert len(si._params) == 2
+    assert si._params[0] is w1.param.value
+    assert si._params[1] is w2.param.value
+
+
+def test_interactive_pandas_series_operator_widget_update(series):
+    w = pn.widgets.FloatSlider(value=2., start=1., end=5.)
+    si = Interactive(series)
+    si = si + w
+
+    w.value = 3.
+    assert repr(si._transform) == "dim('*').pd+FloatSlider(end=5.0, start=1.0, value=3.0)"
+    
+    out = si._callback()
+    assert isinstance(out, pn.pane.DataFrame)
+    pd.testing.assert_series_equal(out.object.A, series + 3.)
+
+
+def test_interactive_pandas_series_method_widget_update(series):
+    w = pn.widgets.IntSlider(value=2, start=1, end=5)
+    si = Interactive(series)
+    si = si.head(w)
+
+    w.value = 3
+    assert repr(si._transform) =="dim('*').pd.head(IntSlider(end=5, start=1, value=3))"
+    
+    out = si._callback()
+    assert isinstance(out, pn.pane.DataFrame)
+    pd.testing.assert_series_equal(out.object.A, series.head(3))
+
+
+def test_interactive_pandas_series_operator_and_method_widget_update(series):
+    w1 = pn.widgets.FloatSlider(value=2., start=1., end=5.)
+    w2 = pn.widgets.IntSlider(value=2, start=1, end=5)
+    si = Interactive(series)
+    si = (si + w1).head(w2)
+
+    w1.value = 3.
+    w2.value = 3
+
+    assert repr(si._transform) == "(dim('*').pd+FloatSlider(end=5.0, start=1.0, value=3.0)).head(IntSlider(end=5, start=1, value=3))"
+
+    out = si._callback()
+    assert isinstance(out, pn.pane.DataFrame)
+    pd.testing.assert_series_equal(out.object.A, (series + 3.).head(3))
+
+
+def test_interactive_pandas_frame_loc(df):
+    dfi = Interactive(df)
+
+    dfi = dfi.loc[:, 'A']
+
+    assert isinstance(dfi, Interactive)
+
+    assert dfi._obj is df
+    assert isinstance(dfi._current, pd.Series)
+    pd.testing.assert_series_equal(dfi._current, df.loc[:, 'A'])
+    assert repr(dfi._transform) == "dim('*').pd.loc, getitem, (slice(None, None, None), 'A')"
+    assert dfi._depth == 3
+
+
+def test_interactive_pandas_frame_selection(df, clone_spy):
+    dfi = Interactive(df)
+
+    # There are 2 references to dfi in the right part of this expression,
+    # so it's cloned twice from its root, which is why in the end dfi._depth
+    # only reaches 1. 
+    # TODO: Comment no longer true...
+    dfi = dfi[dfi.A > 1]
+
+    assert isinstance(dfi, Interactive)
+
+    assert dfi._obj is df
+    assert isinstance(dfi._current, pd.DataFrame)
+    pd.testing.assert_frame_equal(dfi._current, df[df.A > 1])
+    assert repr(dfi._transform) == "dim('*', getitem, dim('*').pd.A)>1"
+    assert dfi._depth == 2
+
+    assert clone_spy.count == 5
+
+    assert not clone_spy.calls[0].args
+    assert clone_spy.calls[0].kwargs == {'copy': True}
+
+    assert len(clone_spy.calls[1].args) == 1
+    assert repr(clone_spy.calls[1].args[0]) == "dim('*').pd.A()"
+    assert clone_spy.calls[1].kwargs == {'inherit_kwargs': {}}
+
+    assert len(clone_spy.calls[2].args) == 1
+    assert repr(clone_spy.calls[2].args[0]) == "(dim('*').pd.A())>1"
+    assert not clone_spy.calls[2].kwargs
+
+    assert not clone_spy.calls[3].args
+    assert clone_spy.calls[3].kwargs == {'copy': True}
+
+    assert len(clone_spy.calls[4].args) == 1
+    assert repr(clone_spy.calls[4].args[0]) == "dim('*', getitem, (dim('*').pd.A())>1)"
+    assert not clone_spy.calls[4].kwargs
+
+
+def test_interactive_pandas_frame_chained_attrs(df, clone_spy):
+    dfi = Interactive(df)
+
+    dfi = dfi.A.max()
+
+    assert isinstance(dfi, Interactive)
+
+    assert dfi._obj is df
+    assert isinstance(dfi._current, float)
+    assert pytest.approx(dfi._current, df.A.max())
+    # This is a weird repr! Bug?
+    assert repr(dfi._transform) == "dim('*').pd.A).max("
+    assert dfi._depth == 4
+
+    assert clone_spy.count == 4
+
+    assert not clone_spy.calls[0].args
+    assert clone_spy.calls[0].kwargs == {'copy': True}
+
+    assert len(clone_spy.calls[1].args) == 1
+    assert repr(clone_spy.calls[1].args[0]) == "dim('*').pd.A()"
+    assert clone_spy.calls[1].kwargs == {'inherit_kwargs': {}}
+
+    assert not clone_spy.calls[2].args
+    assert clone_spy.calls[2].kwargs == {'copy': True}
+
+    assert len(clone_spy.calls[3].args) == 1
+    assert repr(clone_spy.calls[3].args[0]) == "(dim('*').pd.A()).max()"
+    assert clone_spy.calls[3].kwargs == {'plot': False}
+
+
+def test_interactive_pandas_out_repr(series):
+    si = Interactive(series)
+    si = si.max()
+
+    assert isinstance(si, Interactive)
+    assert isinstance(si._current, pd.Series)
+    assert pytest.approx(si._current.A, series.max())
+    assert si._obj is series
+    assert repr(si._transform) == "dim('*').pd.max()"
+    # One _clone from _resolve_accessor, two from _clone
+    assert si._depth == 3
+
+    # Equivalent to eval
+    out = si._callback()
+
+    assert isinstance(out, pd.Series)
+    assert pytest.approx(out.A, series.max())
+
+
+def test_interactive_pandas_out_frame(series):
+    si = Interactive(series)
+    si = si.head(2)
+
+    assert isinstance(si, Interactive)
+    assert isinstance(si._current, pd.DataFrame)
+    pd.testing.assert_series_equal(si._current.A, series.head(2))
+    assert si._obj is series
+    assert repr(si._transform) == "dim('*').pd.head(2)"
+    # One _clone from _resolve_accessor, two from _clone
+    assert si._depth == 3
+
+    # Equivalent to eval
+    out = si._callback()
+
+    assert isinstance(out, pn.pane.DataFrame)
+    pd.testing.assert_frame_equal(out.object, si._current)
+
+
+@pytest.mark.parametrize('op', [
+    '-',   # __neg__
+
+    # Doesn't any of the supported data implement __not__?
+    # e.g. `not series` raises an error.
+    # 'not', # __not__
+
+    '+',   # _pos__
+])
+def test_interactive_pandas_series_operator_unary(series, op):
+    if op == '~':
+        series = pd.Series([True, False, True], name='A')
+    si = Interactive(series)
+    si = eval(f'{op} si')
+
+    assert isinstance(si, Interactive)
+    assert isinstance(si._current, pd.DataFrame)
+    pd.testing.assert_series_equal(si._current.A, eval(f'{op} series'))
+    assert si._obj is series
+    assert repr(si._transform) == f"{op}dim('*')"
+    assert si._depth == 2
+
+
+def test_interactive_pandas_series_operator_unary_invert():  # __invert__
+    series = pd.Series([True, False, True], name='A')
+    si = Interactive(series)
+    si = ~si
+
+    assert isinstance(si, Interactive)
+    assert isinstance(si._current, pd.DataFrame)
+    pd.testing.assert_series_equal(si._current.A, ~series)
+    assert si._obj is series
+    assert repr(si._transform) == "dim('*', inv)"
+    assert si._depth == 2
+
+
+@pytest.mark.parametrize('op', [
+    '+',  # __add__
+    '&',  # __and__
+    '/',  # __div__
+    '==', # __eq__
+    '//', # __floordiv__
+    '>=', # __ge__
+    '>',  # __gt__
+    '<=', # __le__
+    '<',  # __lt__
+    '<',  # __lt__
+    # '<<',  # __lshift__
+    '%',  # __mod__
+    '*',  # __mul__
+    '!=',  # __ne__
+    '|',  # __or__
+    # '>>',  # __rshift__
+    '**',  # __pow__
+    '-',  # __sub__
+    '/',  # __truediv__
+])
+def test_interactive_pandas_series_operator_binary(series, op):
+    if op in ['&', '|']:
+        series = pd.Series([True, False, True], name='A')
+        val = True
+    else:
+        val = 2.
+    si = Interactive(series)
+    si = eval(f'si {op} {val}')
+
+    assert isinstance(si, Interactive)
+    assert isinstance(si._current, pd.DataFrame)
+    pd.testing.assert_series_equal(si._current.A, eval(f'series {op} {val}'))
+    assert si._obj is series
+    val_repr = '2.0' if isinstance(val, float) else 'True'
+    assert repr(si._transform) == f"dim('*').pd{op}{val_repr}"
+    assert si._depth == 2
+
+
+@pytest.mark.xfail()
+@pytest.mark.parametrize('op', [
+    '+',  # __radd__
+    '&',  # __rand__
+    '/',  # __rdiv__
+    '//', # __rfloordiv__
+    # '<<',  # __rlshift__
+    '%',  # __rmod__
+    '*',  # __rmul__
+    '|',  # __ror__
+    '**',  # __rpow__
+    # '>>',  # __rshift__
+    '-',  # __rsub__
+    '/',  # __rtruediv__
+])
+def test_interactive_pandas_series_operator_reverse_binary(op):
+    if op in ['&', '|']:
+        series = pd.Series([True, False, True], name='A')
+        val = True
+    else:
+        series = pd.Series([1.0, 2.0, 3.0], name='A')
+        val = 2.
+    si = Interactive(series)
+    si = eval(f'{val} {op} si')
+
+    assert isinstance(si, Interactive)
+    assert isinstance(si._current, pd.DataFrame)
+    pd.testing.assert_series_equal(si._current.A, eval(f'{val} {op} series'))
+    assert si._obj is series
+    val_repr = '2.0' if isinstance(val, float) else 'True'
+    assert repr(si._transform) == f"{val_repr}{op}dim('*')"
+    assert si._depth == 2

--- a/hvplot/tests/testinteractive.py
+++ b/hvplot/tests/testinteractive.py
@@ -1,3 +1,5 @@
+import hvplot.pandas  # noqa
+import hvplot.xarray  # noqa
 import numpy as np
 import pandas as pd
 import panel as pn
@@ -5,8 +7,7 @@ import pytest
 import xarray as xr
 
 from holoviews.util.transform import dim
-
-from hvplot import bind, hvPlot, hvPlotTabular
+from hvplot import bind
 from hvplot.interactive import Interactive
 from hvplot.xarray import XArrayInteractive
 
@@ -61,56 +62,6 @@ def clone_spy():
     yield spy
 
     Interactive._clone = _clone
-
-
-@pytest.fixture
-def pandas_patch_interactive():
-    _patch_interactive = lambda self: Interactive(self)
-    _patch_interactive.__doc__ = Interactive.__call__.__doc__
-    interactive_prop = property(_patch_interactive)
-    setattr(pd.DataFrame, 'interactive', interactive_prop)
-    setattr(pd.Series, 'interactive', interactive_prop)
-
-    yield
-
-    delattr(pd.DataFrame, 'interactive')
-    delattr(pd.Series, 'interactive')
-
-
-@pytest.fixture
-def pandas_patch_hvplot():
-    _patch_plot = lambda self: hvPlotTabular(self)
-    _patch_plot.__doc__ = hvPlotTabular.__call__.__doc__
-    plot_prop = property(_patch_plot)
-    setattr(pd.DataFrame, 'hvplot', plot_prop)
-    setattr(pd.Series, 'hvplot', plot_prop)
-
-    yield
-
-    delattr(pd.DataFrame, 'hvplot')
-    delattr(pd.Series, 'hvplot')
-
-
-@pytest.fixture
-def xarray_patch_interactive():
-    xr.register_dataset_accessor('interactive')(XArrayInteractive)
-    xr.register_dataarray_accessor('interactive')(XArrayInteractive)
-
-    yield
-
-    delattr(xr.DataArray, 'interactive')
-    delattr(xr.Dataset, 'interactive')
-
-
-@pytest.fixture
-def xarray_patch_hvplot():
-    xr.register_dataset_accessor('hvplot')(hvPlot)
-    xr.register_dataarray_accessor('hvplot')(hvPlot)
-
-    yield
-
-    delattr(xr.DataArray, 'hvplot')
-    delattr(xr.Dataset, 'hvplot')
 
 
 def test_spy(clone_spy, series):
@@ -209,7 +160,6 @@ def test_interactive_xarray_function():
     assert dsi._transform == dim('air2')
 
 
-@pytest.mark.usefixtures("pandas_patch_interactive", "pandas_patch_hvplot")
 def test_interactive_pandas_dataframe_accessor():
     df = pd._testing.makeMixedDataFrame()
     dfi = df.interactive()
@@ -220,7 +170,6 @@ def test_interactive_pandas_dataframe_accessor():
         dfi.hvplot.scatter(kind="area")
 
 
-@pytest.mark.usefixtures("xarray_patch_interactive", "xarray_patch_hvplot")
 def test_interactive_xarray_dataset_accessor():
     ds = xr.tutorial.load_dataset('air_temperature')
     dsi = ds.air.interactive
@@ -266,7 +215,6 @@ def test_interactive_pandas_series_init(series, clone_spy):
     assert si._depth == 0
 
 
-@pytest.mark.usefixtures("pandas_patch_interactive")
 def test_interactive_pandas_series_accessor(series, clone_spy):
 
     si = series.interactive()

--- a/hvplot/tests/testoperations.py
+++ b/hvplot/tests/testoperations.py
@@ -3,6 +3,7 @@ import sys
 from unittest import SkipTest
 from parameterized import parameterized
 
+import hvplot.pandas  # noqa
 import numpy as np
 import pandas as pd
 

--- a/hvplot/tests/testoptions.py
+++ b/hvplot/tests/testoptions.py
@@ -1,21 +1,13 @@
 import hvplot
 import holoviews as hv
 import numpy as np
+import pandas as pd
 import pytest
+import xarray as xr
 
 from holoviews import Store
 from holoviews.core.options import Options, OptionTree
 from packaging.version import Version
-
-try:
-    import pandas as pd
-except ImportError:
-    pd = None
-
-try:
-    import xarray as xr
-except ImportError:
-    xr = None
 
 
 @pytest.fixture(scope='class')
@@ -55,7 +47,6 @@ def symmetric_df():
                                         columns=['x', 'y', 'number'])
 
 
-@pytest.mark.skipif(pd is None, reason='Pandas not available')
 @pytest.mark.usefixtures('load_pandas_accessor')
 class TestOptions:
 
@@ -501,7 +492,6 @@ def ds2(da, da2):
     return xr.Dataset(dict(foo=da, bar=da2))
 
 
-@pytest.mark.skipif(xr is None, reason='Xarray not available')
 @pytest.mark.usefixtures('load_xarray_accessor')
 class TestXarrayTitle:
 

--- a/hvplot/tests/testoverrides.py
+++ b/hvplot/tests/testoverrides.py
@@ -1,17 +1,12 @@
 from collections import OrderedDict
-from unittest import SkipTest
 
 import numpy as np
 import pandas as pd
+import xarray as xr
 
 from hvplot.plotting import hvPlot, hvPlotTabular
 from holoviews import Store, Scatter
 from holoviews.element.comparison import ComparisonTestCase
-
-try:
-    import xarray as xr
-except:
-    xr = None
 
 
 class TestOverrides(ComparisonTestCase):
@@ -61,8 +56,6 @@ class TestOverrides(ComparisonTestCase):
 class TestXArrayOverrides(ComparisonTestCase):
 
     def setUp(self):
-        if xr is None:
-            raise SkipTest('XArray not available')
         coords = OrderedDict([('time', [0, 1]), ('lat', [0, 1]), ('lon', [0, 1])])
         self.da_img_by_time = xr.DataArray(np.arange(8).reshape((2, 2, 2)),
                                            coords, ['time', 'lat', 'lon']).assign_coords(

--- a/setup.py
+++ b/setup.py
@@ -82,6 +82,7 @@ extras_require = {
         'xarray',
         'pooch',
         'scipy',
+        'ipywidgets',
     ],
     'examples': _examples,
     'doc': _examples + [


### PR DESCRIPTION
This PR adds various tests to `Interactive`. The aim of these tests is two-fold: cover parts that were untested and better track the underlying logic of `Interactive`. More comments in particular are meant to be added.

Interestingly I wrote these tests first based on the `0.7.3` version of hvPlot, before the support for functions as input was added. The logic at the time was slightly easier to comprehend. When writing the tests I added some utility to inspect calls to the `_clone` method at it seemed central to the way `Interactive` operates. When I finally ran the tests against *master* I had to update these tests, `_clone` is called more than it used too. The logic of `Interactive` has become more difficult to track.