### PR TITLE
Add simple polars support

### DIFF
--- a/doc/index.md
+++ b/doc/index.md
@@ -86,6 +86,20 @@ alt: Works with Dask
 align: center
 ---
 :::
+:::{tab-item} Polars
+```python
+import polars
+import hvplot.polars
+
+df_polars = polars.from_pandas(df)
+df_polars.hvplot.scatter(x='bill_length_mm', y='bill_depth_mm', by='species')
+```
+```{image} ./_static/home/dask.gif
+---
+alt: Works with Polars
+align: center
+---
+:::
 
 :::{tab-item} GeoPandas
 ```python

--- a/doc/index.md
+++ b/doc/index.md
@@ -86,20 +86,6 @@ alt: Works with Dask
 align: center
 ---
 :::
-:::{tab-item} Polars
-```python
-import polars
-import hvplot.polars
-
-df_polars = polars.from_pandas(df)
-df_polars.hvplot.scatter(x='bill_length_mm', y='bill_depth_mm', by='species')
-```
-```{image} ./_static/home/dask.gif
----
-alt: Works with Polars
-align: center
----
-:::
 
 :::{tab-item} GeoPandas
 ```python
@@ -112,6 +98,20 @@ gdf.hvplot(global_extent=True, tiles=True)
 ```{image} ./_static/home/geopandas.gif
 ---
 alt: Works with GeoPandas
+align: center
+---
+:::
+:::{tab-item} Polars
+```python
+import polars
+import hvplot.polars
+
+df_polars = polars.from_pandas(df)
+df_polars.hvplot.scatter(x='bill_length_mm', y='bill_depth_mm', by='species')
+```
+```{image} ./_static/home/dask.gif
+---
+alt: Works with Polars
 align: center
 ---
 :::

--- a/examples/user_guide/Introduction.ipynb
+++ b/examples/user_guide/Introduction.ipynb
@@ -8,6 +8,7 @@
     "\n",
     "* [Pandas](https://pandas.pydata.org): DataFrame, Series (columnar/tabular data)\n",
     "* [Rapids cuDF](https://docs.rapids.ai/api/cudf/stable/): GPU DataFrame, Series (columnar/tabular data)\n",
+    "* [Polars](https://www.pola.rs/): Polars is a fast DataFrame library/in-memory query engine (columnar/tabular data)\n",
     "* [Dask](https://www.dask.org): DataFrame, Series (distributed/out of core arrays and columnar data)\n",
     "* [XArray](https://xarray.pydata.org): Dataset, DataArray (labelled multidimensional arrays)\n",
     "* [Streamz](https://streamz.readthedocs.io): DataFrame(s), Series(s) (streaming columnar data)\n",

--- a/hvplot/polars.py
+++ b/hvplot/polars.py
@@ -56,8 +56,6 @@ class hvPlotTabularPolars(hvPlotTabular):
 
 
 def patch(name="hvplot", extension="bokeh", logo=False):
-    import hvplot.pandas  # noqa
-
     post_patch(extension, logo)
 
 

--- a/hvplot/polars.py
+++ b/hvplot/polars.py
@@ -23,16 +23,19 @@ class hvPlotTabularPolars(hvPlotTabular):
 
         # Find columns which should be converted for LazyDataFrame and DataFrame
         if isinstance(self._data, (pl.LazyFrame, pl.DataFrame)):
-            possible_columns = [
-                [v] if isinstance(v, str) else v
-                for v in params.values()
-                if isinstance(v, (str, list))
-            ]
-            columns = (
-                set(self._data.columns) & set(itertools.chain(*possible_columns))
-            ) or {self._data.columns[0]}
-            columns |= {x, y}
-            columns.discard(None)
+            if params.get("hover_cols") == "all":
+                columns = list(self._data.columns)
+            else:
+                possible_columns = [
+                    [v] if isinstance(v, str) else v
+                    for v in params.values()
+                    if isinstance(v, (str, list))
+                ]
+                columns = (
+                    set(self._data.columns) & set(itertools.chain(*possible_columns))
+                ) or {self._data.columns[0]}
+                columns |= {x, y}
+                columns.discard(None)
 
         if isinstance(self._data, pl.DataFrame):
             data = self._data.select(columns).to_pandas()

--- a/hvplot/polars.py
+++ b/hvplot/polars.py
@@ -5,16 +5,11 @@ from hvplot import hvPlotTabular, post_patch
 from hvplot.converter import HoloViewsConverter
 from hvplot.util import is_list_like
 
-try:
-    import polars as pl
-except:
-    raise ImportError(
-        "Could not patch plotting API onto Polars. Polars could not be imported."
-    )
-
 
 class hvPlotTabularPolars(hvPlotTabular):
     def _get_converter(self, x=None, y=None, kind=None, **kwds):
+        import polars as pl
+
         params = dict(self._metadata, **kwds)
         x = x or params.pop("x", None)
         y = y or params.pop("y", None)
@@ -53,6 +48,12 @@ class hvPlotTabularPolars(hvPlotTabular):
 
 
 def patch(name="hvplot", extension="bokeh", logo=False):
+    try:
+        import polars as pl
+    except:
+        raise ImportError(
+            "Could not patch plotting API onto Polars. Polars could not be imported."
+        )
     pl.api.register_dataframe_namespace(name)(hvPlotTabularPolars)
     pl.api.register_series_namespace(name)(hvPlotTabularPolars)
     pl.api.register_lazyframe_namespace(name)(hvPlotTabularPolars)

--- a/hvplot/polars.py
+++ b/hvplot/polars.py
@@ -1,0 +1,57 @@
+import itertools
+
+from hvplot import hvPlotTabular, post_patch
+from hvplot.converter import HoloViewsConverter
+
+try:
+    import polars as pl
+except:
+    raise ImportError(
+        "Could not patch plotting API onto Polars. Polars could not be imported."
+    )
+
+
+@pl.api.register_dataframe_namespace("hvplot")
+@pl.api.register_series_namespace("hvplot")
+@pl.api.register_lazyframe_namespace("hvplot")
+class hvPlotTabularPolars(hvPlotTabular):
+    def _get_converter(self, x=None, y=None, kind=None, **kwds):
+        params = dict(self._metadata, **kwds)
+        x = x or params.pop("x", None)
+        y = y or params.pop("y", None)
+        kind = kind or params.pop("kind", None)
+
+        # Find columns which should be converted for LazyDataFrame and DataFrame
+        if isinstance(self._data, (pl.LazyFrame, pl.DataFrame)):
+            possible_columns = [
+                [v] if isinstance(v, str) else v
+                for v in params.values()
+                if isinstance(v, (str, list))
+            ]
+            columns = (
+                set(self._data.columns) & set(itertools.chain(*possible_columns))
+            ) or {self._data.columns[0]}
+            columns |= {x, y}
+            columns.discard(None)
+
+        if isinstance(self._data, pl.DataFrame):
+            data = self._data.select(columns).to_pandas()
+        elif isinstance(self._data, pl.Series):
+            data = self._data.to_pandas()
+        elif isinstance(self._data, pl.LazyFrame):
+            data = self._data.select(columns).collect().to_pandas()
+        else:
+            raise ValueError(
+                "Only Polars DataFrame, Series, and LazyFrame are supported"
+            )
+
+        return HoloViewsConverter(data, x, y, kind=kind, **params)
+
+
+def patch(name="hvplot", extension="bokeh", logo=False):
+    import hvplot.pandas  # noqa
+
+    post_patch(extension, logo)
+
+
+patch()

--- a/hvplot/polars.py
+++ b/hvplot/polars.py
@@ -1,3 +1,4 @@
+"""Adds the `.hvplot` method to pl.DataFrame, pl.LazyFrame and pl.Series"""
 import itertools
 
 from hvplot import hvPlotTabular, post_patch

--- a/hvplot/polars.py
+++ b/hvplot/polars.py
@@ -2,6 +2,7 @@ import itertools
 
 from hvplot import hvPlotTabular, post_patch
 from hvplot.converter import HoloViewsConverter
+from hvplot.util import is_list_like
 
 try:
     import polars as pl
@@ -34,7 +35,9 @@ class hvPlotTabularPolars(hvPlotTabular):
                 columns = (
                     set(self._data.columns) & set(itertools.chain(*possible_columns))
                 ) or {self._data.columns[0]}
-                columns |= {x, y}
+                xs = x if is_list_like(x) else (x,)
+                ys = y if is_list_like(y) else (y,)
+                columns |= {*xs, *ys}
                 columns.discard(None)
 
         if isinstance(self._data, pl.DataFrame):

--- a/hvplot/polars.py
+++ b/hvplot/polars.py
@@ -13,9 +13,6 @@ except:
     )
 
 
-@pl.api.register_dataframe_namespace("hvplot")
-@pl.api.register_series_namespace("hvplot")
-@pl.api.register_lazyframe_namespace("hvplot")
 class hvPlotTabularPolars(hvPlotTabular):
     def _get_converter(self, x=None, y=None, kind=None, **kwds):
         params = dict(self._metadata, **kwds)
@@ -56,6 +53,10 @@ class hvPlotTabularPolars(hvPlotTabular):
 
 
 def patch(name="hvplot", extension="bokeh", logo=False):
+    pl.api.register_dataframe_namespace(name)(hvPlotTabularPolars)
+    pl.api.register_series_namespace(name)(hvPlotTabularPolars)
+    pl.api.register_lazyframe_namespace(name)(hvPlotTabularPolars)
+
     post_patch(extension, logo)
 
 

--- a/hvplot/tests/plotting/testcore.py
+++ b/hvplot/tests/plotting/testcore.py
@@ -4,18 +4,63 @@ import hvplot.pandas  # noqa
 
 import pytest
 
-@pytest.mark.parametrize("y", (
+try:
+    import polars as pl
+    import hvplot.polars  # noqa
+except ImportError:
+    pl = None
+
+
+FRAME_IGNORE_TYPES = {"bivariate", "heatmap", "hexbin", "labels", "vectorfield"}
+SERIES_IGNORE_TYPES = {*FRAME_IGNORE_TYPES, "points", "polygons", "ohlc", "paths"}
+
+y_combinations = pytest.mark.parametrize("y", (
     ["A", "B", "C", "D"],
     ("A", "B", "C", "D"),
     {"A", "B", "C", "D"},
     np.array(["A", "B", "C", "D"]),
     pd.Index(["A", "B", "C", "D"]),
     pd.Series(["A", "B", "C", "D"]),
-    ))
-def test_diffent_input_types(y):
+    ),
+    ids=lambda x: type(x).__name__
+)
+
+@y_combinations
+def test_diffent_input_types_pandas(y):
     df = pd._testing.makeDataFrame()
     types = {t for t in dir(df.hvplot) if not t.startswith("_")}
-    ignore_types = {'bivariate', 'heatmap', 'hexbin', 'labels', 'vectorfield'}
 
-    for t in types - ignore_types:
+    for t in types - FRAME_IGNORE_TYPES:
         df.hvplot(y=y, kind=t)
+
+
+def test_series_pandas():
+    ser = pd.Series(np.random.rand(10), name="A")
+    assert isinstance(ser, pd.Series)
+
+    types = {t for t in dir(ser.hvplot) if not t.startswith("_")}
+    for t in types - SERIES_IGNORE_TYPES:
+        ser.hvplot(kind=t)
+
+
+
+@pytest.mark.skipif(pl is None, reason="polars not installed")
+@pytest.mark.parametrize("cast", (pl.DataFrame, pl.LazyFrame))
+@y_combinations
+def test_diffent_input_types_polars(y, cast):
+    df = cast(pd._testing.makeDataFrame())
+    assert isinstance(df, cast)
+
+    types = {t for t in dir(df.hvplot) if not t.startswith("_")}
+    for t in types - FRAME_IGNORE_TYPES:
+        df.hvplot(y=y, kind=t)
+
+
+@pytest.mark.skipif(pl is None, reason="polars not installed")
+def test_series_polars():
+    ser = pl.Series(values=np.random.rand(10), name="A")
+    assert isinstance(ser, pl.Series)
+
+    types = {t for t in dir(ser.hvplot) if not t.startswith("_")}
+    for t in types - SERIES_IGNORE_TYPES:
+        ser.hvplot(kind=t)

--- a/hvplot/tests/plotting/testcore.py
+++ b/hvplot/tests/plotting/testcore.py
@@ -7,8 +7,13 @@ import pytest
 try:
     import polars as pl
     import hvplot.polars  # noqa
+    skip_polar = False
 except ImportError:
-    pl = None
+    class pl:
+        DataFrame = None
+        LazyFrame = None
+        Series = None
+    skip_polar = True
 
 
 FRAME_IGNORE_TYPES = {"bivariate", "heatmap", "hexbin", "labels", "vectorfield"}
@@ -44,7 +49,7 @@ def test_series_pandas():
 
 
 
-@pytest.mark.skipif(pl is None, reason="polars not installed")
+@pytest.mark.skipif(skip_polar, reason="polars not installed")
 @pytest.mark.parametrize("cast", (pl.DataFrame, pl.LazyFrame))
 @y_combinations
 def test_diffent_input_types_polars(y, cast):
@@ -56,7 +61,7 @@ def test_diffent_input_types_polars(y, cast):
         df.hvplot(y=y, kind=t)
 
 
-@pytest.mark.skipif(pl is None, reason="polars not installed")
+@pytest.mark.skipif(skip_polar, reason="polars not installed")
 def test_series_polars():
     ser = pl.Series(values=np.random.rand(10), name="A")
     assert isinstance(ser, pl.Series)

--- a/hvplot/tests/testpatch.py
+++ b/hvplot/tests/testpatch.py
@@ -100,3 +100,28 @@ class TestPatchStreamz(TestCase):
         from streamz.dataframe import Random
         random_df = Random()
         self.assertIsInstance(random_df.groupby('x').sum().y.hvplot, hvPlotTabular)
+
+
+class TestPatchPolars(TestCase):
+
+    def setUp(self):
+        try:
+            import polars as pl # noqa
+        except:
+            raise SkipTest('Polars not available')
+        import hvplot.polars   # noqa
+
+    def test_polars_series_patched(self):
+        import polars as pl
+        pseries = pl.Series([0, 1, 2])
+        self.assertIsInstance(pseries.hvplot, hvPlotTabular)
+
+    def test_polars_dataframe_patched(self):
+        import polars as pl
+        pdf = pl.DataFrame({'x': [1, 3, 5], 'y': [2, 4, 6]})
+        self.assertIsInstance(pdf.hvplot, hvPlotTabular)
+
+    def test_polars_lazyframe_patched(self):
+        import polars as pl
+        pldf = pl.LazyFrame({'x': [1, 3, 5], 'y': [2, 4, 6]})
+        self.assertIsInstance(pldf.hvplot, hvPlotTabular)

--- a/setup.py
+++ b/setup.py
@@ -60,6 +60,7 @@ extras_require['tests'] = [
     'pooch',
     'scipy',
     'ipywidgets',
+    'polars',
 ]
 
 # Dependencies required to run the notebooks


### PR DESCRIPTION
resolves https://github.com/holoviz/hvplot/issues/1023

This adds a simple Polars support to hvplot by converting it to a Pandas DataFrame before putting it into the machinery of hvplot. I'm trying to convert only the necessary columns for the  DataFrame and LazyDataFrame. 

Using the API as described [here](https://pola-rs.github.io/polars/py-polars/html/reference/api.html).

``` python
import hvplot.polars  # noqa
import polars as pl
from bokeh.sampledata.autompg import autompg

df = pl.DataFrame(autompg)
s = df.select("mpg").to_series()
ldf = df.lazy()

type(df), type(s), type(ldf)

df.hvplot(y="cyl")
s.hvplot()
ldf.hvplot.scatter()
```

![image](https://github.com/holoviz/hvplot/assets/19758978/ab3d03bc-b9e2-41ec-96b2-aab6ed73d729)
