### PR TITLE
Show categorical legend with hvplot's `by` keyword and datashader.

### DIFF
--- a/hvplot/converter.py
+++ b/hvplot/converter.py
@@ -2335,7 +2335,7 @@ class HoloViewsConverter:
             if 'tools' in opts_ and kind in ["polygons", "paths"] and not vdims:
                 opts_["tools"] = [t for t in opts_["tools"] if t != "hover"]
         if self.geo: params['crs'] = self.crs
-        if self.by:
+        if self.by and not self.datashade:
             obj = Dataset(data, self.by+kdims, vdims).to(element, kdims, vdims, self.by, **params)
             if self.subplots:
                 obj = obj.layout(sort=False)

--- a/hvplot/converter.py
+++ b/hvplot/converter.py
@@ -1595,7 +1595,7 @@ class HoloViewsConverter:
             ys += [self.kwds['yerr1']]
         kdims, vdims = self._get_dimensions([x], ys)
 
-        if self.by:
+        if self.by and not self.datashade:
             if element is Bars and not self.subplots:
                 if any(y in self.indexes for y in ys):
                     data = data.reset_index()


### PR DESCRIPTION
Currently using hvplot with datashader and the `by` keyword does not show a legend. This PR makes the `by` keyword behave as if only a categorical aggregator was specified when datashader is used, ensuring a legend is created.

A small example where the change is effective:

```python
import numpy as np
import pandas as pd
import hvplot
import hvplot.pandas
import datashader as ds
import holoviews.operation.datashader as hd

df = pd.DataFrame(
    np.random.normal(size=(20, 2)),
    columns=['x', 'y']
)
df['cat'] = df.x.apply(lambda x: 'c0' if x < 0 else 'c1')
df['cat'] = df.cat.astype('category')

df.hvplot.points(
    x='x',
    y='y',
    by='cat',
    # aggregator=ds.by('cat'),
    color_key={'c0': '#ff0000', 'c1': '#0000ff'},
    datashade=True,
    dynspread=True,
)
```

