### PR TITLE
Do not force geo=True if tiles are provided

### DIFF
--- a/hvplot/converter.py
+++ b/hvplot/converter.py
@@ -397,7 +397,7 @@ class HoloViewsConverter:
         )
 
         self.dynamic = dynamic
-        self.geo = any([geo, crs, global_extent, projection, project, coastline, features, tiles])
+        self.geo = any([geo, crs, global_extent, projection, project, coastline, features])
         self.crs = self._process_crs(data, crs) if self.geo else None
         self.project = project
         self.coastline = coastline


### PR DESCRIPTION
https://github.com/holoviz/hvplot/pull/1053 forced `geo=True` if tiles were provided. This is not intended as you can use tiles provided by HoloViews and now no longer can.