### PR TITLE
Disable the urls test

### DIFF
--- a/hvplot/tests/test_links.py
+++ b/hvplot/tests/test_links.py
@@ -47,11 +47,11 @@ def _verify_urls(urls):
     return True
 
 
-@pytest.mark.parametrize(["file"], FIXTURES)
-def test_urls(file: pathlib.Path):
-    """The urls is docstring should be valid"""
-    # Given
-    text = file.read_text()
-    urls = _find_urls(text)
-    # When/ Then
-    assert _verify_urls(urls)
+# @pytest.mark.parametrize(["file"], FIXTURES)
+# def test_urls(file: pathlib.Path):
+#     """The urls is docstring should be valid"""
+#     # Given
+#     text = file.read_text()
+#     urls = _find_urls(text)
+#     # When/ Then
+#     assert _verify_urls(urls)


### PR DESCRIPTION
I thought they would not be picked up as the file name is `test_links.py` while the test files in hvPlot are formatted as `testthing.py`, I was wrong, and it appeared this test isn't very robust and fails from time to time.