### PR TITLE
Fix considering plots with one y variable as categorical

### DIFF
--- a/hvplot/converter.py
+++ b/hvplot/converter.py
@@ -609,7 +609,7 @@ class HoloViewsConverter:
                     # Default to categorical camp if we detect categorical shading
                     if ((self.datashade or self.rasterize) and (self.aggregator is None or 'count_cat' in str(self.aggregator)) and
                         ((self.by and not self.subplots) or
-                         (isinstance(self.y, list) or (self.y is None and len(set(self.variables) - set(self.indexes)) > 1)))):
+                         ((isinstance(self.y, list) and len(self.y) > 1) or (self.y is None and len(set(self.variables) - set(self.indexes)) > 1)))):
                         self._style_opts['cmap'] = self._default_cmaps['categorical']
                     elif symmetric:
                         self._style_opts['cmap'] = self._default_cmaps['diverging']

--- a/hvplot/tests/testoperations.py
+++ b/hvplot/tests/testoperations.py
@@ -212,6 +212,11 @@ class TestDatashader(ComparisonTestCase):
         assert isinstance(plot, ImageStack)
         assert plot.opts["cmap"] == cc.palette['glasbey_category10']
 
+    def test_rasterize_single_y_in_list_linear_cmap(self):
+        plot = self.df.hvplot.line(y=['y'], rasterize=True)
+        opts = Store.lookup_options('bokeh', plot[()], 'style').kwargs
+        assert opts.get('cmap') == 'kbc_r'
+
     def test_resample_when_error_unset_operation(self):
         with pytest.raises(
             ValueError,

--- a/hvplot/tests/testoperations.py
+++ b/hvplot/tests/testoperations.py
@@ -213,6 +213,7 @@ class TestDatashader(ComparisonTestCase):
         assert plot.opts["cmap"] == cc.palette['glasbey_category10']
 
     def test_rasterize_single_y_in_list_linear_cmap(self):
+        # Regression, see https://github.com/holoviz/hvplot/issues/1210
         plot = self.df.hvplot.line(y=['y'], rasterize=True)
         opts = Store.lookup_options('bokeh', plot[()], 'style').kwargs
         assert opts.get('cmap') == 'kbc_r'


### PR DESCRIPTION
Fixes https://github.com/holoviz/hvplot/issues/1210

This is basically take 2 of https://github.com/holoviz/hvplot/pull/843 that complete the original implementation of https://github.com/holoviz/hvplot/pull/759. Without this fix, a list of 1 `y` variable is assimilated as a categorical.