### PR TITLE
Limit explorer widget width

### DIFF
--- a/hvplot/ui.py
+++ b/hvplot/ui.py
@@ -467,7 +467,7 @@ class hvPlotExplorer(Viewer):
             self.statusbar,
             show_name=False,
             default_layout=pn.Row,
-            margin=(0, 56)
+            margin=(5, 56, 0, 56)
         )
         controls = [
             p.class_

--- a/hvplot/ui.py
+++ b/hvplot/ui.py
@@ -467,7 +467,7 @@ class hvPlotExplorer(Viewer):
             self.statusbar,
             show_name=False,
             default_layout=pn.Row,
-            margin=(5, 56, 0, 56)
+            margin=(0, 56)
         )
         controls = [
             p.class_


### PR DESCRIPTION
Condenses the widget box so there's more space for the plot. Will address the time slider in another PR.

Builds on top of https://github.com/holoviz/hvplot/pull/1197 and partially addresses https://github.com/holoviz/hvplot/issues/1190

Changes based on discovery in https://github.com/holoviz/panel/issues/5856

<img width="1332" alt="image" src="https://github.com/holoviz/hvplot/assets/15331990/e2c93aed-554b-4880-ba34-e77537eace98">
