### PR TITLE
Add panel pin to ensure Bokeh <3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ install_requires = [
     'pandas',
     'numpy>=1.15',
     'packaging',
+    'panel >=0.11.0',
 ]
 
 _examples = [


### PR DESCRIPTION
FIxes https://github.com/holoviz/hvplot/issues/970

With the release of Bokeh 3 users started to get Bokeh 3 when installing hvPlot, while it's not compatible with it.

This PR adds Panel as a runtime dependency, as it is actually required by the explorer. It also pins it to `>=0.11.0` as this version of Panel is the first one that added an upper pin to Bokeh.

Alternatively we could have pinned HoloViews to `>= 1.15.0` as it pinned `"panel >=0.13.1"`, however it's just been released 6 months ago. Previous releases of HoloViews pinned `"panel >=0.9.5"` which didn't have the upper pin for Bokeh.