### PR TITLE
Ensure interactive pipeline is not re-executed needlessly

### DIFF
--- a/hvplot/interactive.py
+++ b/hvplot/interactive.py
@@ -1,12 +1,102 @@
 """
 interactive API
+
+How Interactive works
+---------------------
+
+`Interactive` is a wrapper around a Python object that lets users create
+interactive pipelines by calling existing APIs on an object with dynamic
+parameters or widgets.
+
+An `Interactive` instance watches what operations are applied to the object.
+
+To do so, each operation returns a new `Interactive` instance - the creation
+of a new instance being taken care of by the `_clone` method - which allows
+the next operation to be recorded, and so on and so forth. E.g. `dfi.head()`
+first records that the `'head'` attribute is accessed, this is achieved
+by overriding `__getattribute__`. A new interactive object is returned,
+which will then record that it is being called, and that new object will be
+itself called as `Interactive` implements `__call__`. `__call__`  returns
+another `Interactive` instance.
+
+Note that under the hood even more `Interactive` instances may be created,
+but this is the gist of it.
+
+To be able to watch all the potential operations that may be applied to an
+object, `Interactive` implements on top of `__getattribute__` and
+`__call__`:
+
+- operators such as `__gt__`, `__add__`, etc.
+- the builtin functions `__abs__` and `__round__`
+- `__getitem__`
+- `__array_ufunc__`
+
+The `_depth` attribute starts at 0 and is incremented by 1 everytime
+a new `Interactive` instance is created part of a chain.
+The root instance in an expression has a `_depth` of 0. An expression can
+consist of multiple chains, such as `dfi[dfi.A > 1]`, as the `Interactive`
+instance is referenced twice in the expression. As a consequence `_depth`
+is not the total count of `Interactive` instance creations of a pipeline,
+it is the count of instances created in the outer chain. In the example, that
+would be `dfi[]`. `Interactive` instances don't have references about
+the instances that created them or that they create, they just know their
+current location in a chain thanks to `_depth`. However, as some parameters
+need to be passed down the whole pipeline, they do have to propagate. E.g.
+in `dfi.interactive(width=200)`, `width=200` will be propagated as `kwargs`.
+
+Recording the operations applied to an object in a pipeline is done
+by gradually building a so-called "dim expression", or "dim transform",
+which is an expression language provided by HoloViews. dim transform
+objects are a way to express transforms on `Dataset`s, a `Dataset` being
+another HoloViews object that is a wrapper around common data structures
+such as Pandas/Dask/... Dataframes/Series, Xarray Dataset/DataArray, etc.
+For instance a Python expression such as `(series + 2).head()` can be
+expressed with a dim transform whose repr will be `(dim('*').pd+2).head(2)`,
+effectively showing that the dim transfom has recorded the different
+operations that are meant to be applied to the data.
+The `_transform` attribute stores the dim transform.
+
+The `_obj` attribute holds the original data structure that feeds the
+pipeline. All the `Interactive` instances created while parsing the
+pipeline share the same `_obj` object. And they all wrap it in a `Dataset`
+instance, and all apply the current dim transform they are aware of to
+the original data structure to compute the intermediate state of the data,
+that is stored it in the `_current_` attribute. Doing so is particularly
+useful in Notebook sessions, as this allows to inspect the transformed
+object at any point of the pipeline, and as such provide correct
+auto-completion and docstrings. E.g. executing `dfi.A.max?` in a Notebook
+will correctly return the docstring of the Pandas Series `.max()` method,
+as the pipeline evaluates `dfi.A` to hold a current object `_current` that
+is a Pandas Series, and no longer and DataFrame.
+
+The `_obj` attribute is implemented as a property which gets/sets the value
+from a list that contains the shared attribute. This is required for the
+"function as input" to be able to update the object from a callback set up
+on the root Interactive instance.
+
+Internally interactive holds the current evaluated state on the `_current_`
+attribute, when some parameter in the interactive pipeline is changed
+the pipeline is marked as `_dirty`. This means that the next time `_current`
+is accessed the pipeline will be re-evaluated to get the up-to-date
+current value.
+
+The `_method` attribute is a string that temporarily stores the method/attr
+accessed on the object, e.g. `_method` is 'head' in `dfi.head()`, until the
+Interactive instance created in the pipeline is called at which point `_method`
+is reset to None. In cases such as `dfi.head` or `dfi.A`, `_method` is not
+(yet) reset to None. At this stage the Interactive instance returned has
+its `_current` attribute not updated, e.g. `dfi.A._current` is still the
+original dataframe, not the 'A' series. Keeping `_method` is thus useful for
+instance to display `dfi.A`, as the evaluation of the object will check
+whether `_method` is set or not, and if it's set it will use it to compute
+the object returned, e.g. the series `df.A` or the method `df.head`, and
+display its repr.
 """
 
 import abc
 import operator
 import sys
 
-from collections import defaultdict
 from functools import partial
 from packaging.version import Version
 from types import FunctionType, MethodType
@@ -59,99 +149,6 @@ def _find_widgets(op):
                 if widget not in widgets:
                     widgets.append(widget)
     return widgets
-
-
-
-# How Interactive works
-# ---------------------
-
-# `Interactive` is a wrapper around a Python object that lets users create
-# interactive pipelines by calling existing APIs on an object with dynamic
-# parameters or widgets.
-
-# An `Interactive` instance watches what operations are applied to the object.
-
-# To do so, each operation returns a new `Interactive` instance - the creation
-# of a new instance being taken care of by the `_clone` method - which allows
-# the next operation to be recorded, and so on and so forth. E.g. `dfi.head()`
-# first records that the `'head'` attribute is accessed, this is achieved
-# by overriding `__getattribute__`. A new interactive object is returned,
-# which will then record that it is being called, and that new object will be
-# itself called as `Interactive` implements `__call__`. `__call__`  returns
-# another `Interactive` instance.
-
-# Note that under the hood even more `Interactive` instances may be created,
-# but this is the gist of it.
-
-# To be able to watch all the potential operations that may be applied to an
-# object, `Interactive` implements on top of `__getattribute__` and
-# `__call__`:
-
-# - operators such as `__gt__`, `__add__`, etc.
-# - the builtin functions `__abs__` and `__round__`
-# - `__getitem__`
-# - `__array_ufunc__`
-
-# The `_depth` attribute starts at 0 and is incremented by 1 everytime
-# a new `Interactive` instance is created part of a chain.
-# The root instance in an expression has a `_depth` of 0. An expression can
-# consist of multiple chains, such as `dfi[dfi.A > 1]`, as the `Interactive`
-# instance is referenced twice in the expression. As a consequence `_depth`
-# is not the total count of `Interactive` instance creations of a pipeline,
-# it is the count of instances created in the outer chain. In the example, that
-# would be `dfi[]`. `Interactive` instances don't have references about
-# the instances that created them or that they create, they just know their
-# current location in a chain thanks to `_depth`. However, as some parameters
-# need to be passed down the whole pipeline, they do have to propagate. E.g.
-# in `dfi.interactive(width=200)`, `width=200` will be propagated as `kwargs`.
-
-# Recording the operations applied to an object in a pipeline is done
-# by gradually building a so-called "dim expression", or "dim transform",
-# which is an expression language provided by HoloViews. dim transform
-# objects are a way to express transforms on `Dataset`s, a `Dataset` being
-# another HoloViews object that is a wrapper around common data structures
-# such as Pandas/Dask/... Dataframes/Series, Xarray Dataset/DataArray, etc.
-# For instance a Python expression such as `(series + 2).head()` can be
-# expressed with a dim transform whose repr will be `(dim('*').pd+2).head(2)`,
-# effectively showing that the dim transfom has recorded the different
-# operations that are meant to be applied to the data.
-# The `_transform` attribute stores the dim transform.
-
-# The `_obj` attribute holds the original data structure that feeds the
-# pipeline. All the `Interactive` instances created while parsing the
-# pipeline share the same `_obj` object. And they all wrap it in a `Dataset`
-# instance, and all apply the current dim transform they are aware of to
-# the original data structure to compute the intermediate state of the data,
-# that is stored it in the `_current_` attribute. Doing so is particularly
-# useful in Notebook sessions, as this allows to inspect the transformed
-# object at any point of the pipeline, and as such provide correct
-# auto-completion and docstrings. E.g. executing `dfi.A.max?` in a Notebook
-# will correctly return the docstring of the Pandas Series `.max()` method,
-# as the pipeline evaluates `dfi.A` to hold a current object `_current` that
-# is a Pandas Series, and no longer and DataFrame.
-
-# The `_obj` attribute is implemented as a property which gets/sets the value
-# from a list that contains the shared attribute. This is required for the
-# "function as input" to be able to update the object from a callback set up
-# on the root Interactive instance.
-
-# Internally interactive holds the current evaluated state on the `_current_`
-# attribute, when some parameter in the interactive pipeline is changed
-# the pipeline is marked as `_dirty`. This means that the next time `_current`
-# is accessed the pipeline will be re-evaluated to get the up-to-date
-# current value.
-
-# The `_method` attribute is a string that temporarily stores the method/attr
-# accessed on the object, e.g. `_method` is 'head' in `dfi.head()`, until the
-# Interactive instance created in the pipeline is called at which point `_method`
-# is reset to None. In cases such as `dfi.head` or `dfi.A`, `_method` is not
-# (yet) reset to None. At this stage the Interactive instance returned has
-# its `_current` attribute not updated, e.g. `dfi.A._current` is still the
-# original dataframe, not the 'A' series. Keeping `_method` is thus useful for
-# instance to display `dfi.A`, as the evaluation of the object will check
-# whether `_method` is set or not, and if it's set it will use it to compute
-# the object returned, e.g. the series `df.A` or the method `df.head`, and
-# display its repr.
 
 
 class Interactive:

--- a/hvplot/interactive.py
+++ b/hvplot/interactive.py
@@ -676,20 +676,23 @@ class Interactive:
         Returns the current state of the interactive expression. The
         returned object is no longer interactive.
         """
-        if self._current_ is not _Undefined:
-            return self._current_
-        obj = self._obj
-        ds = hv.Dataset(obj)
-        transform = self._transform
-        if ds.interface.datatype == 'xarray' and is_xarray_dataarray(obj):
-            transform = transform.clone(obj.name)
-        obj = transform.apply(ds, keep_index=True, compute=False)
+        if self._current_ is _Undefined:
+            obj = self._obj
+            ds = hv.Dataset(obj)
+            transform = self._transform
+            if ds.interface.datatype == 'xarray' and is_xarray_dataarray(obj):
+                transform = transform.clone(obj.name)
+            obj = transform.apply(ds, keep_index=True, compute=False)
+            self._current_ = obj
+        else:
+            obj = self._current_
+
         if self._method:
             # E.g. `pi = dfi.A` leads to `pi._method` equal to `'A'`.
             obj = getattr(obj, self._method, obj)
         if self._plot:
             obj = Interactive._fig
-        self._current_ = obj
+
         return obj
 
     def layout(self, **kwargs):

--- a/hvplot/interactive.py
+++ b/hvplot/interactive.py
@@ -148,7 +148,7 @@ def _find_widgets(op):
 # display its repr.
 
 
-def _Undefined():
+class _Undefined():
     "Sentinel object indicating object is undefined"
 
 

--- a/hvplot/tests/testinteractive.py
+++ b/hvplot/tests/testinteractive.py
@@ -683,6 +683,17 @@ def test_interactive_pandas_frame_bind_operator_out_widgets(df):
     assert widgets[1] is w
 
 
+def test_interactive_reevaluate_uses_cached_value(series):
+    w = pn.widgets.FloatSlider(value=2., start=1., end=5.)
+    si = Interactive(series)
+    si = si + w
+
+    w.value = 3.
+    assert repr(si._transform) == "dim('*').pd+FloatSlider(end=5.0, start=1.0, value=3.0)"
+
+    assert si._callback().object is si._callback().object
+
+
 def test_interactive_pandas_series_operator_widget_update(series):
     w = pn.widgets.FloatSlider(value=2., start=1., end=5.)
     si = Interactive(series)
@@ -692,6 +703,7 @@ def test_interactive_pandas_series_operator_widget_update(series):
     assert repr(si._transform) == "dim('*').pd+FloatSlider(end=5.0, start=1.0, value=3.0)"
 
     out = si._callback()
+    assert out.object is si.eval()
     assert isinstance(out, pn.pane.DataFrame)
     pd.testing.assert_series_equal(out.object.A, series + 3.)
 
@@ -705,6 +717,7 @@ def test_interactive_pandas_series_method_widget_update(series):
     assert repr(si._transform) =="dim('*').pd.head(IntSlider(end=5, start=1, value=3))"
 
     out = si._callback()
+    assert out.object is si.eval()
     assert isinstance(out, pn.pane.DataFrame)
     pd.testing.assert_series_equal(out.object.A, series.head(3))
 
@@ -721,6 +734,7 @@ def test_interactive_pandas_series_operator_and_method_widget_update(series):
     assert repr(si._transform) == "(dim('*').pd+FloatSlider(end=5.0, start=1.0, value=3.0)).head(IntSlider(end=5, start=1, value=3))"
 
     out = si._callback()
+    assert out.object is si.eval()
     assert isinstance(out, pn.pane.DataFrame)
     pd.testing.assert_series_equal(out.object.A, (series + 3.).head(3))
 


### PR DESCRIPTION
- Fixes `Interactive.eval()` ensuring it returns the current value (previously it would only ever return the initial value)
- Ensures that unless parameters change we don't re-evaluate the pipeline each time the value is requested by a callback.