### PR TITLE
Fix HoloViews .opts warning by not calling GeoViews features

### DIFF
--- a/hvplot/converter.py
+++ b/hvplot/converter.py
@@ -1334,7 +1334,7 @@ class HoloViewsConverter:
     def _apply_layers(self, obj):
         if self.coastline:
             import geoviews as gv
-            coastline = gv.feature.coastline()
+            coastline = gv.feature.coastline
             if self.coastline in ['10m', '50m', '110m']:
                 coastline = coastline.opts(scale=self.coastline)
             elif self.coastline is not True:
@@ -1346,13 +1346,12 @@ class HoloViewsConverter:
         if self.features:
             import geoviews as gv
             for feature in reversed(self.features):
-                feature_cls = getattr(gv.feature, feature)
-                if feature_cls is None:
+                feature_obj = getattr(gv.feature, feature)
+                if feature_obj is None:
                     raise ValueError(
                         "Feature %r was not recognized, must be one of "
                         "'borders', 'coastline', 'lakes', 'land', 'ocean', "
                         "'rivers' and 'states'." % feature)
-                feature_obj = feature_cls()
                 if isinstance(self.features, dict):
                     scale = self.features[feature]
                     if scale not in ['10m', '50m', '110m']:


### PR DESCRIPTION
Fixes https://github.com/holoviz/hvplot/issues/823

GeoViews `Feature` objects are already instantiated in Geoviews. These objects are callable, this can be used to set up their options. hvPlot was calling them but not passing any options, making it a no-op. This PR was motivated by a HoloViews issue that led to a warning being emitted on a no-op `.opts` call (https://github.com/holoviz/holoviews/issues/5407)