### PR TITLE
Fix projection when xlim/ylim provided

### DIFF
--- a/hvplot/converter.py
+++ b/hvplot/converter.py
@@ -230,6 +230,9 @@ class HoloViewsConverter:
         Whether to project the data before plotting (adds initial
         overhead but avoids projecting data when plot is dynamically
         updated).
+    projection (default=None): str or Cartopy CRS
+        Coordinate reference system of the plot specified as Cartopy
+        CRS object or class name.
     tiles (default=False):
         Whether to overlay the plot on a tile source. Tiles sources
         can be selected by name or a tiles object or class can be passed,
@@ -255,7 +258,8 @@ class HoloViewsConverter:
     ]
 
     _geo_options = [
-        'geo', 'crs', 'features', 'project', 'coastline', 'tiles'
+        'geo', 'crs', 'features', 'project', 'coastline', 'tiles',
+        'projection', 'global_extents'
     ]
 
     _axis_options = [
@@ -393,7 +397,7 @@ class HoloViewsConverter:
         )
 
         self.dynamic = dynamic
-        self.geo = any([geo, crs, global_extent, projection, project, coastline, features])
+        self.geo = any([geo, crs, global_extent, projection, project, coastline, features, tiles])
         self.crs = self._process_crs(data, crs) if self.geo else None
         self.project = project
         self.coastline = coastline
@@ -434,13 +438,20 @@ class HoloViewsConverter:
                         "Projection must be defined as cartopy CRS or "
                         "one of the following CRS string:\n {}".format(all_crs))
 
-            proj_crs = projection or ccrs.GOOGLE_MERCATOR
-            if self.crs != proj_crs:
+            projection = projection or (ccrs.GOOGLE_MERCATOR if tiles else self.crs)
+            if tiles and projection != ccrs.GOOGLE_MERCATOR:
+                raise ValueError(
+                    "Tiles can only be used with output projection of "
+                    "`cartopy.crs.GOOGLE_MERCATOR`. To get rid of this error "
+                    "remove `projection=` or `tiles=`"
+                )
+
+            if self.crs != projection:
                 px0, py0, px1, py1 = ccrs.GOOGLE_MERCATOR.boundary.bounds
                 x0, x1 = xlim or (px0, px1)
                 y0, y1 = ylim or (py0, py1)
                 extents = (x0, y0, x1, y1)
-                x0, y0, x1, y1 = project_extents(extents, self.crs, proj_crs)
+                x0, y0, x1, y1 = project_extents(extents, self.crs, projection)
                 if xlim:
                     xlim = (x0, x1)
                 if ylim:

--- a/hvplot/tests/testgeo.py
+++ b/hvplot/tests/testgeo.py
@@ -107,6 +107,11 @@ class TestProjections(TestGeo):
         with self.assertRaisesRegex(ValueError, "Projection must be defined"):
             self.da.hvplot.image('x', 'y', projection='foo')
 
+    def test_plot_with_projection_raises_an_error_when_tiles_set(self):
+        da = self.da.copy()
+        with self.assertRaisesRegex(ValueError, "Tiles can only be used with output projection"):
+            da.hvplot.image('x', 'y', crs=self.crs, projection='Robinson', tiles=True)
+
 
 class TestGeoAnnotation(TestCase):
 


### PR DESCRIPTION
This closes #951, #738, #529 but I only have the test for #529 so far.

Here are the examples from #951. They all run with no errors

```python
import hvplot.pandas  # noqa
import cartopy.crs as ccrs

from bokeh.sampledata.airport_routes import airports

# Case 1: This example works
airports.hvplot.points('Longitude', 'Latitude', geo=True, color='red', alpha=0.2,
                       xlim=(-180, -30), ylim=(0, 72), tiles='ESRI')

# Case 2: xlim/ylim are not obeyed when the map tile is removed 
airports.hvplot.points('Longitude', 'Latitude', geo=True, color='red', alpha=0.2,
                       xlim=(-180, -30), ylim=(0, 72))

# Case 3: Setting ymin > 0 raises errors
# Change ymin from 0 to 10
airports.hvplot.points('Longitude', 'Latitude', geo=True, color='red', alpha=0.2,
                       xlim=(-180, -30), ylim=(10, 72))

# Case 4: Setting ymax < 0 also raises errors
airports.hvplot.points('Longitude', 'Latitude', geo=True, color='red', alpha=0.2,
                       xlim=(-180, -30), ylim=(-20, -5))

# Works if geo=False
airports.hvplot.points('Longitude', 'Latitude', geo=False, color='red', alpha=0.2,
                       xlim=(-180, -30), ylim=(10, 72))
```

Here is the MRE from #738. Runs with no error

```python
import numpy as np
import xarray as xr
import cartopy.crs as ccrs

import hvplot.xarray
import rioxarray

da = xr.DataArray(np.arange(1_000_000).reshape(1000,1000),
                  coords=dict(x=np.linspace(577200, 867600, 1000),
                              y=np.linspace(-1802100, -2036700, 1000))
                 )

da = da.rio.write_crs(32635)
crs = ccrs.epsg(32635)
da.hvplot(x="x", y="y", crs=crs, rasterize=True) 
```
