### PR TITLE
support polars in hvplot.plot method

### DIFF
--- a/hvplot/plotting/__init__.py
+++ b/hvplot/plotting/__init__.py
@@ -1,5 +1,5 @@
 import holoviews as hv
-from ..util import with_hv_extension
+from ..util import with_hv_extension, is_polars
 
 from .core import hvPlot, hvPlotTabular   # noqa
 
@@ -30,6 +30,9 @@ def plot(data, kind, **kwargs):
         if v is not None:
             no_none_kwargs[k] = v
 
+    if is_polars(data):
+        from hvplot.polars import hvPlotTabularPolars
+        return hvPlotTabularPolars(data)(kind=kind, **no_none_kwargs)
     return hvPlotTabular(data)(kind=kind, **no_none_kwargs)
 
 

--- a/hvplot/util.py
+++ b/hvplot/util.py
@@ -348,6 +348,12 @@ def is_dask(data):
     import dask.dataframe as dd
     return isinstance(data, (dd.DataFrame, dd.Series))
 
+def is_polars(data):
+    if not check_library(data, 'polars'):
+        return False
+    import polars as pl
+    return isinstance(data, (pl.DataFrame, pl.Series))
+
 def is_intake(data):
     if "intake" not in sys.modules:
         return False

--- a/hvplot/util.py
+++ b/hvplot/util.py
@@ -352,7 +352,7 @@ def is_polars(data):
     if not check_library(data, 'polars'):
         return False
     import polars as pl
-    return isinstance(data, (pl.DataFrame, pl.Series))
+    return isinstance(data, (pl.DataFrame, pl.Series, pl.LazyFrame))
 
 def is_intake(data):
     if "intake" not in sys.modules:


### PR DESCRIPTION
hvplot already supports Polars (thank, well done 🙌  🙏 🥳 )

Fancy making `hvPlotTabularPolars` available in the toplevel `plot` function, so that a plotting backend functionality could be considered for Polars too?