### PR TITLE
Interactive: propagate max_rows

### DIFF
--- a/hvplot/interactive.py
+++ b/hvplot/interactive.py
@@ -280,12 +280,13 @@ class Interactive:
         return evaluate
 
     def _clone(self, transform=None, plot=None, loc=None, center=None,
-               dmap=None, copy=False, **kwargs):
+               dmap=None, copy=False, max_rows=None, **kwargs):
         plot = self._plot or plot
         transform = transform or self._transform
         loc = self._loc if loc is None else loc
         center = self._center if center is None else center
         dmap = self._dmap if dmap is None else dmap
+        max_rows = self._max_rows if max_rows is None else max_rows
         depth = self._depth + 1
         if copy:
             kwargs = dict(self._kwargs, inherit_kwargs=self._inherit_kwargs, method=self._method, **kwargs)
@@ -293,7 +294,7 @@ class Interactive:
             kwargs = dict(self._inherit_kwargs, **dict(self._kwargs, **kwargs))
         return type(self)(self._obj, fn=self._fn, transform=transform, plot=plot, depth=depth,
                          loc=loc, center=center, dmap=dmap, _shared_obj=self._shared_obj,
-                         max_rows=self._max_rows, **kwargs)
+                         max_rows=max_rows, **kwargs)
 
     def _repr_mimebundle_(self, include=[], exclude=[]):
         return self.layout()._repr_mimebundle_()

--- a/hvplot/interactive.py
+++ b/hvplot/interactive.py
@@ -270,7 +270,7 @@ class Interactive:
         else:
             kwargs = dict(self._inherit_kwargs, **dict(self._kwargs, **kwargs))
         return type(self)(self._obj, fn=self._fn, transform=transform, plot=plot, depth=depth,
-                         loc=loc, center=center, dmap=dmap, **kwargs)
+                         loc=loc, center=center, dmap=dmap, max_rows=self._max_rows, **kwargs)
 
     def _repr_mimebundle_(self, include=[], exclude=[]):
         return self.layout()._repr_mimebundle_()

--- a/hvplot/tests/testinteractive.py
+++ b/hvplot/tests/testinteractive.py
@@ -863,25 +863,25 @@ def test_interactive_pandas_out_frame_max_rows_accessor_called(series):
 
 
 def test_interactive_pandas_out_frame_kwargs(series):
-    si = Interactive(series, width=100)
+    si = Interactive(series, width=111)
     si = si.head(2)
 
     # Equivalent to eval
     out = si._callback()
 
     assert isinstance(out, pn.pane.DataFrame)
-    assert out.width == 100
+    assert out.width == 111
 
 
 def test_interactive_pandas_out_frame_kwargs_accessor_called(series):
-    si = series.interactive(width=100)
+    si = series.interactive(width=111)
     si = si.head(2)
 
     # Equivalent to eval
     out = si._callback()
 
     assert isinstance(out, pn.pane.DataFrame)
-    assert out.width == 100
+    assert out.width == 111
 
 
 def test_interactive_pandas_out_frame_attrib(df):

--- a/hvplot/tests/testinteractive.py
+++ b/hvplot/tests/testinteractive.py
@@ -873,6 +873,17 @@ def test_interactive_pandas_out_frame_kwargs(series):
     assert out.width == 100
 
 
+def test_interactive_pandas_out_frame_kwargs_accessor_called(series):
+    si = series.interactive(width=100)
+    si = si.head(2)
+
+    # Equivalent to eval
+    out = si._callback()
+
+    assert isinstance(out, pn.pane.DataFrame)
+    assert out.width == 100
+
+
 def test_interactive_pandas_out_frame_attrib(df):
     dfi = Interactive(df)
     dfi = dfi.A

--- a/hvplot/tests/testinteractive.py
+++ b/hvplot/tests/testinteractive.py
@@ -804,7 +804,6 @@ def test_interactive_pandas_out_frame(series):
     pd.testing.assert_frame_equal(out.object, si._current)
 
 
-@pytest.mark.xfail(reason='Bug: max_rows is not propagated to the next instance')
 def test_interactive_pandas_out_frame_max_rows(series):
     si = Interactive(series, max_rows=5)
     si = si.head(2)

--- a/hvplot/tests/testinteractive.py
+++ b/hvplot/tests/testinteractive.py
@@ -851,6 +851,17 @@ def test_interactive_pandas_out_frame_max_rows(series):
     assert out.max_rows == 5
 
 
+def test_interactive_pandas_out_frame_max_rows_accessor_called(series):
+    si = series.interactive(max_rows=5)
+    si = si.head(2)
+
+    # Equivalent to eval
+    out = si._callback()
+
+    assert isinstance(out, pn.pane.DataFrame)
+    assert out.max_rows == 5
+
+
 def test_interactive_pandas_out_frame_kwargs(series):
     si = Interactive(series, width=100)
     si = si.head(2)


### PR DESCRIPTION
Interactive has a `max_rows` parameter that should be passed down to the `pn.pane.DataFrame` object created when the output of a pipeline is a dataframe. This parameter was not passed down the pipeline, which is fixed by this PR.