### PR TITLE
Improve error message mentionning pyproj

### DIFF
--- a/hvplot/util.py
+++ b/hvplot/util.py
@@ -231,7 +231,7 @@ def process_crs(crs):
         import geoviews as gv # noqa
         import pyproj
     except ImportError:
-        raise ImportError('Geographic projection support requires GeoViews and cartopy.')
+        raise ImportError('Geographic projection support requires GeoViews, pyproj and cartopy.')
 
     if crs is None:
         return ccrs.PlateCarree()


### PR DESCRIPTION
Fixes https://github.com/holoviz/hvplot/issues/534

In the issue it was suggested to mention GeoViews only. The more robust approach seems to instead declare all the dependencies required by `process_crs`.