### PR TITLE
Improve `autorange` docs

### DIFF
--- a/examples/user_guide/Timeseries_Data.ipynb
+++ b/examples/user_guide/Timeseries_Data.ipynb
@@ -15,6 +15,7 @@
    "source": [
     "import hvplot.pandas  # noqa\n",
     "from bokeh.sampledata.sea_surface_temperature import sea_surface_temperature as sst\n",
+    "\n",
     "sst.hvplot()"
    ]
   },
@@ -60,8 +61,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Auto range\n",
-    "Automatic auto-ranging on the data in x or y is supported, making it easy to scale the given axes and fit the entire visible curve after a zoom or pan."
+    "### Auto-range\n",
+    "\n",
+    "*(Available with HoloViews >= 1.16)*\n",
+    "\n",
+    "Automatic ranging, aka auto-ranging, on the data in x or y is supported, making it easy to scale the given axes and fit the entire visible curve after a zoom or pan. Try zooming in on the plot and panning around, the y range nicely adapt to fit the curve. "
    ]
   },
   {

--- a/hvplot/converter.py
+++ b/hvplot/converter.py
@@ -86,7 +86,7 @@ class HoloViewsConverter:
     ---------------
     autorange (default=None): Literal['x', 'y'] | None
         Whether to enable auto-ranging along the x- or y-axis when
-        zooming.
+        zooming. Requires HoloViews >= 1.16.
     clim: tuple
         Lower and upper bound of the color scale
     cnorm (default='linear'): str
@@ -494,7 +494,10 @@ class HoloViewsConverter:
         if ylim is not None:
             plot_opts['ylim'] = tuple(ylim)
 
-        plot_opts['autorange'] = autorange
+        if autorange is not None and hv_version < Version('1.16.0'):
+            param.main.param.warning('autorange option requires HoloViews >= 1.16')
+        else:
+            plot_opts['autorange'] = autorange
 
         self.invert = invert
         if loglog is not None:


### PR DESCRIPTION
Follow-up on https://github.com/holoviz/hvplot/pull/1128 with minor docs improvements, indications that HoloViews >= 1.16 is required and handling of `autorange` when older versions are used with a warning.