### PR TITLE
Doc: reintroduce colorbars in the matplotlib guide

### DIFF
--- a/examples/user_guide/Plotting_with_Matplotlib.ipynb
+++ b/examples/user_guide/Plotting_with_Matplotlib.ipynb
@@ -295,7 +295,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "crime.hvplot.scatter(x='Violent Crime rate', y='Burglary rate')"
+    "crime.hvplot.scatter(x='Violent Crime rate', y='Burglary rate', c='Year')"
    ]
   },
   {
@@ -365,7 +365,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "crime.hvplot.bivariate(x='Violent Crime rate', y='Burglary rate', width=600, height=500, colorbar=False)"
+    "crime.hvplot.bivariate(x='Violent Crime rate', y='Burglary rate', width=600, height=500)"
    ]
   },
   {
@@ -383,7 +383,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "flights.compute().hvplot.heatmap(x='day', y='carrier', C='depdelay', reduce_function=np.mean, colorbar=False).opts(show_values=False)"
+    "flights.compute().hvplot.heatmap(x='day', y='carrier', C='depdelay', reduce_function=np.mean).opts(show_values=False)"
    ]
   },
   {


### PR DESCRIPTION
Addresses https://github.com/holoviz/hvplot/issues/868, basically reverting https://github.com/holoviz/hvplot/pull/852.