### PR TITLE
Improve bar documentation especially for color

### DIFF
--- a/examples/reference/pandas/bar.ipynb
+++ b/examples/reference/pandas/bar.ipynb
@@ -18,9 +18,7 @@
     "\n",
     "A `bar` plot represents **categorical data** with rectangular bars with heights proportional to the **numerical values** that they represent.\n",
     "The x-axis represents the categories and the y axis represents the numerical value scale.\n",
-    "The bars are of equal width which allows for instant comparison of data.\n",
-    "\n",
-    "Write `hvplot.extension('bokeh')`, `hvplot.extension('matplotlib')` or `hvplot.extension('plotly')` to change the plotting backend"
+    "The bars are of equal width which allows for instant comparison of data."
    ]
   },
   {
@@ -32,7 +30,7 @@
     "pd.DataFrame({\n",
     "    \"framework\": [\"hvPlot\", \"HoloViews\", \"Panel\"], \n",
     "    \"stars\": [700, 2400, 2600]\n",
-    "}).hvplot.bar(x=\"framework\", y=\"stars\", color=\"gold\", title=\"Bar Plot of Github Stars as of March 2023\", ylabel=\"⭐\")"
+    "}).hvplot.bar(x=\"framework\", y=\"stars\", color=\"gold\", title=\"Bar Plot of Github Stars\", ylabel=\"⭐\")"
    ]
   },
   {
@@ -41,7 +39,7 @@
    "source": [
     "## Data\n",
     "\n",
-    "Lets import some data"
+    "Let's import some data."
    ]
   },
   {
@@ -53,13 +51,6 @@
     "from bokeh.sampledata.autompg import autompg_clean as autompg\n",
     "\n",
     "autompg.head()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Note that the columns `yr`, `origin`, `name` and `mfr` are categorical.Note that the columns `yr`, `origin`, `name` and `mfr` are categorical."
    ]
   },
   {
@@ -135,7 +126,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "If you don't specify the `x` argument, then the index will be used"
+    "If you don't specify the `x` argument, then the index will be used."
    ]
   },
   {
@@ -151,7 +142,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "You may also plot a **`MultiIndex`** on the x-axis"
+    "When the index is a `MultiIndex`, the x-axis represents the multiple categories included in the index, the outer index level being displayed as the outer category."
    ]
   },
   {
@@ -167,7 +158,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Instead of plotting the `MultiIndex` on the x-axis you stack the values"
+    "You can instead stack on the y-axis the values of the nested index/category, *origin* in this example, by setting `stacked` to `True`."
    ]
   },
   {
@@ -183,7 +174,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "You may use **wide form data** by specifying multiply `y` columns"
+    "To plot multiple categories on the x-axis when the data is **wide form**, you need to provide a list of columns to `y`."
    ]
   },
   {
@@ -199,7 +190,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "and you may also stack the values of the *wide form* data"
+    "And you may also stack the values of the *wide form* data."
    ]
   },
   {
@@ -219,7 +210,7 @@
     "\n",
     "You can control the `bar` color using the `color` argument. It accepts the name of a column, the name of a color or a list of colors.\n",
     "\n",
-    "Here is an example using a single named color"
+    "Here is an example using a single named color."
    ]
   },
   {
@@ -235,7 +226,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Here is an example using a list of colors"
+    "Here is an example using a list of colors."
    ]
   },
   {
@@ -251,54 +242,23 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Here is an example using the name of a column"
+    "Here is an example using the name of a column."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "autompg_long_form.hvplot.bar(y='mpg', color=\"weight\", colorbar=True, clabel=\"Weight\", cmap=\"bmy\", width=1000)"
    ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Bar Api Documentation"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "hvplot.help('bar')"
-   ]
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
    "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/examples/reference/pandas/bar.ipynb
+++ b/examples/reference/pandas/bar.ipynb
@@ -6,6 +6,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import pandas as pd\n",
     "import hvplot.pandas  # noqa"
    ]
   },
@@ -13,19 +14,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "`bar` can be used on dataframes with regular `Index` or `MultiIndex`."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from bokeh.sampledata.autompg import autompg_clean as df\n",
+    "## Introduction\n",
     "\n",
-    "table = df.groupby('yr').mean()\n",
-    "table.head()"
+    "A `bar` plot represents **categorical data** with rectangular bars with heights proportional to the **numerical values** that they represent.\n",
+    "The x-axis represents the categories and the y axis represents the numerical value scale.\n",
+    "The bars are of equal width which allows for instant comparison of data.\n",
+    "\n",
+    "Write `hvplot.extension('bokeh')`, `hvplot.extension('matplotlib')` or `hvplot.extension('plotly')` to change the plotting backend"
    ]
   },
   {
@@ -34,24 +29,19 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "table.hvplot.bar(y='mpg', height=500)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "table = df.groupby(['yr', 'origin']).mean()\n",
-    "table.head()"
+    "pd.DataFrame({\n",
+    "    \"framework\": [\"hvPlot\", \"HoloViews\", \"Panel\"], \n",
+    "    \"stars\": [700, 2400, 2600]\n",
+    "}).hvplot.bar(x=\"framework\", y=\"stars\", color=\"gold\", title=\"Bar Plot of Github Stars as of March 2023\", ylabel=\"⭐\")"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "When mutiple axes are being used on the xaxis, plots can be stacked or unstacked."
+    "## Data\n",
+    "\n",
+    "Lets import some data"
    ]
   },
   {
@@ -60,7 +50,23 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "table.hvplot.bar(stacked=True, height=500, legend='top_left')"
+    "from bokeh.sampledata.autompg import autompg_clean as autompg\n",
+    "\n",
+    "autompg.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note that the columns `yr`, `origin`, `name` and `mfr` are categorical.Note that the columns `yr`, `origin`, `name` and `mfr` are categorical."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We define *long form data*, i.e. one row per `yr` categorical value."
    ]
   },
   {
@@ -69,14 +75,230 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "table.hvplot.bar(stacked=False, height=500, rot=60)"
+    "autompg_long_form = autompg.groupby(\"yr\").mean(numeric_only=True).reset_index()\n",
+    "autompg_long_form.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    " We define a dataset with a *multi index* representing multiple categories"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "autompg_multi_index = autompg.query(\"yr<=80\").groupby(['yr', 'origin']).mean(numeric_only=True)\n",
+    "autompg_multi_index.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We define *wide form data*, i.e. multiple columns representing a category like `origin`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "autompg_wide = autompg_multi_index.reset_index().pivot(index='yr', columns='origin', values='mpg')\n",
+    "autompg_wide.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Basic Bar Plots\n",
+    "\n",
+    "You can plot **long form data** if you specify the categorical x-value using the `x` argument and the numerical y-value using the `y-argument`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "autompg_long_form.hvplot.bar(x=\"yr\", y=\"mpg\", width=1000)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If you don't specify the `x` argument, then the index will be used"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "autompg_long_form.hvplot.bar(y=\"mpg\", width=1000)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You may also plot a **`MultiIndex`** on the x-axis"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "autompg_multi_index.hvplot.bar(width=1000, rot=90)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Instead of plotting the `MultiIndex` on the x-axis you stack the values"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "autompg_multi_index.hvplot.bar(stacked=True, width=1000, legend=\"top_left\", height=500)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You may use **wide form data** by specifying multiply `y` columns"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "autompg_wide.hvplot.bar(y=['Asia', 'Europe', 'North America'], width=1000, ylabel=\"mpg\", rot=90)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "and you may also stack the values of the *wide form* data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "autompg_wide.hvplot.bar(y=['Asia', 'Europe', 'North America'], ylabel=\"mpg\", stacked=True, width=1000, legend=\"top_left\", height=500)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Colorful Bar Plots\n",
+    "\n",
+    "You can control the `bar` color using the `color` argument. It accepts the name of a column, the name of a color or a list of colors.\n",
+    "\n",
+    "Here is an example using a single named color"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "autompg_long_form.hvplot.bar(x=\"yr\", y=\"mpg\", color=\"teal\", width=1000)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Here is an example using a list of colors"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "autompg_wide.hvplot.bar(y=['Asia', 'Europe', 'North America'], width=1000, ylabel=\"mpg\", color=[\"#ba2649\", \"#ffa7ca\", \"#1a6b54\"], rot=90)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Here is an example using the name of a column"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "autompg_long_form.hvplot.bar(y='mpg', color=\"weight\", colorbar=True, clabel=\"Weight\", cmap=\"bmy\", width=1000)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Bar Api Documentation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "hvplot.help('bar')"
    ]
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
    "name": "python",
-   "pygments_lexer": "ipython3"
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.7"
   }
  },
  "nbformat": 4,

--- a/hvplot/converter.py
+++ b/hvplot/converter.py
@@ -129,7 +129,7 @@ class HoloViewsConverter:
         tuples of tuples to specify different amounts of padding for
         upper and lower bounds.
     rescale_discrete_levels (default=True): boolean
-        If `cnorm='eq_hist` and there are only a few discrete values,
+        If `cnorm='eq_hist'` and there are only a few discrete values,
         then `rescale_discrete_levels=True` (the default) decreases
         the lower limit of the autoranged span so that the values are
         rendering towards the (more visible) top of the `cmap` range,
@@ -151,7 +151,7 @@ class HoloViewsConverter:
     title (default=''): str
         Title for the plot
     tools (default=[]): list
-        List of tool instances or strings (e.g. ['tap', box_select'])
+        List of tool instances or strings (e.g. ['tap', 'box_select'])
     xaxis/yaxis: str or None
         Whether to show the x/y-axis and whether to place it at the
         'top'/'bottom' and 'left'/'right' respectively.

--- a/hvplot/plotting/core.py
+++ b/hvplot/plotting/core.py
@@ -962,10 +962,8 @@ class hvPlotTabular(hvPlotBase):
 
         A `bar` plot represents categorical data with rectangular bars
         with heights proportional to the values that they represent. The x-axis
-        plots categories and the y axis represents the value scale.
+        represents the categories and the y axis represents the value scale.
         The bars are of equal width which allows for instant comparison of data.
-
-        `bar` can be used on dataframes with regular Index or MultiIndex.
 
         Reference: https://hvplot.holoviz.org/reference/pandas/bar.html
 
@@ -981,13 +979,14 @@ class hvPlotTabular(hvPlotBase):
         color : str or array-like, optional.
             The color for each of the series. Possible values are:
 
+            The name of the field to draw the colors from. The field can contain numerical values or strings
+            representing colors.
+            
             A single color string referred to by name, RGB or RGBA code, for instance 'red' or
             '#a98d19'.
 
             A sequence of color strings referred to by name, RGB or RGBA code, which will be used
-            for each series recursively. For instance ['green','yellow'] each field’s line will be
-            filled in green or yellow, alternatively. If there is only a single series to be
-            plotted, then only the first color from the color list will be used.
+            for each series recursively. For instance ['red', 'green','blue'].
         **kwds : optional
             Additional keywords arguments are documented in `hvplot.help('bar')`.
 

--- a/hvplot/plotting/core.py
+++ b/hvplot/plotting/core.py
@@ -981,7 +981,7 @@ class hvPlotTabular(hvPlotBase):
 
             The name of the field to draw the colors from. The field can contain numerical values or strings
             representing colors.
-            
+
             A single color string referred to by name, RGB or RGBA code, for instance 'red' or
             '#a98d19'.
 


### PR DESCRIPTION
Addresses a users comment about limited `bar` documentation and no documentation of `color`. See https://discourse.holoviz.org/t/is-there-a-way-to-add-a-specific-color-to-each-group-in-a-grouped-bar-plot-like-hue-in-seaborns-barplot/5066

Also fixes a few docstring bugs identified when rendering the output of `hvplot.help('bar')` on Discourse.

https://user-images.githubusercontent.com/42288570/224508335-3a1d31b4-64ee-4943-a0ee-591886aa3529.mp4

## Issues identified while working on this

The main issue is that lots of things does not work for Matplotlib and Plotly backends as they do for Bokeh backend

- #1034 
- #1035 
- #1036 
- #1037 
- #1038 
- #1039 