### PR TITLE
Interactive: only register once the function parameters watchers

### DIFF
--- a/hvplot/tests/testinteractive.py
+++ b/hvplot/tests/testinteractive.py
@@ -223,26 +223,62 @@ def test_interactive_pandas_dataframe_hvplot_accessor_dmap_kind_widget(df):
 
 
 def test_interactive_with_bound_function_calls():
-    df = pd.DataFrame({"species": [1, 1, 2, 2], "sex": 2 * ["MALE", "FEMALE"]})
+    df = pd.DataFrame({"species": [1, 1, 1, 2, 2, 2], "sex": 3 * ["MALE", "FEMALE"]})
 
     w_species = pn.widgets.Select(name='Species', options=[1, 2])
     w_sex = pn.widgets.MultiSelect(name='Sex', value=['MALE'], options=['MALE', 'FEMALE'])
 
-    def load_data(species):
-        """Simluate loading data from e.g a database or from a web API."""
-        data = df.loc[df['species'] == species]
-        load_data.COUNT += 1
-        return data
+    def load_data(species, watch=True):
+        if watch:
+            load_data.COUNT += 1
+        return df.loc[df['species'] == species]
 
     load_data.COUNT = 0
 
     # Setting up interactive with a function
     dfi = bind(load_data, w_species).interactive()
+    dfi = dfi.loc[dfi['sex'].isin(w_sex)]
+
+    out = dfi.output()
+
+    assert isinstance(out, pn.param.ParamFunction)
+    assert isinstance(out._pane, pn.pane.DataFrame)
+    pd.testing.assert_frame_equal(
+        out._pane.object,
+        load_data(w_species.value, watch=False).loc[df['sex'].isin(w_sex.value)]
+    )
+
     (dfi.loc[dfi['sex'].isin(w_sex)])
     assert load_data.COUNT ==  1
 
-    # w_species.value = 2
-    # assert load_data.COUNT == 2
+    w_species.value = 2
+
+    pd.testing.assert_frame_equal(
+        out._pane.object,
+        load_data(w_species.value, watch=False).loc[df['sex'].isin(w_sex.value)]
+    )
+
+    assert load_data.COUNT == 2
+
+    dfi = dfi.head(1)
+
+    assert load_data.COUNT == 2
+
+    out = dfi.output()
+
+    pd.testing.assert_frame_equal(
+        out._pane.object,
+        load_data(w_species.value, watch=False).loc[df['sex'].isin(w_sex.value)].head(1)
+    )
+
+    w_species.value = 1
+
+    pd.testing.assert_frame_equal(
+        out._pane.object,
+        load_data(w_species.value, watch=False).loc[df['sex'].isin(w_sex.value)].head(1)
+    )
+
+    assert load_data.COUNT == 3
 
 
 def test_interactive_pandas_series_init(series, clone_spy):


### PR DESCRIPTION
Alternative implementation (https://github.com/holoviz/hvplot/pull/768) to fix https://github.com/holoviz/hvplot/issues/763

The problem in https://github.com/holoviz/hvplot/issues/763 was two-fold:

1. the callback used to update the original pipeline object (`self._obj`, e.g. a DataFrame) was registered every time a new `Interactive` instance was created. Even a small pipeline creates many instances so that led to many calls being made when one of the parameters controlling the input function changed.
2. only the last callback registered was actually updating the right `self._obj` object. Even if all the instances share the same object, setting a new object in the update callback would not lead to that new object being set on all the instances, just on that particular one. This is why in the previous attempts made to fix this issue, which I've also tried, only setting the callbacks on the root instance (`depth == 0`) didn't work; the Interactive instance being updated isn't the one that drives the display.

To fix 2., I've added a small abstraction layer using a list as the data holder and properties to access/edit the object held, so that the underlying object can be shared across all the Interactive instances created in a pipeline. This means that any change made to `_obj` by any Interactive instance will be visible to all the other instances.
To fix 1. I've used `depth == 0` to only register the update watchers on the root instance, which now works thanks to the fix for 2.