### PR TITLE
Use dynspread=True by default for explorer if datashade/rasterize

### DIFF
--- a/hvplot/ui.py
+++ b/hvplot/ui.py
@@ -288,7 +288,7 @@ class Operations(Controls):
     aggregator = param.Selector(default=None, objects=AGGREGATORS, doc="""
         Aggregator to use when applying rasterize or datashade operation.""")
 
-    dynspread = param.Boolean(default=False, doc="""
+    dynspread = param.Boolean(default=True, doc="""
         Allows plots generated with datashade=True or rasterize=True
         to increase the point size to make sparse regions more visible.""")
 


### PR DESCRIPTION
I think it's more user friendly if dynspread is True, or else can barely see anything:
<img width="1056" alt="image" src="https://github.com/holoviz/hvplot/assets/15331990/28636b98-bfd2-4f7e-9ba1-740c3465f85a">

With dynspread=True:
<img width="1031" alt="image" src="https://github.com/holoviz/hvplot/assets/15331990/4d6f70b9-6ccd-456d-b747-23f021825ca7">

