### PR TITLE
Support plots that use `by` with `rasterize` with hv.ImageStack

### DIFF
--- a/hvplot/converter.py
+++ b/hvplot/converter.py
@@ -1330,7 +1330,7 @@ class HoloViewsConverter:
                 opts['rescale_discrete_levels'] = self._plot_opts['rescale_discrete_levels']
         else:
             operation = rasterize
-            if hv.__version__ < '1.18.0':
+            if Version(hv.__version__) < Version('1.18.0a1'):
                 eltype = 'Image'
             else:
                 eltype = 'ImageStack' if self.by else 'Image'

--- a/hvplot/converter.py
+++ b/hvplot/converter.py
@@ -468,10 +468,7 @@ class HoloViewsConverter:
 
         # By type
         self.subplots = subplots
-        if subplots:
-            self._by_type = NdLayout
-        else:
-            self._by_type = NdOverlay
+        self._by_type = NdLayout if subplots else NdOverlay
 
         self._backend = Store.current_backend
         if hvplot_extension.compatibility is None:
@@ -1338,7 +1335,6 @@ class HoloViewsConverter:
                 style['cmap'] = self._style_opts['cmap']
             if self._dim_ranges.get('c', (None, None)) != (None, None):
                 style['clim'] = self._dim_ranges['c']
-            print(style)
 
         processed = operation(obj, **opts)
 
@@ -1514,12 +1510,10 @@ class HoloViewsConverter:
         cur_opts = {
             element.name: cur_el_opts,
             'NdOverlay': filter_opts('NdOverlay', dict(self._overlay_opts, batched=False), backend='bokeh'),
-            'ImageStack': filter_opts('ImageStack', dict(self._overlay_opts, batched=False), backend='bokeh'),
         }
         compat_opts = {
             element.name: compat_el_opts,
             'NdOverlay': filter_opts('NdOverlay', dict(self._overlay_opts), backend=self._backend_compat),
-            'ImageStack': filter_opts('ImageStack', dict(self._overlay_opts), backend=self._backend_compat),
         }
 
         ys = [y]
@@ -1543,7 +1537,6 @@ class HoloViewsConverter:
             chart = Dataset(data, self.by+kdims, vdims).to(
                 element, kdims, vdims, self.by).relabel(**self._relabel)
             chart = chart.layout() if self.subplots else chart.overlay(sort=False)
-            print(type(chart), "PROBLEM ABOVE ^^^")
         else:
             chart = element(data, kdims, vdims).relabel(**self._relabel)
         return (chart.redim(**self._redim)

--- a/hvplot/converter.py
+++ b/hvplot/converter.py
@@ -1330,7 +1330,10 @@ class HoloViewsConverter:
                 opts['rescale_discrete_levels'] = self._plot_opts['rescale_discrete_levels']
         else:
             operation = rasterize
-            eltype = 'ImageStack' if self.by else 'Image'
+            if hv.__version__ < '1.18.0':
+                eltype = 'Image'
+            else:
+                eltype = 'ImageStack' if self.by else 'Image'
             if 'cmap' in self._style_opts:
                 style['cmap'] = self._style_opts['cmap']
             if self._dim_ranges.get('c', (None, None)) != (None, None):

--- a/hvplot/converter.py
+++ b/hvplot/converter.py
@@ -582,7 +582,7 @@ class HoloViewsConverter:
                     symmetric = self._process_symmetric(symmetric, clim, check_symmetric_max)
                 if self._style_opts.get('cmap') is None:
                     # Default to categorical camp if we detect categorical shading
-                    if (self.datashade and (self.aggregator is None or 'count_cat' in str(self.aggregator)) and
+                    if ((self.datashade or self.rasterize) and (self.aggregator is None or 'count_cat' in str(self.aggregator)) and
                         ((self.by and not self.subplots) or
                          (isinstance(self.y, list) or (self.y is None and len(set(self.variables) - set(self.indexes)) > 1)))):
                         self._style_opts['cmap'] = self._default_cmaps['categorical']

--- a/hvplot/tests/testoperations.py
+++ b/hvplot/tests/testoperations.py
@@ -3,12 +3,13 @@ import sys
 from unittest import SkipTest
 from parameterized import parameterized
 
+import colorcet as cc
 import hvplot.pandas  # noqa
 import numpy as np
 import pandas as pd
 
 from holoviews import Store
-from holoviews.element import Image, QuadMesh
+from holoviews.element import Image, QuadMesh, ImageStack
 from holoviews.element.comparison import ComparisonTestCase
 from hvplot.converter import HoloViewsConverter
 
@@ -194,6 +195,11 @@ class TestDatashader(ComparisonTestCase):
         actual = plot.callback.inputs[0].callback.operation.p['rescale_discrete_levels']
         assert actual is expected
 
+    def test_rasterize_by(self):
+        expected = 'category'
+        plot = self.df.hvplot(x='x', y='y', by=expected, rasterize=True, dynamic=False)
+        assert isinstance(plot, ImageStack)
+        assert plot.opts["cmap"] == cc.palette['glasbey_category10']
 
 class TestChart2D(ComparisonTestCase):
 


### PR DESCRIPTION
Alongside https://github.com/holoviz/holoviews/pull/5751
```python
import pandas as pd
import hvplot.pandas
import holoviews as hv
hv.extension('bokeh')

df = pd.DataFrame(
    {
        "time": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
        "value": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
        "by": ["d", "d", "d", "a", "a", "b", "b", "b", "b", "b"],
    }
)

df.hvplot(
    x="time",
    y="value",
    by="by",
    rasterize=True,
    color_key="RdBu_r"
)

```

<img width="352" alt="image" src="https://github.com/holoviz/hvplot/assets/15331990/f64e45cd-8367-4a69-90a9-da8ef91de831">

colorbar is not yet supported in HoloViews.