### PR TITLE
fix .hvplot for ibis

### DIFF
--- a/hvplot/converter.py
+++ b/hvplot/converter.py
@@ -851,7 +851,7 @@ class HoloViewsConverter:
                                  'e.g. a NumPy array or xarray Dataset, '
                                  'found %s type' % (kind, type(self.data).__name__))
 
-            if hasattr(data, 'columns') and data.columns.name and not group_label:
+            if hasattr(data, 'columns') and hasattr(data.columns, 'name') and data.columns.name and not group_label:
                 group_label = data.columns.name
             elif not group_label:
                 group_label = 'Variable'

--- a/hvplot/ibis.py
+++ b/hvplot/ibis.py
@@ -4,8 +4,8 @@ def patch(name='hvplot', extension='bokeh', logo=False):
     try:
         import ibis
     except:
-        raise ImportError('Could not patch plotting API onto dask. '
-                          'Dask could not be imported.')
+        raise ImportError('Could not patch plotting API onto ibis. '
+                          'Ibis could not be imported.')
     _patch_plot = lambda self: hvPlotTabular(self)
     _patch_plot.__doc__ = hvPlotTabular.__call__.__doc__
     patch_property = property(_patch_plot)

--- a/hvplot/tests/testibis.py
+++ b/hvplot/tests/testibis.py
@@ -6,7 +6,7 @@ try:
     import hvplot.ibis # noqa
     import pandas as pd
 except:
-    pytest.skip(reason='Ibis test dependencies not available', allow_module_level=True)
+    pytest.skip(allow_module_level=True)
 
 
 @pytest.fixture

--- a/hvplot/tests/testibis.py
+++ b/hvplot/tests/testibis.py
@@ -1,0 +1,22 @@
+"""Ibis works with hvplot"""
+import pytest
+
+try:
+    import ibis
+    import hvplot.ibis # noqa
+    import pandas as pd
+except:
+    pytest.skip(reason='Ibis test dependencies not available', allow_module_level=True)
+
+
+@pytest.fixture
+def table():
+    df = pd.DataFrame({
+        "x": [pd.Timestamp("2022-01-01"), pd.Timestamp("2022-01-02")], "y": [1,2]
+    })
+    con = ibis.pandas.connect({"df": df})
+    return con.table("df")
+
+def test_can_hvplot(table):
+    """hvplot works with Ibis"""
+    table.hvplot(x="x", y="y")


### PR DESCRIPTION
Closes #988 

After this change I can produce a plot from the example in #988. But it seems it does not understand the Timestamp type should be shown as datetime on the x-axis. I will create a separate issue with holoviews for that.

![image](https://user-images.githubusercontent.com/42288570/204079900-09be667d-ec37-4989-84cd-fcc350da1c6b.png)

I've created an issue here https://github.com/holoviz/holoviews/issues/5521.