### PR TITLE
Explorer: disable the geo controls when geoviews is not installed

### DIFF
--- a/hvplot/ui.py
+++ b/hvplot/ui.py
@@ -350,14 +350,17 @@ class Geographic(Controls):
 
         self.param.crs.objects = crs_list
         self.param.projection.objects = crs_list
+        updates = {}
         if self.projection is None:
-            self.projection = crs_list[0]
+            updates['projection'] = crs_list[0]
 
         if self.global_extent is None:
-            self.global_extent = True
+            updates['global_extent'] = True
 
         if self.features is None:
-            self.features = ['coastline']
+            updates['features'] = ['coastline']
+
+        self.param.update(**updates)
 
 
 class Operations(Controls):

--- a/hvplot/ui.py
+++ b/hvplot/ui.py
@@ -309,20 +309,20 @@ class Geographic(Controls):
     _widgets_kwargs = {'geo': {'type': pn.widgets.Toggle}}
 
     def __init__(self, data,  **params):
-        self._gv_available = False
+        gv_available = False
         try:
             import geoviews  # noqa
-            self._gv_available = True
+            gv_available = True
         except ImportError:
             pass
 
         geo_params = GEO_KEYS + ['geo']
-        if not self._gv_available and  any(p in params for p in geo_params):
+        if not gv_available and any(p in params for p in geo_params):
             raise ImportError(
                 'GeoViews must be installed to enable the geographic options.'
             )
         super().__init__(data, **params)
-        if not self._gv_available:
+        if not gv_available:
             for p in geo_params:
                 self.param[p].constant = True
             # Workaround: Checkbox widgets don't yet have a tooltip

--- a/hvplot/ui.py
+++ b/hvplot/ui.py
@@ -582,7 +582,7 @@ class hvPlotExplorer(Viewer):
                 if (pname == 'x' or pname == 'y') and getattr(self, pname, None) is None:
                     setattr(self, pname, p.objects[0])
 
-    def _plot(self, *events):
+    def _plot(self):
         y = self.y_multi if 'y_multi' in self._controls.parameters else self.y
         if isinstance(y, list) and len(y) == 1:
             y = y[0]


### PR DESCRIPTION
Addressing (a tiny) part of https://github.com/holoviz/hvplot/issues/1190 with a different take compared to https://github.com/holoviz/hvplot/pull/1200 whose goal is to cover all kind of exceptions the explorer might raise, while in this PR I focused on finding the best way to let them know they should install GeoViews to enable the geo controls.

I ended up trying to import geoviews on initialization and if that fails disabling all the geo controls:

<img width="1120" alt="image" src="https://github.com/holoviz/hvplot/assets/35924738/b9dac3f6-741b-4cf5-8498-12a93bd3975d">

The `Checkbox` widget has no tooltip so instead I used a Toggle with a label that is updated to indicate GeoViews is required.
Trying to instantiate an explorer by passing geo kwargs (e.g. `df.explorer(geo=True)`) will raise an import error.