### PR TITLE
Respect hover_cols for OHLC

### DIFF
--- a/hvplot/converter.py
+++ b/hvplot/converter.py
@@ -2060,7 +2060,7 @@ class HoloViewsConverter:
             o, h, l, c = y
         neg, pos = self.kwds.get('neg_color', 'red'), self.kwds.get('pos_color', 'green')
         color_exp = (dim(o)>dim(c)).categorize({True: neg, False: pos})
-        ds = Dataset(data, [x], [o, h, l, c])
+        ds = Dataset(data, [x], [o, h, l, c] + self.hover_cols)
         if ds.data[x].dtype.kind in 'SUO':
             rects = Rectangles(ds, [x, o, x, c])
         else:
@@ -2078,9 +2078,9 @@ class HoloViewsConverter:
         tools = seg_cur_opts.pop('tools', [])
         if 'hover' in tools:
             tools[tools.index('hover')] = HoverTool(tooltips=[
-                (x, '@{%s}' % x), ('Open', '@{%s}' % o), ('High', '@{%s}' % h),
-                ('Low', '@{%s}' % l), ('Close', '@{%s}' % c)
-            ])
+                (x, f'@{x}'), ('Open', f'@{o}'), ('High', f'@{h}'),
+                ('Low', f'@{l}'), ('Close', f'@{c}')
+            ] + [(hc, f'@{hc}') for hc in self.hover_cols])
         seg_cur_opts['tools'] = tools
         seg_cur_opts ['color'] = self.kwds.get('line_color', 'black')
         if 'xlabel' not in seg_cur_opts:

--- a/hvplot/converter.py
+++ b/hvplot/converter.py
@@ -2060,7 +2060,11 @@ class HoloViewsConverter:
             o, h, l, c = y
         neg, pos = self.kwds.get('neg_color', 'red'), self.kwds.get('pos_color', 'green')
         color_exp = (dim(o)>dim(c)).categorize({True: neg, False: pos})
-        ds = Dataset(data, [x], [o, h, l, c] + self.hover_cols)
+        ohlc_cols = [o, h, l, c]
+        if x in self.hover_cols:
+            self.hover_cols.remove(x)
+        vdims = list(dict.fromkeys(ohlc_cols + self.hover_cols))
+        ds = Dataset(data, [x], vdims)
         if ds.data[x].dtype.kind in 'SUO':
             rects = Rectangles(ds, [x, o, x, c])
         else:
@@ -2080,7 +2084,7 @@ class HoloViewsConverter:
             tools[tools.index('hover')] = HoverTool(tooltips=[
                 (x, f'@{x}'), ('Open', f'@{o}'), ('High', f'@{h}'),
                 ('Low', f'@{l}'), ('Close', f'@{c}')
-            ] + [(hc, f'@{hc}') for hc in self.hover_cols])
+            ] + [(hc, f'@{hc}') for hc in vdims[4:]])
         seg_cur_opts['tools'] = tools
         seg_cur_opts ['color'] = self.kwds.get('line_color', 'black')
         if 'xlabel' not in seg_cur_opts:

--- a/hvplot/tests/plotting/testohlc.py
+++ b/hvplot/tests/plotting/testohlc.py
@@ -18,4 +18,14 @@ def test_ohlc_hover_cols():
     segments = plot.Segments.I
     assert 'Volume' in segments
     tooltips = segments.opts.get('plot').kwargs['tools'][0].tooltips
-    assert ('Volume', '@Volume') in tooltips
+    assert len(tooltips) == len(df.columns) + 1
+    assert tooltips[-1] == ('Volume', '@Volume')
+
+
+def test_ohlc_hover_cols_all():
+    plot = df.hvplot.ohlc(y=ohlc_cols, hover_cols='all')
+    segments = plot.Segments.I
+    assert 'Volume' in segments
+    tooltips = segments.opts.get('plot').kwargs['tools'][0].tooltips
+    assert len(tooltips) == len(df.columns) + 1
+    assert tooltips[-1] == ('Volume', '@Volume')

--- a/hvplot/tests/plotting/testohlc.py
+++ b/hvplot/tests/plotting/testohlc.py
@@ -1,0 +1,21 @@
+import pandas as pd
+import hvplot.pandas  # noqa
+
+
+df = pd.DataFrame({
+        'Open': [100.00, 101.25, 102.75],
+        'High': [104.10, 105.50, 110.00],
+        'Low': [94.00, 97.10, 99.20],
+        'Close': [101.15, 99.70, 109.50],
+        'Volume': [10012, 5000, 18000],
+    }, index=[pd.Timestamp('2022-08-01'), pd.Timestamp('2022-08-03'), pd.Timestamp('2022-08-04')])
+
+ohlc_cols = ['Open', 'High', 'Low', 'Close']
+
+
+def test_ohlc_hover_cols():
+    plot = df.hvplot.ohlc(y=ohlc_cols, hover_cols=['Volume'])
+    segments = plot.Segments.I
+    assert 'Volume' in segments
+    tooltips = segments.opts.get('plot').kwargs['tools'][0].tooltips
+    assert ('Volume', '@Volume') in tooltips


### PR DESCRIPTION
Addresses https://github.com/holoviz/hvplot/issues/1214

```python
import pandas as pd
import hvplot.pandas

df = pd.DataFrame({
        "Open": [100.00, 101.25, 102.75],
        "High": [104.10, 105.50, 110.00],
        "Low": [94.00, 97.10, 99.20],
        "Close": [101.15, 99.70, 109.50],
        "Volume": [10012, 5000, 18000],
    }, index=[pd.Timestamp("2022-08-01"), pd.Timestamp("2022-08-03"), pd.Timestamp("2022-08-04")])

ohlc_cols = ["Open", "High", "Low", "Close"]
df.hvplot.ohlc(y=ohlc_cols, hover_cols=["Volume"])
```

<img width="718" alt="image" src="https://github.com/holoviz/hvplot/assets/35924738/75502a20-37cc-48a0-99a0-3be761100e2f">
