### PR TITLE
Add tests for `downsample`

### DIFF
--- a/examples/user_guide/Timeseries_Data.ipynb
+++ b/examples/user_guide/Timeseries_Data.ipynb
@@ -189,6 +189,9 @@
    "metadata": {},
    "source": [
     "### Downsample time series\n",
+    "\n",
+    "*(Available with HoloViews >= 1.16)*\n",
+    "\n",
     "An option when working with large time series is to downsample the data before plotting it. This can be done with `downsample=True`, which applies the `lttb` (Largest Triangle Three Buckets) algorithm to the data."
    ]
   },

--- a/hvplot/converter.py
+++ b/hvplot/converter.py
@@ -203,7 +203,7 @@ class HoloViewsConverter:
     downsample (default=False):
         Whether to apply LTTB (Largest Triangle Three Buckets)
         downsampling to the element (note this is only well behaved for
-        timeseries data).
+        timeseries data). Requires HoloViews >= 1.16.
     dynspread (default=False):
         For plots generated with datashade=True or rasterize=True,
         automatically increase the point size when the data is sparse

--- a/hvplot/converter.py
+++ b/hvplot/converter.py
@@ -1279,7 +1279,10 @@ class HoloViewsConverter:
             opts['height'] = self._plot_opts['height']
 
         if self.downsample:
-            from holoviews.operation.downsample import downsample1d
+            try:
+                from holoviews.operation.downsample import downsample1d
+            except ImportError:
+                raise ImportError('Downsampling requires HoloViews >=1.16')
 
             if self.x_sampling:
                 opts['x_sampling'] = self.x_sampling

--- a/hvplot/tests/testoperations.py
+++ b/hvplot/tests/testoperations.py
@@ -235,3 +235,24 @@ class TestChart2D(ComparisonTestCase):
                               x_sampling=5, y_sampling=2)
         assert all(plot.data.x.diff('x').round(0) == 5)
         assert all(plot.data.y.diff('y').round(0) == 2)
+
+
+class TestDownsample(ComparisonTestCase):
+    def setUp(self):
+        import hvplot.pandas # noqa
+        self.df = pd.DataFrame(np.random.random(100))
+
+    def test_downsample_default(self):
+        from holoviews.operation.downsample import downsample1d
+
+        plot = self.df.hvplot.line(downsample=True)
+
+        assert isinstance(plot.callback.operation, downsample1d)
+
+    def test_downsample_opts(self):
+        plot = self.df.hvplot.line(downsample=True, width=100, height=50, x_sampling=5, xlim=(0, 5))
+
+        assert plot.callback.operation.p.width == 100
+        assert plot.callback.operation.p.height == 50
+        assert plot.callback.operation.p.x_sampling == 5
+        assert plot.callback.operation.p.x_range == (0, 5)


### PR DESCRIPTION
Follow-up of https://github.com/holoviz/hvplot/pull/1127 with some tests and indicating that downsampling is available only if HoloViews >= 1.16 is installed.