### PR TITLE
add downstream polars test

### DIFF
--- a/hvplot/tests/plotting/testcore.py
+++ b/hvplot/tests/plotting/testcore.py
@@ -1,3 +1,6 @@
+from packaging.version import Version
+from unittest import SkipTest
+
 import numpy as np
 import pandas as pd
 import hvplot.pandas  # noqa
@@ -87,3 +90,12 @@ def test_series_polars(kind):
     ser = pl.Series(values=np.random.rand(10), name="A")
     assert isinstance(ser, pl.Series)
     ser.hvplot(kind=kind)
+
+@pytest.mark.skipif(skip_polar, reason="polars not installed")
+@series_kinds
+def test_series_polars_downstream(kind):
+    if Version(pl.__version__) < Version('0.20.3'):
+        raise SkipTest('plot namespace in Polars introduced in 0.20.3')
+    ser = pl.Series(values=np.random.rand(10), name="A")
+    assert isinstance(ser, pl.Series)
+    ser.plot(kind=kind)


### PR DESCRIPTION
Hey - just wanted to suggest this as a "sister PR" to https://github.com/pola-rs/polars/pull/13238

Then, we could be confident that the "Polars 🤝 hvPlot" compatibility stays stable?