### PR TITLE
Exclude Python 3.6 / Linux from the test matrix

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -133,9 +133,10 @@ jobs:
       matrix:
         os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
         python-version: ['3.6']
-        include:
+        exclude:
         - os: ubuntu-latest
-          path: /usr/share/miniconda3/envs/
+          python-version: '3.6'
+        include:
         - os: macos-latest
           path: /Users/runner/miniconda3/envs/
         - os: windows-latest


### PR DESCRIPTION
As apparently unavailable on ubuntu-latest and I have a preference for keeping ubuntu-latest every where across HoloViz repos instead of pinning it.