### PR TITLE
Default to the light theme

### DIFF
--- a/doc/_static/custom.css
+++ b/doc/_static/custom.css
@@ -1,4 +1,4 @@
-:root {
+:root[data-theme="light"] {
     --pst-color-primary: 56,123,178;
     --pst-color-link: 56,123,178;
     --pst-color-link-hover: 254,203,56;

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -81,4 +81,5 @@ html_context.update({
     "last_release": f"v{release}",
     "github_user": "holoviz",
     "github_repo": "panel",
+    "default_mode": "light",
 })


### PR DESCRIPTION
The dark theme doesn't play well with plots in general, we should for now just support the light theme. The theme switcher was already removed, but the theme wasn't by default set to the light one, so visitors get whatever default theme configured they have.