### PR TITLE
Add workaround when having axes which are datetime-like

### DIFF
--- a/hvplot/ui.py
+++ b/hvplot/ui.py
@@ -3,7 +3,7 @@ import numpy as np
 import panel as pn
 import param
 
-from holoviews.core.util import is_number, max_range
+from holoviews.core.util import datetime_types, dt_to_int, is_number, max_range
 from holoviews.element import tile_sources
 from holoviews.plotting.util import list_cmaps
 from panel.viewable import Viewer
@@ -179,16 +179,32 @@ class Axes(Controls):
     def _update_ranges(self):
         xlim = self.explorer.xlim()
         if xlim is not None and is_number(xlim[0]) and is_number(xlim[1]):
+            xlim = self._convert_to_int(xlim)
             self.param.xlim.precedence = 0
             self.param.xlim.bounds = xlim
         else:
             self.param.xlim.precedence = -1
         ylim = self.explorer.ylim()
         if ylim is not None and is_number(ylim[0]) and is_number(ylim[1]):
+            ylim = self._convert_to_int(ylim)
             self.param.ylim.precedence = 0
             self.param.ylim.bounds = ylim
         else:
             self.param.ylim.precedence = -1
+
+    @staticmethod
+    def _convert_to_int(val):
+        """
+        Converts datetime to int to avoid the error in https://github.com/holoviz/hvplot/issues/964.
+
+        This function is a workaround and should be removed when a better solution is found.
+
+        """
+
+        if isinstance(val[0], datetime_types) and isinstance(val[1], datetime_types):
+            val = (dt_to_int(val[0], "ms"), dt_to_int(val[1], "ms"))
+
+        return val
 
 
 class Labels(Controls):


### PR DESCRIPTION
This workaround converts datetime limits to integers to at least get some functionality instead of the error given in https://github.com/holoviz/hvplot/issues/964. 

https://user-images.githubusercontent.com/19758978/202196533-f9af37ab-72a9-4ec0-8684-5b56b953bd8c.mp4
