### PR TITLE
Fix docs links CSS

### DIFF
--- a/doc/_static/custom.css
+++ b/doc/_static/custom.css
@@ -1,7 +1,7 @@
 :root[data-theme="light"] {
-    --pst-color-primary: 56,123,178;
-    --pst-color-link: 56,123,178;
-    --pst-color-link-hover: 254,203,56;
+    --pst-color-primary: rgb(56,123,178);
+    --pst-color-link: rgb(56,123,178);
+    --pst-color-link-hover: rgb(254,203,56);
 }
 
 .sphx-glr-thumbcontainer {

--- a/setup.py
+++ b/setup.py
@@ -87,7 +87,7 @@ extras_require = {
     'examples': _examples,
     'doc': _examples + [
         'nbsite >=0.7.2rc2',
-        'pydata-sphinx-theme',
+        'pydata-sphinx-theme <0.10',
         'sphinx-copybutton',
         'sphinx-design',
     ]


### PR DESCRIPTION
The links on the website were no longer correctly highlighted. I've created a branch from the last time the main site was built and made the changes required to fix that. I also had to pin the pydata-sphinx-theme as the latest version broke our docs build (https://github.com/pydata/pydata-sphinx-theme/issues/926). This branch has been then rebased on master.