### PR TITLE
Cancel concurrent test workflows

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '0 15 * * SUN'
-    
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,6 +9,10 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '0 15 * * SUN'
+    
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   pre_commit:


### PR DESCRIPTION
Cancel concurrent jobs to avoid bogging down CI across the holoviz org.