### PR TITLE
Interactive: callback dependent only when parameters found

### DIFF
--- a/hvplot/interactive.py
+++ b/hvplot/interactive.py
@@ -318,8 +318,7 @@ class Interactive:
 
     @property
     def _callback(self):
-        @pn.depends(*self._params)
-        def evaluate(*args, **kwargs):
+        def evaluate_inner():
             obj = self._obj
             ds = hv.Dataset(obj)
             transform = self._transform
@@ -335,6 +334,14 @@ class Interactive:
                 return pn.pane.DataFrame(obj, max_rows=self._max_rows, **self._kwargs)
             else:
                 return obj
+        params = self._params
+        if params:
+            @pn.depends(*params)
+            def evaluate(*args, **kwargs):
+                return evaluate_inner()
+        else:
+            def evaluate():
+                return evaluate_inner()
         return evaluate
 
     def _clone(self, transform=None, plot=None, loc=None, center=None,


### PR DESCRIPTION
This is to avoid a warning emitted by Panel, there's more details in https://github.com/holoviz/panel/pull/3715.