### PR TITLE
Update Param method

### DIFF
--- a/hvplot/converter.py
+++ b/hvplot/converter.py
@@ -590,7 +590,7 @@ class HoloViewsConverter:
 
         self._plot_opts = plot_opts
         self._overlay_opts = {k: v for k, v in self._plot_opts.items()
-                              if k in OverlayPlot.param.params()}
+                              if k in OverlayPlot.param.objects()}
 
         self._norm_opts = {'framewise': framewise, 'axiswise': not plot_opts.get('shared_axes')}
         self.kwds = kwds

--- a/hvplot/ui.py
+++ b/hvplot/ui.py
@@ -373,7 +373,7 @@ class hvPlotExplorer(Viewer):
         # Assumes the controls aren't passed on instantiation.
         controls = [
             p.class_
-            for p in self.param.params().values()
+            for p in self.param.objects().values()
             if isinstance(p, param.ClassSelector)
             and issubclass(p.class_, Controls)
         ]

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ install_requires = [
     'numpy>=1.15',
     'packaging',
     'panel >=0.11.0',
+    'param >=1.9.0',
 ]
 
 _examples = [


### PR DESCRIPTION
- Add `param` as a runtime dependency, `>=1.9.0` for when `.param.objects()` was added. It was an oversight not having it explicitly listed in the runtime deps, as it's used directly for the *Explorer*
- Replace usage of `.param.params()` with `.param.objects()`
