### PR TITLE
Prepare for Param 2.0

### DIFF
--- a/hvplot/converter.py
+++ b/hvplot/converter.py
@@ -412,7 +412,7 @@ class HoloViewsConverter:
                                   'install -c pyviz geoviews')
         if self.geo:
             if self.kind not in self._geo_types:
-                param.main.warning(
+                param.main.param.warning(
                     "geo option cannot be used with kind=%r plot "
                     "type. Geographic plots are only supported for "
                     "following plot types: %r" % (self.kind, self._geo_types))
@@ -606,7 +606,7 @@ class HoloViewsConverter:
         if debug:
             kwds = dict(x=self.x, y=self.y, by=self.by, kind=self.kind,
                         groupby=self.groupby, grid=self.grid)
-            param.main.warning('Plotting {kind} plot with parameters x: {x}, '
+            param.main.param.warning('Plotting {kind} plot with parameters x: {x}, '
                                'y: {y}, by: {by}, groupby: {groupby}, row/col: {grid}'.format(**kwds))
 
     def _process_symmetric(self, symmetric, clim, check_symmetric_max):

--- a/hvplot/plotting/core.py
+++ b/hvplot/plotting/core.py
@@ -113,7 +113,7 @@ class hvPlotBase:
         if name in plots:
             plot_opts = plots[name]
             if "kind" in plot_opts and name in HoloViewsConverter._kind_mapping:
-                param.main.warning(
+                param.main.param.warning(
                     "Custom options for existing plot types should not "
                     "declare the 'kind' argument. The .%s plot method "
                     "was unexpectedly customized with kind=%r." % (plot_opts["kind"], name)

--- a/hvplot/tests/testinteractive.py
+++ b/hvplot/tests/testinteractive.py
@@ -665,7 +665,7 @@ def test_interactive_pandas_frame_bind_out_widgets(df):
 
 
 def test_interactive_pandas_frame_bind_operator_out_widgets(df):
-    select = pn.widgets.Select(default='A', options=list(df.columns))
+    select = pn.widgets.Select(value='A', options=list(df.columns))
 
     def sel_col(col):
         return df[col]


### PR DESCRIPTION
Simon spotted one test that would failed with https://github.com/holoviz/param/pull/729, this PR fixes it.

I've also fixed some usages of Param's warning, that would break on Param 2.0.