### PR TITLE
Interactive: no DynamicMap when hvplot kind is not a string

### DIFF
--- a/hvplot/interactive.py
+++ b/hvplot/interactive.py
@@ -765,7 +765,7 @@ class _hvplot:
         new = self._interactive._resolve_accessor()
         transform = new._transform
         transform = type(transform)(transform, 'hvplot', accessor=True)
-        dmap = 'kind' not in kwargs or not isinstance(kwargs['kind'], str)
+        dmap = 'kind' not in kwargs or isinstance(kwargs['kind'], str)
         return new._clone(transform(*args, **kwargs), dmap=dmap)
 
     def __getattr__(self, attr):

--- a/hvplot/tests/testinteractive.py
+++ b/hvplot/tests/testinteractive.py
@@ -205,7 +205,6 @@ def test_interactive_xarray_dataset_hvplot_accessor(dataarray):
         dai.hvplot.line(kind="area")
 
 
-@pytest.mark.xfail(reason='Not sure?')
 def test_interactive_pandas_dataframe_hvplot_accessor_dmap(df):
     dfi = df.interactive()
     dfi = dfi.hvplot.line(y='A')
@@ -219,7 +218,7 @@ def test_interactive_pandas_dataframe_hvplot_accessor_dmap_kind_widget(df):
     dfi = df.interactive()
     dfi = dfi.hvplot(kind=w, y='A')
 
-    assert dfi._dmap is True
+    assert dfi._dmap is False
 
 
 def test_interactive_with_bound_function_calls():


### PR DESCRIPTION
I think this is reverting to the previous behavior. If not  this example in the docs fail:
<img width="743" alt="image" src="https://user-images.githubusercontent.com/35924738/186725219-03a5a21a-3237-455e-b4eb-88a7c2afbebe.png">

Updated a test that I think was expecting the wrong outcome.