### PR TITLE
Ensure that xarray dataset metadata propagates to NdOverlays

### DIFF
--- a/hvplot/converter.py
+++ b/hvplot/converter.py
@@ -1622,7 +1622,7 @@ class HoloViewsConverter:
         for c in y:
             kdims, vdims = self._get_dimensions([x], [c])
             chart = element(data, kdims, vdims).redim(**{c: self.value_label})
-            charts.append((c, chart.relabel(**self._relabel)))
+            charts.append((c, chart.relabel(**self._relabel).redim(**self._redim)))
         return (self._by_type(charts, self.group_label, sort=False)
                 .opts(cur_opts, backend='bokeh')
                 .opts(compat_opts, backend=self._backend_compat))

--- a/hvplot/tests/testcharts.py
+++ b/hvplot/tests/testcharts.py
@@ -78,7 +78,7 @@ class TestChart2D(ComparisonTestCase):
     def test_xarray_dataset_with_attrs(self):
         try:
             import xarray as xr
-            import hvplot.xarray
+            import hvplot.xarray  # noqa
         except ImportError:
             raise SkipTest('xarray not available')
 

--- a/hvplot/tests/testcharts.py
+++ b/hvplot/tests/testcharts.py
@@ -3,7 +3,7 @@ import numpy as np
 from unittest import SkipTest, expectedFailure
 from parameterized import parameterized
 
-from holoviews import NdOverlay, Store, dim
+from holoviews import NdOverlay, Store, dim, render
 from holoviews.element import Curve, Area, Scatter, Points, Path, HeatMap
 from holoviews.element.comparison import ComparisonTestCase
 
@@ -73,6 +73,23 @@ class TestChart2D(ComparisonTestCase):
         plot = self.time_df.hvplot.heatmap(x='time.hour', y='time.day', C='temp')
         assert plot.kdims == ['time.hour', 'time.day']
         assert plot.vdims == ['temp']
+
+
+    def test_xarray_dataset_with_attrs(self):
+        try:
+            import xarray as xr
+            import hvplot.xarray
+        except ImportError:
+            raise SkipTest('xarray not available')
+
+
+        dset = xr.Dataset(
+            {"u": ("t", [1, 3]), "v": ("t", [4, 2])},
+            coords={"t": ("t", [0, 1], {"long_name": "time", "units": "s"})},
+        )
+        ndoverlay = dset.hvplot.line()
+
+        assert render(ndoverlay, "bokeh").xaxis.axis_label == "time (s)"
 
 
 class TestChart2DDask(TestChart2D):


### PR DESCRIPTION
Fixes #816

With this change, the xarray dataset metadata propagates to `NdOverlay` figures. This will give more descriptive information like the xlabel in the example below, where it before only showed `t`. 

![image](https://user-images.githubusercontent.com/19758978/195145381-7df34382-f673-4ba1-9f02-d7ee2d0094c6.png)


The added `.redim` could be placed on the line above or below, but I can´t think of a reason why one of them is better than the other.   