### PR TITLE
improve the hist reference guide

### DIFF
--- a/examples/reference/pandas/hist.ipynb
+++ b/examples/reference/pandas/hist.ipynb
@@ -88,10 +88,11 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "If you want to plot the distribution of a categorical column you can calculate the distribution using `value_counts` and plot it using `.hvplot.bar`."
+    "If you want to plot the distribution of a categorical column you can calculate the distribution using Pandas' method `value_counts` and plot it using `.hvplot.bar`."
    ]
   },
   {

--- a/examples/reference/pandas/hist.ipynb
+++ b/examples/reference/pandas/hist.ipynb
@@ -70,7 +70,7 @@
     "import pandas as pd\n",
     "from bokeh.sampledata.commits import data as commits\n",
     "\n",
-    "commits=commits.reset_index().sort_values(\"datetime\")\n",
+    "commits = commits.reset_index().sort_values(\"datetime\")\n",
     "commits.head(3)"
    ]
   },

--- a/examples/reference/pandas/hist.ipynb
+++ b/examples/reference/pandas/hist.ipynb
@@ -105,22 +105,9 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
    "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/examples/reference/pandas/hist.ipynb
+++ b/examples/reference/pandas/hist.ipynb
@@ -6,14 +6,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import hvplot.pandas  # noqa"
+    "import hvplot.pandas  # noqa\n",
+    "\n",
+    "# hvplot.extension(\"matplotlib\")"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "`hist` is often a good way to start looking at data to get a sense of the distribution. Similar methods include [`kde`](kde.ipny) (also available as `density`)."
+    "`hist` is often a good way to start looking at continous data to get a sense of the distribution. Similar methods include [`kde`](kde.ipynb) (also available as `density`)."
    ]
   },
   {
@@ -22,9 +24,18 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from bokeh.sampledata.autompg import autompg_clean as df\n",
+    "from bokeh.sampledata.autompg import autompg_clean\n",
     "\n",
-    "df.sample(n=5)"
+    "autompg_clean.sample(n=5)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "autompg_clean.hvplot.hist(\"weight\")"
    ]
   },
   {
@@ -40,16 +51,78 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "df.hvplot.hist(\"weight\", by=\"origin\", subplots=True, width=250)"
+    "autompg_clean.hvplot.hist(\"weight\", by=\"origin\", subplots=True, width=250)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You can also plot histograms of *datetime* data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "from bokeh.sampledata.commits import data as commits\n",
+    "\n",
+    "commits=commits.reset_index().sort_values(\"datetime\")\n",
+    "commits.head(3)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "commits.hvplot.hist(\n",
+    "    \"datetime\",\n",
+    "    bin_range=(pd.Timestamp('2012-11-30'), pd.Timestamp('2017-05-01')),\n",
+    "    bins=54,   \n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If you want to plot the distribution of a categorical column you can calculate the distribution using `value_counts` and plot it using `.hvplot.bar`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "autompg_clean[\"mfr\"].value_counts().hvplot.bar(invert=True, flip_yaxis=True, height=500)"
    ]
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
    "name": "python",
-   "pygments_lexer": "ipython3"
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.7"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/hvplot/plotting/core.py
+++ b/hvplot/plotting/core.py
@@ -1244,7 +1244,7 @@ class hvPlotTabular(hvPlotBase):
 
     def hist(self, y=None, by=None, **kwds):
         """
-        A `histogram` displays an approximate representation of the distribution of numerical data.
+        A `histogram` displays an approximate representation of the distribution of continous data.
 
         Reference: https://hvplot.holoviz.org/reference/pandas/hist.html
 
@@ -1252,6 +1252,7 @@ class hvPlotTabular(hvPlotBase):
         ----------
         y : string or sequence
             Field(s) in the *wide* data to compute the distribution(s) from.
+            Please note the fields should contain continuous data. Not categorical.
         by : string or sequence
             Field(s) in the *long* data to group by.
         bins : int, optional
@@ -1294,6 +1295,20 @@ class hvPlotTabular(hvPlotBase):
             df = pd.DataFrame(np.random.randint(1, 7, 6000), columns = ['one'])
             df['two'] = df['one'] + np.random.randint(1, 7, 6000)
             df.hvplot.hist(bins=12, alpha=0.5, color=["lightgreen", "pink"])
+
+        If you want to show the distribution of the values of a categorical column,
+        you can use `value_counts` and `bar` as shown below
+
+        .. code-block::
+
+            import hvplot.pandas
+            import pandas as pd
+
+            data = pd.DataFrame({
+                "library": ["bokeh", "plotly", "matplotlib", "bokeh", "matplotlib", "matplotlib"]
+            })
+
+            data["library"].value_counts().hvplot.bar(invert=True, flip_yaxis=True)
 
         References
         ----------

--- a/hvplot/plotting/core.py
+++ b/hvplot/plotting/core.py
@@ -1308,7 +1308,7 @@ class hvPlotTabular(hvPlotBase):
                 "library": ["bokeh", "plotly", "matplotlib", "bokeh", "matplotlib", "matplotlib"]
             })
 
-            data["library"].value_counts().hvplot.bar(invert=True, flip_yaxis=True)
+            data["library"].value_counts().hvplot.bar()
 
         References
         ----------

--- a/hvplot/plotting/core.py
+++ b/hvplot/plotting/core.py
@@ -1297,7 +1297,7 @@ class hvPlotTabular(hvPlotBase):
             df.hvplot.hist(bins=12, alpha=0.5, color=["lightgreen", "pink"])
 
         If you want to show the distribution of the values of a categorical column,
-        you can use `value_counts` and `bar` as shown below
+        you can use Pandas' method `value_counts` and `bar` as shown below
 
         .. code-block::
 


### PR DESCRIPTION
Closes #998. 

Please note https://github.com/holoviz/holoviews/pull/5540 closes the issue about the non-understandable error message when trying to `hist` categorical data.

In addition, I've added more examples to illustrate what is possible.

Comparing to the plotly documentation there is still a long, long way to go https://plotly.com/python/histograms/.