### PR TITLE
Add support for opts in explorer (v2)

### DIFF
--- a/hvplot/tests/testui.py
+++ b/hvplot/tests/testui.py
@@ -289,8 +289,7 @@ def test_explorer_code_dataframe():
 
 
 def test_explorer_code_gridded():
-    ds = xr.tutorial.open_dataset('air_temperature')
-    explorer = hvplot.explorer(ds, x='lon', y='lat', kind='image')
+    explorer = hvplot.explorer(ds_air_temperature, x='lon', y='lat', kind='image')
     code = explorer.code
     assert code == dedent("""\
         ds['air'].hvplot(
@@ -315,8 +314,8 @@ def test_explorer_code_gridded():
 
 
 def test_explorer_code_gridded_dataarray():
-    ds = xr.tutorial.open_dataset('air_temperature')['air']
-    explorer = hvplot.explorer(ds, x='lon', y='lat', kind='image')
+    da = ds_air_temperature['air']
+    explorer = hvplot.explorer(da, x='lon', y='lat', kind='image')
     code = explorer.code
     assert code == dedent("""\
         da.hvplot(
@@ -335,6 +334,36 @@ def test_explorer_code_gridded_dataarray():
             kind='image',
             x='lon',
             y='lat'
+        )
+        ```"""
+    )
+
+
+def test_explorer_code_opts():
+    da = ds_air_temperature["air"]
+    explorer = hvplot.explorer(da, x="lon", y="lat", kind="image", opts={"color_levels": 3})
+    code = explorer.code
+    assert code == dedent("""\
+        da.hvplot(
+            colorbar=True,
+            groupby=['time'],
+            kind='image',
+            x='lon',
+            y='lat'
+        ).opts(
+            color_levels=3
+        )""")
+
+    assert explorer._code_pane.object == dedent("""\
+        ```python
+        da.hvplot(
+            colorbar=True,
+            groupby=['time'],
+            kind='image',
+            x='lon',
+            y='lat'
+        ).opts(
+            color_levels=3
         )
         ```"""
     )

--- a/hvplot/tests/testui.py
+++ b/hvplot/tests/testui.py
@@ -63,7 +63,7 @@ def test_explorer_plot_code():
             "    by=['species'],\n"
             "    kind='scatter',\n"
             "    x='bill_length_mm',\n"
-            "    y=['bill_depth_mm']\n"
+            "    y=['bill_depth_mm'],\n"
             ")"
         )
     )
@@ -76,7 +76,7 @@ def test_explorer_plot_code():
             "    by=['species'],\n"
             "    kind='scatter',\n"
             "    x='bill_length_mm',\n"
-            "    y=['bill_depth_mm']\n"
+            "    y=['bill_depth_mm'],\n"
             ")"
         )
     )
@@ -274,7 +274,7 @@ def test_explorer_code_dataframe():
         df.hvplot(
             kind='points',
             x='bill_length_mm',
-            y='species'
+            y='species',
         )"""
     )
     assert explorer._code_pane.object == dedent("""\
@@ -282,7 +282,7 @@ def test_explorer_code_dataframe():
         df.hvplot(
             kind='points',
             x='bill_length_mm',
-            y='species'
+            y='species',
         )
         ```"""
     )
@@ -297,7 +297,7 @@ def test_explorer_code_gridded():
             groupby=['time'],
             kind='image',
             x='lon',
-            y='lat'
+            y='lat',
         )""")
 
     assert explorer._code_pane.object == dedent("""\
@@ -307,7 +307,7 @@ def test_explorer_code_gridded():
             groupby=['time'],
             kind='image',
             x='lon',
-            y='lat'
+            y='lat',
         )
         ```"""
     )
@@ -323,7 +323,7 @@ def test_explorer_code_gridded_dataarray():
             groupby=['time'],
             kind='image',
             x='lon',
-            y='lat'
+            y='lat',
         )""")
 
     assert explorer._code_pane.object == dedent("""\
@@ -333,15 +333,15 @@ def test_explorer_code_gridded_dataarray():
             groupby=['time'],
             kind='image',
             x='lon',
-            y='lat'
+            y='lat',
         )
         ```"""
     )
 
 
 def test_explorer_code_opts():
-    da = ds_air_temperature["air"]
-    explorer = hvplot.explorer(da, x="lon", y="lat", kind="image", opts={"color_levels": 3})
+    da = ds_air_temperature['air']
+    explorer = hvplot.explorer(da, x='lon', y='lat', kind='image', opts={'color_levels': 3})
     code = explorer.code
     assert code == dedent("""\
         da.hvplot(
@@ -349,9 +349,9 @@ def test_explorer_code_opts():
             groupby=['time'],
             kind='image',
             x='lon',
-            y='lat'
+            y='lat',
         ).opts(
-            color_levels=3
+            color_levels=3,
         )""")
 
     assert explorer._code_pane.object == dedent("""\
@@ -361,9 +361,9 @@ def test_explorer_code_opts():
             groupby=['time'],
             kind='image',
             x='lon',
-            y='lat'
+            y='lat',
         ).opts(
-            color_levels=3
+            color_levels=3,
         )
         ```"""
     )

--- a/hvplot/tests/testui.py
+++ b/hvplot/tests/testui.py
@@ -217,9 +217,11 @@ def test_explorer_live_update_after_init():
     explorer.statusbar.live_update = False
     explorer.kind = 'line'
     assert explorer._hv_pane.object.type is hv.Scatter
+    assert 'line' not in explorer.code
 
     explorer.statusbar.live_update = True
     assert explorer._hv_pane.object.type is hv.Curve
+    assert 'line' in explorer.code
 
 
 def test_explorer_method_dataframe():

--- a/hvplot/ui.py
+++ b/hvplot/ui.py
@@ -672,7 +672,7 @@ class hvPlotExplorer(Viewer):
         if kwargs:
             for k, v in kwargs.items():
                 args += f'    {k}={v!r},\n'
-            args = args[:-2]
+            args = args[:-1]
         return args
 
     def save(self, filename, **kwargs):

--- a/hvplot/ui.py
+++ b/hvplot/ui.py
@@ -522,8 +522,6 @@ class hvPlotExplorer(Viewer):
                     setattr(self, pname, p.objects[0])
 
     def _plot(self, *events):
-        if not self.statusbar.live_update:
-            return
         y = self.y_multi if 'y_multi' in self._controls.parameters else self.y
         if isinstance(y, list) and len(y) == 1:
             y = y[0]
@@ -572,6 +570,8 @@ class hvPlotExplorer(Viewer):
             self._layout.loading = False
 
     def _refresh(self, *events):
+        if not self.statusbar.live_update:
+            return
         self._plot()
         with param.parameterized.discard_events(self):
             self.code = self.plot_code()


### PR DESCRIPTION
Supersedes https://github.com/holoviz/hvplot/pull/1159

https://github.com/holoviz/hvplot/pull/1159 was a bit too painful to merge and as the changes weren't not so much I decided to commit them in a new PR. Changes compared to it include being more explicit about the fact that these are options dedicated to being applied to the plot via HoloViews `element.opts(...)`.