### PR TITLE
Set categorically shaded when there's more than one variable

### DIFF
--- a/hvplot/converter.py
+++ b/hvplot/converter.py
@@ -1258,7 +1258,7 @@ class HoloViewsConverter:
         if self.by and not self.subplots:
             opts['aggregator'] = reductions.count_cat(self.by[0])
             categorical = True
-        elif ((isinstance(self.y, list) or self.y is None and len(set(self.variables) - set(self.indexes)) > 1) and
+        elif ((isinstance(self.y, list) and len(self.y) > 1 or self.y is None and len(set(self.variables) - set(self.indexes)) > 1) and
               self.kind in ('scatter', 'line', 'area')):
             opts['aggregator'] = reductions.count_cat(self.group_label)
             categorical = True


### PR DESCRIPTION
The docs built failed [here](https://pyviz-dev.github.io/hvplot/user_guide/Gridded_Data.html#rasterizing) as `y` is implicitly set to `['air']`, which was not anticipated in this conditional:
```python
        elif ((isinstance(self.y, list) or self.y is None and len(set(self.variables) - set(self.indexes)) > 1) and
              self.kind in ('scatter', 'line', 'area')):
```