### PR TITLE
fix typo in the docstring and an explanation for `interactive.panel()` and `interactive.widgets()`

### DIFF
--- a/examples/user_guide/Interactive.ipynb
+++ b/examples/user_guide/Interactive.ipynb
@@ -405,7 +405,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "If you want more control over the layout, you can use any of the features from [Panel](https://panel.holoviz.org):"
+    "If you want more control over the layout, you can use any of the features from [Panel](https://panel.holoviz.org). In this case, `interactive.panel()` (or `interactive.output()`) make sure you display the interactive plot only, with the widgets explicitly declared by `interactive.widgets()`:"
    ]
   },
   {

--- a/hvplot/interactive.py
+++ b/hvplot/interactive.py
@@ -492,7 +492,7 @@ class Interactive:
 
         Examples
         --------
-        >>> widget = panel.wid7ugets.IntSlider(value=1, start=1, end=5)
+        >>> widget = panel.widgets.IntSlider(value=1, start=1, end=5)
         >>> dfi = df.interactive(width=200)
         >>> dfi.head(widget)
         """


### PR DESCRIPTION
This is not major and should be straightforward.
I hope it is fine to create a PR to such a simple fix.

The explanation in the tutorial originates from this discussion.
https://discourse.holoviz.org/t/why-is-the-multiselect-rendered-twice-and-the-chart-only-once/6286/3

I noticed the typo while looking for extra arguments in `interactive()`