### PR TITLE
Transform columnar data for interactive

### DIFF
--- a/hvplot/converter.py
+++ b/hvplot/converter.py
@@ -34,6 +34,7 @@ from .util import (
     is_streamz, is_ibis, is_xarray, is_xarray_dataarray, process_crs,
     process_intake, process_xarray, check_library, is_geodataframe,
     process_derived_datetime_xarray, process_derived_datetime_pandas,
+    _convert_col_names_to_str,
 )
 from .utilities import hvplot_extension
 
@@ -655,12 +656,6 @@ class HoloViewsConverter:
                     "'{}' must be either a valid crs or an reference to "
                     "a `data.attr` containing a valid crs.".format(crs))
 
-    def _transform_columnar_data(self, data):
-        renamed = {c: str(c) for c in data.columns if not isinstance(c, str)}
-        if renamed:
-            data = data.rename(columns=renamed)
-        return data
-
     def _process_data(self, kind, data, x, y, by, groupby, row, col,
                       use_dask, persist, backlog, label, group_label,
                       value_label, hover_cols, attr_labels, transforms,
@@ -681,8 +676,7 @@ class HoloViewsConverter:
         # update the `_dataset` property (of the hv object its __call__ method
         # returns) with a hv Dataset created from the source data, which
         # is done for optimizating some operations in HoloViews.
-        if hasattr(data, 'columns'):
-            data = self._transform_columnar_data(data)
+        data = _convert_col_names_to_str(data)
 
         self.source_data = data
 
@@ -1571,7 +1565,7 @@ class HoloViewsConverter:
         if data is None:
             data = self.data
         elif not self.gridded_data:
-            data = self._transform_columnar_data(data)
+            data = _convert_col_names_to_str(data)
 
         x = self._process_chart_x(data, x, y, single_y, categories=categories)
         y = self._process_chart_y(data, x, y, single_y)

--- a/hvplot/interactive.py
+++ b/hvplot/interactive.py
@@ -272,7 +272,7 @@ class Interactive:
         self._inherit_kwargs = inherit_kwargs
         self._max_rows = max_rows
         self._kwargs = kwargs
-        ds = hv.Dataset(self._obj)
+        ds = hv.Dataset(self._transform_columnar_data(self._obj))
         if _current is not None:
             self._current_ = _current
         else:
@@ -292,6 +292,12 @@ class Interactive:
             self._shared_obj = [obj]
         else:
             self._shared_obj[0] = obj
+
+    def _transform_columnar_data(self, data):
+        renamed = {c: str(c) for c in getattr(data, "columns", []) if not isinstance(c, str)}
+        if renamed:
+            data = data.rename(columns=renamed)
+        return data
 
     @property
     def _current(self):

--- a/hvplot/interactive.py
+++ b/hvplot/interactive.py
@@ -111,7 +111,10 @@ from panel.util import get_method_owner, full_groupby
 from panel.widgets.base import Widget
 
 from .converter import HoloViewsConverter
-from .util import _flatten, is_tabular, is_xarray, is_xarray_dataarray
+from .util import (
+    _flatten, is_tabular, is_xarray, is_xarray_dataarray,
+    _convert_col_names_to_str,
+)
 
 
 def _find_widgets(op):
@@ -272,7 +275,7 @@ class Interactive:
         self._inherit_kwargs = inherit_kwargs
         self._max_rows = max_rows
         self._kwargs = kwargs
-        ds = hv.Dataset(self._transform_columnar_data(self._obj))
+        ds = hv.Dataset(_convert_col_names_to_str(self._obj))
         if _current is not None:
             self._current_ = _current
         else:
@@ -292,12 +295,6 @@ class Interactive:
             self._shared_obj = [obj]
         else:
             self._shared_obj[0] = obj
-
-    def _transform_columnar_data(self, data):
-        renamed = {c: str(c) for c in getattr(data, "columns", []) if not isinstance(c, str)}
-        if renamed:
-            data = data.rename(columns=renamed)
-        return data
 
     @property
     def _current(self):
@@ -688,7 +685,7 @@ class Interactive:
         """
         if self._dirty:
             obj = self._obj
-            ds = hv.Dataset(obj)
+            ds = hv.Dataset(_convert_col_names_to_str(obj))
             transform = self._transform
             if ds.interface.datatype == 'xarray' and is_xarray_dataarray(obj):
                 transform = transform.clone(obj.name)

--- a/hvplot/plotting/scatter_matrix.py
+++ b/hvplot/plotting/scatter_matrix.py
@@ -8,7 +8,7 @@ from packaging.version import Version
 
 from ..backend_transforms import _transfer_opts_cur_backend
 from ..converter import HoloViewsConverter
-from ..util import with_hv_extension
+from ..util import with_hv_extension, _convert_col_names_to_str
 
 
 @with_hv_extension
@@ -79,7 +79,7 @@ def scatter_matrix(data, c=None, chart='scatter', diagonal='hist',
         :func:`pandas.plotting.scatter_matrix` : Equivalent pandas function.
     """
 
-    data = _hv.Dataset(data)
+    data = _hv.Dataset(_convert_col_names_to_str(data))
     supported = list(HoloViewsConverter._kind_mapping)
     if diagonal not in supported:
         raise ValueError('diagonal type must be one of: %s, found %s' %

--- a/hvplot/tests/testinteractive.py
+++ b/hvplot/tests/testinteractive.py
@@ -1381,3 +1381,18 @@ def test_clones_dont_reexecute_transforms():
     df.interactive.pipe(piped, msg="1").pipe(piped, msg="2")
 
     assert len(msgs) == 3
+
+
+def test_interactive_accept_non_str_columnar_data():
+    df = pd.DataFrame(np.random.random((10, 2)))
+    assert all(not isinstance(col, str) for col in df.columns)
+    dfi = Interactive(df)
+
+    w = pn.widgets.FloatSlider(start=0, end=1, step=0.05)
+
+    # Column names converted as string so can no longer use dfi[1]
+    dfi = dfi['1'] + w.param.value
+
+    w.value = 0.5
+
+    pytest.approx(dfi.eval().sum(), (df[1] + 0.5).sum())

--- a/hvplot/tests/testutil.py
+++ b/hvplot/tests/testutil.py
@@ -9,7 +9,10 @@ import pytest
 
 from unittest import TestCase, SkipTest
 
-from hvplot.util import check_crs, is_list_like, process_crs, process_xarray
+from hvplot.util import (
+    check_crs, is_list_like, process_crs, process_xarray,
+    _convert_col_names_to_str,
+)
 
 
 class TestProcessXarray(TestCase):
@@ -314,3 +317,10 @@ def test_is_list_like():
     assert is_list_like(pd.Series(['a', 'b']))
     assert is_list_like(pd.Index(['a', 'b']))
     assert is_list_like(np.array(['a', 'b']))
+
+
+def test_convert_col_names_to_str():
+    df = pd.DataFrame(np.random.random((10, 2)))
+    assert all(not isinstance(col, str) for col in df.columns)
+    df = _convert_col_names_to_str(df)
+    assert all(isinstance(col, str) for col in df.columns)

--- a/hvplot/util.py
+++ b/hvplot/util.py
@@ -548,3 +548,14 @@ def _flatten(line):
             yield from _flatten(element)
         else:
             yield element
+
+
+def _convert_col_names_to_str(data):
+    """Convert column names to string.
+    """
+    if not hasattr(data, 'columns'):
+        return data
+    renamed = {c: str(c) for c in data.columns if not isinstance(c, str)}
+    if renamed:
+        data = data.rename(columns=renamed)
+    return data


### PR DESCRIPTION
In the next release of Holoviews 1.16, this will raise an error:

``` python
import hvplot.pandas
import pandas as pd

pd.DataFrame([1, 2, 3, 4]).interactive()
```

Fixes a known issue first shown here https://github.com/holoviz/hvplot/issues/918 and are related to https://github.com/holoviz/hvplot/pull/932.

Other places that use `hv.Dataset` are here. I don't know if they will error:
![image](https://user-images.githubusercontent.com/19758978/225430887-215d748b-3455-4eb0-b7f0-d361f9e8df96.png)
