### PR TITLE
Some fixes to the operators implemented by Interactive

### DIFF
--- a/hvplot/interactive.py
+++ b/hvplot/interactive.py
@@ -409,10 +409,6 @@ class Interactive:
     def __and__(self, other):
         other = other._transform if isinstance(other, Interactive) else other
         return self._apply_operator(operator.and_, other)
-    def __div__(self, other):
-        # TODO: operator.div is only available in Python 2, to be removed.
-        other = other._transform if isinstance(other, Interactive) else other
-        return self._apply_operator(operator.div, other)
     def __eq__(self, other):
         other = other._transform if isinstance(other, Interactive) else other
         return self._apply_operator(operator.eq, other)

--- a/hvplot/interactive.py
+++ b/hvplot/interactive.py
@@ -462,7 +462,7 @@ class Interactive:
     # Reverse binary operators
     def __radd__(self, other):
         other = other._transform if isinstance(other, Interactive) else other
-        return self._apply_operator(operator.div, other, reverse=True)
+        return self._apply_operator(operator.add, other, reverse=True)
     def __rand__(self, other):
         other = other._transform if isinstance(other, Interactive) else other
         return self._apply_operator(operator.and_, other, reverse=True)

--- a/hvplot/interactive.py
+++ b/hvplot/interactive.py
@@ -378,10 +378,10 @@ class Interactive:
         transform = args[0](transform, *args[3:], **kwargs)
         return new._clone(transform)
 
-    def _apply_operator(self, operator, *args, **kwargs):
+    def _apply_operator(self, operator, *args, reverse=False, **kwargs):
         new = self._resolve_accessor()
         transform = new._transform
-        transform = type(transform)(transform, operator, *args)
+        transform = type(transform)(transform, operator, *args, reverse=reverse)
         return new._clone(transform)
 
     # Builtin functions

--- a/hvplot/tests/testinteractive.py
+++ b/hvplot/tests/testinteractive.py
@@ -920,7 +920,6 @@ def test_interactive_pandas_series_operator_binary(series, op):
     assert si._method is None
 
 
-@pytest.mark.xfail()
 @pytest.mark.parametrize('op', [
     '+',  # __radd__
     '&',  # __rand__

--- a/tox.ini
+++ b/tox.ini
@@ -59,7 +59,7 @@ norecursedirs = doc .git dist build _build .ipynb_checkpoints
 ; to collect files like `test_geo.py`. This setting allows
 ; to avoid renaming all the test files.
 python_files = test*.py
-
+xfail_strict = true
 
 [flake8]
 include = *.py

--- a/tox.ini
+++ b/tox.ini
@@ -59,7 +59,6 @@ norecursedirs = doc .git dist build _build .ipynb_checkpoints
 ; to collect files like `test_geo.py`. This setting allows
 ; to avoid renaming all the test files.
 python_files = test*.py
-xfail_strict = true
 
 [flake8]
 include = *.py


### PR DESCRIPTION
This PR fixes some issues observed on the operators implemented by Interactive:

* reversed operators were implemented but the `reverse` info was never passed to the dim transform
* one dunder method was using the wrong operator
* removed `__div__` as it has been removed in Python 3

This PR also makes the test suite fail when an xfail test actually passes (xpass).