### PR TITLE
CI: fix the test suite on Windows

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -62,7 +62,8 @@ jobs:
       - name: conda setup
         if: steps.cache.outputs.cache-hit != 'true'
         run: |
-          conda update -n base conda
+          conda install -n base -c defaults "conda>=4.12"
+          conda install -n base -c conda-forge "mamba<0.26" --no-update-deps
           conda create -n test-environment
           conda activate test-environment
           conda config --env --append channels pyviz/label/dev --append channels conda-forge
@@ -73,12 +74,12 @@ jobs:
         run: |
           conda activate test-environment
           conda list
-          doit develop_install -o examples -o tests
+          doit develop_install -o examples -o tests --conda-mode=mamba
       - name: patch fiona/geostack on Macos
         if: steps.cache.outputs.cache-hit != 'true' && contains(matrix.os, 'macos')
         run: |
           conda activate test-environment
-          conda install "fiona=1.8" "gdal=3.3"
+          mamba install "fiona=1.8" "gdal=3.3"
       - name: hvplot install if env cached
         if: steps.cache.outputs.cache-hit == 'true'
         run: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -24,13 +24,13 @@ jobs:
         # os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
         python-version: ['3.7']
         # python-version: ['3.7', '3.8', '3.9', '3.10']
-        # include:
+        include:
         # - os: ubuntu-latest
         #   path: /usr/share/miniconda3/envs/
         # - os: macos-latest
         #   path: /Users/runner/miniconda3/envs/
-        # - os: windows-latest
-        #   path: C:\Miniconda3\envs\
+        - os: windows-latest
+          path: C:\Miniconda3\envs\
         # exclude:
         #   # Excluded because of issues with the geo-stack
         #   - os: 'macos-latest'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -21,8 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
-        python-version: ['3.7']
-        # python-version: ['3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10']
         include:
         - os: ubuntu-latest
           path: /usr/share/miniconda3/envs/
@@ -63,6 +62,7 @@ jobs:
         if: steps.cache.outputs.cache-hit != 'true'
         run: |
           conda install -n base -c defaults "conda>=4.12"
+          # TODO: remove pin
           conda install -n base -c conda-forge "mamba<0.26" --no-update-deps
           conda create -n test-environment
           conda activate test-environment
@@ -106,92 +106,92 @@ jobs:
         run: |
           conda activate test-environment
           codecov
-  # test_suite_36:
-  #   name: Pytest on ${{ matrix.os }} with Python ${{ matrix.python-version }}
-  #   runs-on: ${{ matrix.os }}
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
-  #       python-version: ['3.6']
-  #       include:
-  #       - os: ubuntu-latest
-  #         path: /usr/share/miniconda3/envs/
-  #       - os: macos-latest
-  #         path: /Users/runner/miniconda3/envs/
-  #       - os: windows-latest
-  #         path: C:\Miniconda3\envs\
-  #   timeout-minutes: 90
-  #   defaults:
-  #     run:
-  #       shell: bash -l {0} 
-  #   env:
-  #     DESC: "Python ${{ matrix.python-version }} tests"
-  #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  #     PYCTDEV_SELF_CHANNEL: "pyviz/label/dev"
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #       with:
-  #         fetch-depth: "100"
-  #     - uses: actions/setup-python@v2
-  #       with:
-  #         python-version: ${{ matrix.python-version }}
-  #     - uses: conda-incubator/setup-miniconda@v2
-  #       with:
-  #         auto-update-conda: true
-  #         miniconda-version: "latest"
-  #         channel-priority: strict
-  #         channels: pyviz/label/dev,conda-forge,nodefaults
-  #     - name: Fetch unshallow
-  #       run: git fetch --prune --tags --unshallow
-  #     - name: Get Today's date for cache
-  #       run: echo "TODAY=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
-  #     - name: conda cache
-  #       uses: actions/cache@v2
-  #       with:
-  #         path: ${{ matrix.path }}
-  #         key: ${{ runner.os }}-conda-${{ matrix.python-version }}-${{ hashFiles('setup.py') }}-tests_examples-${{ env.TODAY }}-${{ env.CACHE_VERSION }}
-  #       id: cache
-  #     - name: conda setup
-  #       if: steps.cache.outputs.cache-hit != 'true'
-  #       run: |
-  #         conda create -n test-environment python=${{ matrix.python-version }} pyctdev
-  #     - name: doit develop_install py
-  #       if: steps.cache.outputs.cache-hit != 'true'
-  #       run: |
-  #         eval "$(conda shell.bash hook)"
-  #         conda activate test-environment
-  #         conda list
-  #         doit develop_install -o tests
-  #         # - Pin panel on Python 3.6 because one or more dev releases on the 0.13.* series
-  #         # can be installed on Python 3.6 but are actually not compatible with Python 3.6
-  #         # Panel 0.13 will support Python >= 3.7 only so the pin here can stay indefinitely.
-  #         # - Install importlib_resources to fix tqdm that missed adding it as a dependency
-  #         # for 3.6 (https://github.com/conda-forge/tqdm-feedstock/pull/114) 
-  #         conda install "panel=0.12" "importlib_resources" --no-update-deps
-  #     - name: hvplot install if env cached
-  #       if: steps.cache.outputs.cache-hit == 'true'
-  #       run: |
-  #         eval "$(conda shell.bash hook)"
-  #         conda activate test-environment
-  #         python -m pip install --no-deps --no-build-isolation -e .
-  #     - name: doit env_capture
-  #       run: |
-  #         eval "$(conda shell.bash hook)"
-  #         conda activate test-environment
-  #         doit env_capture
-  #     - name: doit test_flakes
-  #       run: |
-  #         eval "$(conda shell.bash hook)"
-  #         conda activate test-environment
-  #         doit test_flakes
-  #     - name: doit test_unit
-  #       run: |
-  #         eval "$(conda shell.bash hook)"
-  #         conda activate test-environment
-  #         doit test_unit
-  #     - name: codecov
-  #       run: |
-  #         eval "$(conda shell.bash hook)"
-  #         conda activate test-environment
-  #         codecov
+  test_suite_36:
+    name: Pytest on ${{ matrix.os }} with Python ${{ matrix.python-version }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
+        python-version: ['3.6']
+        include:
+        - os: ubuntu-latest
+          path: /usr/share/miniconda3/envs/
+        - os: macos-latest
+          path: /Users/runner/miniconda3/envs/
+        - os: windows-latest
+          path: C:\Miniconda3\envs\
+    timeout-minutes: 90
+    defaults:
+      run:
+        shell: bash -l {0} 
+    env:
+      DESC: "Python ${{ matrix.python-version }} tests"
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      PYCTDEV_SELF_CHANNEL: "pyviz/label/dev"
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: "100"
+      - uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - uses: conda-incubator/setup-miniconda@v2
+        with:
+          auto-update-conda: true
+          miniconda-version: "latest"
+          channel-priority: strict
+          channels: pyviz/label/dev,conda-forge,nodefaults
+      - name: Fetch unshallow
+        run: git fetch --prune --tags --unshallow
+      - name: Get Today's date for cache
+        run: echo "TODAY=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
+      - name: conda cache
+        uses: actions/cache@v2
+        with:
+          path: ${{ matrix.path }}
+          key: ${{ runner.os }}-conda-${{ matrix.python-version }}-${{ hashFiles('setup.py') }}-tests_examples-${{ env.TODAY }}-${{ env.CACHE_VERSION }}
+        id: cache
+      - name: conda setup
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: |
+          conda create -n test-environment python=${{ matrix.python-version }} pyctdev
+      - name: doit develop_install py
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: |
+          eval "$(conda shell.bash hook)"
+          conda activate test-environment
+          conda list
+          doit develop_install -o tests
+          # - Pin panel on Python 3.6 because one or more dev releases on the 0.13.* series
+          # can be installed on Python 3.6 but are actually not compatible with Python 3.6
+          # Panel 0.13 will support Python >= 3.7 only so the pin here can stay indefinitely.
+          # - Install importlib_resources to fix tqdm that missed adding it as a dependency
+          # for 3.6 (https://github.com/conda-forge/tqdm-feedstock/pull/114) 
+          conda install "panel=0.12" "importlib_resources" --no-update-deps
+      - name: hvplot install if env cached
+        if: steps.cache.outputs.cache-hit == 'true'
+        run: |
+          eval "$(conda shell.bash hook)"
+          conda activate test-environment
+          python -m pip install --no-deps --no-build-isolation -e .
+      - name: doit env_capture
+        run: |
+          eval "$(conda shell.bash hook)"
+          conda activate test-environment
+          doit env_capture
+      - name: doit test_flakes
+        run: |
+          eval "$(conda shell.bash hook)"
+          conda activate test-environment
+          doit test_flakes
+      - name: doit test_unit
+        run: |
+          eval "$(conda shell.bash hook)"
+          conda activate test-environment
+          doit test_unit
+      - name: codecov
+        run: |
+          eval "$(conda shell.bash hook)"
+          conda activate test-environment
+          codecov

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -24,17 +24,17 @@ jobs:
         # os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
         python-version: ['3.7']
         # python-version: ['3.7', '3.8', '3.9', '3.10']
-        include:
-        - os: ubuntu-latest
-          path: /usr/share/miniconda3/envs/
-        - os: macos-latest
-          path: /Users/runner/miniconda3/envs/
-        - os: windows-latest
-          path: C:\Miniconda3\envs\
-        exclude:
-          # Excluded because of issues with the geo-stack
-          - os: 'macos-latest'
-            python-version: '3.10'
+        # include:
+        # - os: ubuntu-latest
+        #   path: /usr/share/miniconda3/envs/
+        # - os: macos-latest
+        #   path: /Users/runner/miniconda3/envs/
+        # - os: windows-latest
+        #   path: C:\Miniconda3\envs\
+        # exclude:
+        #   # Excluded because of issues with the geo-stack
+        #   - os: 'macos-latest'
+        #     python-version: '3.10'
     timeout-minutes: 90
     defaults:
       run:
@@ -50,7 +50,6 @@ jobs:
       - uses: conda-incubator/setup-miniconda@v2
         with:
           miniconda-version: "latest"
-          channels: conda-forge
       - name: Fetch unshallow
         run: git fetch --prune --tags --unshallow
       - name: Get Today's date for cache
@@ -64,7 +63,8 @@ jobs:
       - name: conda setup
         if: steps.cache.outputs.cache-hit != 'true'
         run: |
-          conda install -n base "mamba>=0.23"
+          conda update -n base conda
+          conda install -n base -c conda-forge "mamba>=0.23" --no-update-deps
           conda create -n test-environment
           conda activate test-environment
           conda config --env --append channels pyviz/label/dev --append channels conda-forge
@@ -107,92 +107,92 @@ jobs:
         run: |
           conda activate test-environment
           codecov
-  test_suite_36:
-    name: Pytest on ${{ matrix.os }} with Python ${{ matrix.python-version }}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
-        python-version: ['3.6']
-        include:
-        - os: ubuntu-latest
-          path: /usr/share/miniconda3/envs/
-        - os: macos-latest
-          path: /Users/runner/miniconda3/envs/
-        - os: windows-latest
-          path: C:\Miniconda3\envs\
-    timeout-minutes: 90
-    defaults:
-      run:
-        shell: bash -l {0} 
-    env:
-      DESC: "Python ${{ matrix.python-version }} tests"
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      PYCTDEV_SELF_CHANNEL: "pyviz/label/dev"
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: "100"
-      - uses: actions/setup-python@v2
-        with:
-          python-version: ${{ matrix.python-version }}
-      - uses: conda-incubator/setup-miniconda@v2
-        with:
-          auto-update-conda: true
-          miniconda-version: "latest"
-          channel-priority: strict
-          channels: pyviz/label/dev,conda-forge,nodefaults
-      - name: Fetch unshallow
-        run: git fetch --prune --tags --unshallow
-      - name: Get Today's date for cache
-        run: echo "TODAY=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
-      - name: conda cache
-        uses: actions/cache@v2
-        with:
-          path: ${{ matrix.path }}
-          key: ${{ runner.os }}-conda-${{ matrix.python-version }}-${{ hashFiles('setup.py') }}-tests_examples-${{ env.TODAY }}-${{ env.CACHE_VERSION }}
-        id: cache
-      - name: conda setup
-        if: steps.cache.outputs.cache-hit != 'true'
-        run: |
-          conda create -n test-environment python=${{ matrix.python-version }} pyctdev
-      - name: doit develop_install py
-        if: steps.cache.outputs.cache-hit != 'true'
-        run: |
-          eval "$(conda shell.bash hook)"
-          conda activate test-environment
-          conda list
-          doit develop_install -o tests
-          # - Pin panel on Python 3.6 because one or more dev releases on the 0.13.* series
-          # can be installed on Python 3.6 but are actually not compatible with Python 3.6
-          # Panel 0.13 will support Python >= 3.7 only so the pin here can stay indefinitely.
-          # - Install importlib_resources to fix tqdm that missed adding it as a dependency
-          # for 3.6 (https://github.com/conda-forge/tqdm-feedstock/pull/114) 
-          conda install "panel=0.12" "importlib_resources" --no-update-deps
-      - name: hvplot install if env cached
-        if: steps.cache.outputs.cache-hit == 'true'
-        run: |
-          eval "$(conda shell.bash hook)"
-          conda activate test-environment
-          python -m pip install --no-deps --no-build-isolation -e .
-      - name: doit env_capture
-        run: |
-          eval "$(conda shell.bash hook)"
-          conda activate test-environment
-          doit env_capture
-      - name: doit test_flakes
-        run: |
-          eval "$(conda shell.bash hook)"
-          conda activate test-environment
-          doit test_flakes
-      - name: doit test_unit
-        run: |
-          eval "$(conda shell.bash hook)"
-          conda activate test-environment
-          doit test_unit
-      - name: codecov
-        run: |
-          eval "$(conda shell.bash hook)"
-          conda activate test-environment
-          codecov
+  # test_suite_36:
+  #   name: Pytest on ${{ matrix.os }} with Python ${{ matrix.python-version }}
+  #   runs-on: ${{ matrix.os }}
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
+  #       python-version: ['3.6']
+  #       include:
+  #       - os: ubuntu-latest
+  #         path: /usr/share/miniconda3/envs/
+  #       - os: macos-latest
+  #         path: /Users/runner/miniconda3/envs/
+  #       - os: windows-latest
+  #         path: C:\Miniconda3\envs\
+  #   timeout-minutes: 90
+  #   defaults:
+  #     run:
+  #       shell: bash -l {0} 
+  #   env:
+  #     DESC: "Python ${{ matrix.python-version }} tests"
+  #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  #     PYCTDEV_SELF_CHANNEL: "pyviz/label/dev"
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #       with:
+  #         fetch-depth: "100"
+  #     - uses: actions/setup-python@v2
+  #       with:
+  #         python-version: ${{ matrix.python-version }}
+  #     - uses: conda-incubator/setup-miniconda@v2
+  #       with:
+  #         auto-update-conda: true
+  #         miniconda-version: "latest"
+  #         channel-priority: strict
+  #         channels: pyviz/label/dev,conda-forge,nodefaults
+  #     - name: Fetch unshallow
+  #       run: git fetch --prune --tags --unshallow
+  #     - name: Get Today's date for cache
+  #       run: echo "TODAY=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
+  #     - name: conda cache
+  #       uses: actions/cache@v2
+  #       with:
+  #         path: ${{ matrix.path }}
+  #         key: ${{ runner.os }}-conda-${{ matrix.python-version }}-${{ hashFiles('setup.py') }}-tests_examples-${{ env.TODAY }}-${{ env.CACHE_VERSION }}
+  #       id: cache
+  #     - name: conda setup
+  #       if: steps.cache.outputs.cache-hit != 'true'
+  #       run: |
+  #         conda create -n test-environment python=${{ matrix.python-version }} pyctdev
+  #     - name: doit develop_install py
+  #       if: steps.cache.outputs.cache-hit != 'true'
+  #       run: |
+  #         eval "$(conda shell.bash hook)"
+  #         conda activate test-environment
+  #         conda list
+  #         doit develop_install -o tests
+  #         # - Pin panel on Python 3.6 because one or more dev releases on the 0.13.* series
+  #         # can be installed on Python 3.6 but are actually not compatible with Python 3.6
+  #         # Panel 0.13 will support Python >= 3.7 only so the pin here can stay indefinitely.
+  #         # - Install importlib_resources to fix tqdm that missed adding it as a dependency
+  #         # for 3.6 (https://github.com/conda-forge/tqdm-feedstock/pull/114) 
+  #         conda install "panel=0.12" "importlib_resources" --no-update-deps
+  #     - name: hvplot install if env cached
+  #       if: steps.cache.outputs.cache-hit == 'true'
+  #       run: |
+  #         eval "$(conda shell.bash hook)"
+  #         conda activate test-environment
+  #         python -m pip install --no-deps --no-build-isolation -e .
+  #     - name: doit env_capture
+  #       run: |
+  #         eval "$(conda shell.bash hook)"
+  #         conda activate test-environment
+  #         doit env_capture
+  #     - name: doit test_flakes
+  #       run: |
+  #         eval "$(conda shell.bash hook)"
+  #         conda activate test-environment
+  #         doit test_flakes
+  #     - name: doit test_unit
+  #       run: |
+  #         eval "$(conda shell.bash hook)"
+  #         conda activate test-environment
+  #         doit test_unit
+  #     - name: codecov
+  #       run: |
+  #         eval "$(conda shell.bash hook)"
+  #         conda activate test-environment
+  #         codecov

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -65,8 +65,8 @@ jobs:
         run: |
           conda create -n test-environment
           conda activate test-environment
+          conda config --env --remove channels defaults --remove channels conda-forge
           conda config --env --append channels pyviz/label/dev --append channels conda-forge
-          conda config --env --remove channels defaults
           conda install python=${{ matrix.python-version }} pyctdev
       - name: doit develop_install py
         if: steps.cache.outputs.cache-hit != 'true'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,7 +11,7 @@ on:
     - cron: '0 15 * * SUN'
 
 env:
-  CACHE_VERSION: 1
+  CACHE_VERSION: 2
 
 jobs:
   test_suite:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -47,9 +47,6 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: "100"
-      - uses: actions/setup-python@v2
-        with:
-          python-version: ${{ matrix.python-version }}
       - uses: conda-incubator/setup-miniconda@v2
         with:
           miniconda-version: "latest"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -50,6 +50,7 @@ jobs:
       - uses: conda-incubator/setup-miniconda@v2
         with:
           miniconda-version: "latest"
+          channels: conda-forge
       - name: Fetch unshallow
         run: git fetch --prune --tags --unshallow
       - name: Get Today's date for cache
@@ -63,7 +64,7 @@ jobs:
       - name: conda setup
         if: steps.cache.outputs.cache-hit != 'true'
         run: |
-          conda install -n base -c conda-forge "mamba>=0.23" --no-update-deps
+          conda install -n base "mamba>=0.23"
           conda create -n test-environment
           conda activate test-environment
           conda config --env --append channels pyviz/label/dev --append channels conda-forge

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -49,7 +49,7 @@ jobs:
       - uses: conda-incubator/setup-miniconda@v2
         with:
           mamba-version: "*"
-          channels: conda-forge
+          channels: pyviz/label/dev,conda-forge
           miniconda-version: "latest"
       - name: Fetch unshallow
         run: git fetch --prune --tags --unshallow
@@ -66,8 +66,7 @@ jobs:
         run: |
           conda create -n test-environment
           conda activate test-environment
-          conda config --env --remove channels defaults --remove channels conda-forge
-          conda config --env --append channels pyviz/label/dev --append channels conda-forge
+          conda config --env --remove channels defaults
           conda install python=${{ matrix.python-version }} pyctdev
       - name: doit develop_install py
         if: steps.cache.outputs.cache-hit != 'true'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -49,6 +49,8 @@ jobs:
           fetch-depth: "100"
       - uses: conda-incubator/setup-miniconda@v2
         with:
+          mamba-version: "*"
+          channels: conda-forge
           miniconda-version: "latest"
       - name: Fetch unshallow
         run: git fetch --prune --tags --unshallow
@@ -63,8 +65,6 @@ jobs:
       - name: conda setup
         if: steps.cache.outputs.cache-hit != 'true'
         run: |
-          conda update -n base conda
-          conda install -n base -c conda-forge "mamba>=0.23" --no-update-deps
           conda create -n test-environment
           conda activate test-environment
           conda config --env --append channels pyviz/label/dev --append channels conda-forge

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,7 +11,7 @@ on:
     - cron: '0 15 * * SUN'
 
 env:
-  CACHE_VERSION: 2
+  CACHE_VERSION: 3
 
 jobs:
   test_suite:
@@ -48,8 +48,6 @@ jobs:
           fetch-depth: "100"
       - uses: conda-incubator/setup-miniconda@v2
         with:
-          mamba-version: "*"
-          channels: pyviz/label/dev,conda-forge
           miniconda-version: "latest"
       - name: Fetch unshallow
         run: git fetch --prune --tags --unshallow
@@ -64,8 +62,10 @@ jobs:
       - name: conda setup
         if: steps.cache.outputs.cache-hit != 'true'
         run: |
+          conda update -n base conda
           conda create -n test-environment
           conda activate test-environment
+          conda config --env --append channels pyviz/label/dev --append channels conda-forge
           conda config --env --remove channels defaults
           conda install python=${{ matrix.python-version }} pyctdev
       - name: doit develop_install py

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -21,7 +21,8 @@ jobs:
       fail-fast: false
       matrix:
         os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.7']
+        # python-version: ['3.7', '3.8', '3.9', '3.10']
         include:
         - os: ubuntu-latest
           path: /usr/share/miniconda3/envs/
@@ -105,92 +106,92 @@ jobs:
         run: |
           conda activate test-environment
           codecov
-  test_suite_36:
-    name: Pytest on ${{ matrix.os }} with Python ${{ matrix.python-version }}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
-        python-version: ['3.6']
-        include:
-        - os: ubuntu-latest
-          path: /usr/share/miniconda3/envs/
-        - os: macos-latest
-          path: /Users/runner/miniconda3/envs/
-        - os: windows-latest
-          path: C:\Miniconda3\envs\
-    timeout-minutes: 90
-    defaults:
-      run:
-        shell: bash -l {0} 
-    env:
-      DESC: "Python ${{ matrix.python-version }} tests"
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      PYCTDEV_SELF_CHANNEL: "pyviz/label/dev"
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: "100"
-      - uses: actions/setup-python@v2
-        with:
-          python-version: ${{ matrix.python-version }}
-      - uses: conda-incubator/setup-miniconda@v2
-        with:
-          auto-update-conda: true
-          miniconda-version: "latest"
-          channel-priority: strict
-          channels: pyviz/label/dev,conda-forge,nodefaults
-      - name: Fetch unshallow
-        run: git fetch --prune --tags --unshallow
-      - name: Get Today's date for cache
-        run: echo "TODAY=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
-      - name: conda cache
-        uses: actions/cache@v2
-        with:
-          path: ${{ matrix.path }}
-          key: ${{ runner.os }}-conda-${{ matrix.python-version }}-${{ hashFiles('setup.py') }}-tests_examples-${{ env.TODAY }}-${{ env.CACHE_VERSION }}
-        id: cache
-      - name: conda setup
-        if: steps.cache.outputs.cache-hit != 'true'
-        run: |
-          conda create -n test-environment python=${{ matrix.python-version }} pyctdev
-      - name: doit develop_install py
-        if: steps.cache.outputs.cache-hit != 'true'
-        run: |
-          eval "$(conda shell.bash hook)"
-          conda activate test-environment
-          conda list
-          doit develop_install -o tests
-          # - Pin panel on Python 3.6 because one or more dev releases on the 0.13.* series
-          # can be installed on Python 3.6 but are actually not compatible with Python 3.6
-          # Panel 0.13 will support Python >= 3.7 only so the pin here can stay indefinitely.
-          # - Install importlib_resources to fix tqdm that missed adding it as a dependency
-          # for 3.6 (https://github.com/conda-forge/tqdm-feedstock/pull/114) 
-          conda install "panel=0.12" "importlib_resources" --no-update-deps
-      - name: hvplot install if env cached
-        if: steps.cache.outputs.cache-hit == 'true'
-        run: |
-          eval "$(conda shell.bash hook)"
-          conda activate test-environment
-          python -m pip install --no-deps --no-build-isolation -e .
-      - name: doit env_capture
-        run: |
-          eval "$(conda shell.bash hook)"
-          conda activate test-environment
-          doit env_capture
-      - name: doit test_flakes
-        run: |
-          eval "$(conda shell.bash hook)"
-          conda activate test-environment
-          doit test_flakes
-      - name: doit test_unit
-        run: |
-          eval "$(conda shell.bash hook)"
-          conda activate test-environment
-          doit test_unit
-      - name: codecov
-        run: |
-          eval "$(conda shell.bash hook)"
-          conda activate test-environment
-          codecov
+  # test_suite_36:
+  #   name: Pytest on ${{ matrix.os }} with Python ${{ matrix.python-version }}
+  #   runs-on: ${{ matrix.os }}
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
+  #       python-version: ['3.6']
+  #       include:
+  #       - os: ubuntu-latest
+  #         path: /usr/share/miniconda3/envs/
+  #       - os: macos-latest
+  #         path: /Users/runner/miniconda3/envs/
+  #       - os: windows-latest
+  #         path: C:\Miniconda3\envs\
+  #   timeout-minutes: 90
+  #   defaults:
+  #     run:
+  #       shell: bash -l {0} 
+  #   env:
+  #     DESC: "Python ${{ matrix.python-version }} tests"
+  #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  #     PYCTDEV_SELF_CHANNEL: "pyviz/label/dev"
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #       with:
+  #         fetch-depth: "100"
+  #     - uses: actions/setup-python@v2
+  #       with:
+  #         python-version: ${{ matrix.python-version }}
+  #     - uses: conda-incubator/setup-miniconda@v2
+  #       with:
+  #         auto-update-conda: true
+  #         miniconda-version: "latest"
+  #         channel-priority: strict
+  #         channels: pyviz/label/dev,conda-forge,nodefaults
+  #     - name: Fetch unshallow
+  #       run: git fetch --prune --tags --unshallow
+  #     - name: Get Today's date for cache
+  #       run: echo "TODAY=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
+  #     - name: conda cache
+  #       uses: actions/cache@v2
+  #       with:
+  #         path: ${{ matrix.path }}
+  #         key: ${{ runner.os }}-conda-${{ matrix.python-version }}-${{ hashFiles('setup.py') }}-tests_examples-${{ env.TODAY }}-${{ env.CACHE_VERSION }}
+  #       id: cache
+  #     - name: conda setup
+  #       if: steps.cache.outputs.cache-hit != 'true'
+  #       run: |
+  #         conda create -n test-environment python=${{ matrix.python-version }} pyctdev
+  #     - name: doit develop_install py
+  #       if: steps.cache.outputs.cache-hit != 'true'
+  #       run: |
+  #         eval "$(conda shell.bash hook)"
+  #         conda activate test-environment
+  #         conda list
+  #         doit develop_install -o tests
+  #         # - Pin panel on Python 3.6 because one or more dev releases on the 0.13.* series
+  #         # can be installed on Python 3.6 but are actually not compatible with Python 3.6
+  #         # Panel 0.13 will support Python >= 3.7 only so the pin here can stay indefinitely.
+  #         # - Install importlib_resources to fix tqdm that missed adding it as a dependency
+  #         # for 3.6 (https://github.com/conda-forge/tqdm-feedstock/pull/114) 
+  #         conda install "panel=0.12" "importlib_resources" --no-update-deps
+  #     - name: hvplot install if env cached
+  #       if: steps.cache.outputs.cache-hit == 'true'
+  #       run: |
+  #         eval "$(conda shell.bash hook)"
+  #         conda activate test-environment
+  #         python -m pip install --no-deps --no-build-isolation -e .
+  #     - name: doit env_capture
+  #       run: |
+  #         eval "$(conda shell.bash hook)"
+  #         conda activate test-environment
+  #         doit env_capture
+  #     - name: doit test_flakes
+  #       run: |
+  #         eval "$(conda shell.bash hook)"
+  #         conda activate test-environment
+  #         doit test_flakes
+  #     - name: doit test_unit
+  #       run: |
+  #         eval "$(conda shell.bash hook)"
+  #         conda activate test-environment
+  #         doit test_unit
+  #     - name: codecov
+  #       run: |
+  #         eval "$(conda shell.bash hook)"
+  #         conda activate test-environment
+  #         codecov

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -73,12 +73,12 @@ jobs:
         run: |
           conda activate test-environment
           conda list
-          doit develop_install -o examples -o tests --conda-mode=mamba
+          doit develop_install -o examples -o tests
       - name: patch fiona/geostack on Macos
         if: steps.cache.outputs.cache-hit != 'true' && contains(matrix.os, 'macos')
         run: |
           conda activate test-environment
-          mamba install "fiona=1.8" "gdal=3.3"
+          conda install "fiona=1.8" "gdal=3.3"
       - name: hvplot install if env cached
         if: steps.cache.outputs.cache-hit == 'true'
         run: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -20,8 +20,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        os: ['windows-latest']
+        # os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
+        python-version: ['3.7']
+        # python-version: ['3.7', '3.8', '3.9', '3.10']
         include:
         - os: ubuntu-latest
           path: /usr/share/miniconda3/envs/
@@ -64,57 +66,47 @@ jobs:
       - name: conda setup
         if: steps.cache.outputs.cache-hit != 'true'
         run: |
-          conda install -n base -c defaults "conda>=4.12"
           conda install -n base -c conda-forge "mamba>=0.23" --no-update-deps
-          conda install -c conda-forge "nodejs=15.3.0" --no-update-deps
           conda create -n test-environment
           conda activate test-environment
-          conda config --env --append channels pyviz/label/dev --append channels conda-forge --append channels nodefaults
+          conda config --env --append channels pyviz/label/dev --append channels conda-forge
           conda config --env --remove channels defaults
           conda install python=${{ matrix.python-version }} pyctdev
       - name: doit develop_install py
         if: steps.cache.outputs.cache-hit != 'true'
         run: |
-          eval "$(conda shell.bash hook)"
           conda activate test-environment
           conda list
           doit develop_install -o examples -o tests --conda-mode=mamba
       - name: patch fiona/geostack on Macos
         if: steps.cache.outputs.cache-hit != 'true' && contains(matrix.os, 'macos')
         run: |
-          eval "$(conda shell.bash hook)"
           conda activate test-environment
           mamba install "fiona=1.8" "gdal=3.3"
       - name: hvplot install if env cached
         if: steps.cache.outputs.cache-hit == 'true'
         run: |
-          eval "$(conda shell.bash hook)"
           conda activate test-environment
           python -m pip install --no-deps --no-build-isolation -e .
       - name: doit env_capture
         run: |
-          eval "$(conda shell.bash hook)"
           conda activate test-environment
           doit env_capture
       - name: doit test_flakes
         run: |
-          eval "$(conda shell.bash hook)"
           conda activate test-environment
           doit test_flakes
       - name: doit test_unit
         run: |
-          eval "$(conda shell.bash hook)"
           conda activate test-environment
           doit test_unit
       - name: test examples
         run: |
-          eval "$(conda shell.bash hook)"
           conda activate test-environment
           bokeh sampledata
           doit test_examples
       - name: codecov
         run: |
-          eval "$(conda shell.bash hook)"
           conda activate test-environment
           codecov
   test_suite_36:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -20,21 +20,19 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ['windows-latest']
-        # os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
-        python-version: ['3.7']
-        # python-version: ['3.7', '3.8', '3.9', '3.10']
+        os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
+        python-version: ['3.7', '3.8', '3.9', '3.10']
         include:
-        # - os: ubuntu-latest
-        #   path: /usr/share/miniconda3/envs/
-        # - os: macos-latest
-        #   path: /Users/runner/miniconda3/envs/
+        - os: ubuntu-latest
+          path: /usr/share/miniconda3/envs/
+        - os: macos-latest
+          path: /Users/runner/miniconda3/envs/
         - os: windows-latest
           path: C:\Miniconda3\envs\
-        # exclude:
-        #   # Excluded because of issues with the geo-stack
-        #   - os: 'macos-latest'
-        #     python-version: '3.10'
+        exclude:
+          # Excluded because of issues with the geo-stack
+          - os: 'macos-latest'
+            python-version: '3.10'
     timeout-minutes: 90
     defaults:
       run:
@@ -107,92 +105,92 @@ jobs:
         run: |
           conda activate test-environment
           codecov
-  # test_suite_36:
-  #   name: Pytest on ${{ matrix.os }} with Python ${{ matrix.python-version }}
-  #   runs-on: ${{ matrix.os }}
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
-  #       python-version: ['3.6']
-  #       include:
-  #       - os: ubuntu-latest
-  #         path: /usr/share/miniconda3/envs/
-  #       - os: macos-latest
-  #         path: /Users/runner/miniconda3/envs/
-  #       - os: windows-latest
-  #         path: C:\Miniconda3\envs\
-  #   timeout-minutes: 90
-  #   defaults:
-  #     run:
-  #       shell: bash -l {0} 
-  #   env:
-  #     DESC: "Python ${{ matrix.python-version }} tests"
-  #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  #     PYCTDEV_SELF_CHANNEL: "pyviz/label/dev"
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #       with:
-  #         fetch-depth: "100"
-  #     - uses: actions/setup-python@v2
-  #       with:
-  #         python-version: ${{ matrix.python-version }}
-  #     - uses: conda-incubator/setup-miniconda@v2
-  #       with:
-  #         auto-update-conda: true
-  #         miniconda-version: "latest"
-  #         channel-priority: strict
-  #         channels: pyviz/label/dev,conda-forge,nodefaults
-  #     - name: Fetch unshallow
-  #       run: git fetch --prune --tags --unshallow
-  #     - name: Get Today's date for cache
-  #       run: echo "TODAY=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
-  #     - name: conda cache
-  #       uses: actions/cache@v2
-  #       with:
-  #         path: ${{ matrix.path }}
-  #         key: ${{ runner.os }}-conda-${{ matrix.python-version }}-${{ hashFiles('setup.py') }}-tests_examples-${{ env.TODAY }}-${{ env.CACHE_VERSION }}
-  #       id: cache
-  #     - name: conda setup
-  #       if: steps.cache.outputs.cache-hit != 'true'
-  #       run: |
-  #         conda create -n test-environment python=${{ matrix.python-version }} pyctdev
-  #     - name: doit develop_install py
-  #       if: steps.cache.outputs.cache-hit != 'true'
-  #       run: |
-  #         eval "$(conda shell.bash hook)"
-  #         conda activate test-environment
-  #         conda list
-  #         doit develop_install -o tests
-  #         # - Pin panel on Python 3.6 because one or more dev releases on the 0.13.* series
-  #         # can be installed on Python 3.6 but are actually not compatible with Python 3.6
-  #         # Panel 0.13 will support Python >= 3.7 only so the pin here can stay indefinitely.
-  #         # - Install importlib_resources to fix tqdm that missed adding it as a dependency
-  #         # for 3.6 (https://github.com/conda-forge/tqdm-feedstock/pull/114) 
-  #         conda install "panel=0.12" "importlib_resources" --no-update-deps
-  #     - name: hvplot install if env cached
-  #       if: steps.cache.outputs.cache-hit == 'true'
-  #       run: |
-  #         eval "$(conda shell.bash hook)"
-  #         conda activate test-environment
-  #         python -m pip install --no-deps --no-build-isolation -e .
-  #     - name: doit env_capture
-  #       run: |
-  #         eval "$(conda shell.bash hook)"
-  #         conda activate test-environment
-  #         doit env_capture
-  #     - name: doit test_flakes
-  #       run: |
-  #         eval "$(conda shell.bash hook)"
-  #         conda activate test-environment
-  #         doit test_flakes
-  #     - name: doit test_unit
-  #       run: |
-  #         eval "$(conda shell.bash hook)"
-  #         conda activate test-environment
-  #         doit test_unit
-  #     - name: codecov
-  #       run: |
-  #         eval "$(conda shell.bash hook)"
-  #         conda activate test-environment
-  #         codecov
+  test_suite_36:
+    name: Pytest on ${{ matrix.os }} with Python ${{ matrix.python-version }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
+        python-version: ['3.6']
+        include:
+        - os: ubuntu-latest
+          path: /usr/share/miniconda3/envs/
+        - os: macos-latest
+          path: /Users/runner/miniconda3/envs/
+        - os: windows-latest
+          path: C:\Miniconda3\envs\
+    timeout-minutes: 90
+    defaults:
+      run:
+        shell: bash -l {0} 
+    env:
+      DESC: "Python ${{ matrix.python-version }} tests"
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      PYCTDEV_SELF_CHANNEL: "pyviz/label/dev"
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: "100"
+      - uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - uses: conda-incubator/setup-miniconda@v2
+        with:
+          auto-update-conda: true
+          miniconda-version: "latest"
+          channel-priority: strict
+          channels: pyviz/label/dev,conda-forge,nodefaults
+      - name: Fetch unshallow
+        run: git fetch --prune --tags --unshallow
+      - name: Get Today's date for cache
+        run: echo "TODAY=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
+      - name: conda cache
+        uses: actions/cache@v2
+        with:
+          path: ${{ matrix.path }}
+          key: ${{ runner.os }}-conda-${{ matrix.python-version }}-${{ hashFiles('setup.py') }}-tests_examples-${{ env.TODAY }}-${{ env.CACHE_VERSION }}
+        id: cache
+      - name: conda setup
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: |
+          conda create -n test-environment python=${{ matrix.python-version }} pyctdev
+      - name: doit develop_install py
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: |
+          eval "$(conda shell.bash hook)"
+          conda activate test-environment
+          conda list
+          doit develop_install -o tests
+          # - Pin panel on Python 3.6 because one or more dev releases on the 0.13.* series
+          # can be installed on Python 3.6 but are actually not compatible with Python 3.6
+          # Panel 0.13 will support Python >= 3.7 only so the pin here can stay indefinitely.
+          # - Install importlib_resources to fix tqdm that missed adding it as a dependency
+          # for 3.6 (https://github.com/conda-forge/tqdm-feedstock/pull/114) 
+          conda install "panel=0.12" "importlib_resources" --no-update-deps
+      - name: hvplot install if env cached
+        if: steps.cache.outputs.cache-hit == 'true'
+        run: |
+          eval "$(conda shell.bash hook)"
+          conda activate test-environment
+          python -m pip install --no-deps --no-build-isolation -e .
+      - name: doit env_capture
+        run: |
+          eval "$(conda shell.bash hook)"
+          conda activate test-environment
+          doit env_capture
+      - name: doit test_flakes
+        run: |
+          eval "$(conda shell.bash hook)"
+          conda activate test-environment
+          doit test_flakes
+      - name: doit test_unit
+        run: |
+          eval "$(conda shell.bash hook)"
+          conda activate test-environment
+          doit test_unit
+      - name: codecov
+        run: |
+          eval "$(conda shell.bash hook)"
+          conda activate test-environment
+          codecov


### PR DESCRIPTION
Ush that was a long fight! For some reason the way the latest `mamba` was installed in the workflow led to some DLL import error on Windows. I went one way and tried many different options, until I finally just decided to pin mamba to an older version, and that worked! Really looking forward to libmamba being the default in conda, which hopefully will have better support than mamba for all the things we do!