### PR TITLE
add script.* to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -124,3 +124,5 @@ hvplot/.version
 
 # MacOS
 .DS_Store
+
+script.*


### PR DESCRIPTION
I very often have `script.py` or `script.ipynb` in my root folder to explore something while developing or to come examples from discourse into while helping users. I've sometimes added these to PRs by mistake. Would like to avoid.