### PR TITLE
Only use long_name if it is a string

### DIFF
--- a/hvplot/converter.py
+++ b/hvplot/converter.py
@@ -949,7 +949,7 @@ class HoloViewsConverter:
                 for var_name, var_attrs in var_tuples:
                     if var_name is None:
                         var_name = 'value'
-                    if 'long_name' in var_attrs:
+                    if isinstance(var_attrs.get('long_name'), str):
                         labels[var_name] = var_attrs['long_name']
                     if 'units' in var_attrs:
                         units[var_name] = var_attrs['units']


### PR DESCRIPTION
Fixes the hvplot part of https://github.com/holoviz/holoviews/issues/5615

This change makes it so that it only uses the long name if it is a string. 