### PR TITLE
Temporarily pin ipykernel

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -68,6 +68,7 @@ _examples = [
     'matplotlib',
     'plotly',
     'pygraphviz',
+    'ipykernel <6.18.0'  # temporary
 ]
 
 extras_require = {


### PR DESCRIPTION
Not to get the 6.18.0 version from conda-forge, already yanked from PyPI.