### PR TITLE
For geopandas, when passing a positional arg it is interpretted as `color`

### DIFF
--- a/hvplot/converter.py
+++ b/hvplot/converter.py
@@ -706,6 +706,10 @@ class HoloViewsConverter:
                     kind = 'polygons'
                 elif geom_type in ('LineString', 'LineRing', 'Line'):
                     kind = 'paths'
+            # if only one arg is provided, treat it like color
+            if x is not None and y is None:
+                kwds['color'] = kwds.pop('color', kwds.pop('c', x))
+                x = None
         elif isinstance(data, pd.DataFrame):
             datatype = 'pandas'
             self.data = data

--- a/hvplot/tests/testgeo.py
+++ b/hvplot/tests/testgeo.py
@@ -261,6 +261,13 @@ class TestGeoPandas(TestCase):
         assert points.kdims == ['x', 'y']
         assert points.vdims == ['index']
 
+    def test_points_hover_cols_positional_arg_sets_color(self):
+        points = self.cities.hvplot('name')
+        assert points.kdims == ['x', 'y']
+        assert points.vdims == ['name']
+        opts = hv.Store.lookup_options('bokeh', points, 'style').kwargs
+        assert opts['color'] == 'name'
+
     def test_points_hover_cols_with_c_set_to_name(self):
         points = self.cities.hvplot(c='name')
         assert points.kdims == ['x', 'y']


### PR DESCRIPTION
Closes #778 

```python
import geopandas as gpd
import hvplot.pandas

countries = gpd.read_file(gpd.datasets.get_path('naturalearth_lowres'))
countries.hvplot("continent")
```

![image](https://user-images.githubusercontent.com/4806877/230495272-b8344b16-a9c5-4f3b-929c-68eeea109152.png)
