### PR TITLE
Compatibility with Pandas 2.2

### DIFF
--- a/hvplot/tests/plotting/testcore.py
+++ b/hvplot/tests/plotting/testcore.py
@@ -4,6 +4,7 @@ import hvplot.pandas  # noqa
 import pytest
 
 from hvplot import hvPlotTabular
+from hvplot.tests.util import makeDataFrame
 
 try:
     import polars as pl
@@ -44,7 +45,7 @@ y_combinations = pytest.mark.parametrize("y", (
 @frame_kinds
 @y_combinations
 def test_dataframe_pandas(kind, y):
-    df = pd._testing.makeDataFrame()
+    df = makeDataFrame()
     df.hvplot(y=y, kind=kind)
 
 
@@ -58,7 +59,7 @@ def test_series_pandas(kind):
 @frame_kinds
 @y_combinations
 def test_dataframe_dask(kind, y):
-    df = dd.from_pandas(pd._testing.makeDataFrame(), npartitions=2)
+    df = dd.from_pandas(makeDataFrame(), npartitions=2)
     assert isinstance(df, dd.DataFrame)
     df.hvplot(y=y, kind=kind)
 
@@ -76,7 +77,7 @@ def test_series_dask(kind):
 @frame_kinds
 @y_combinations
 def test_dataframe_polars(kind, y, cast):
-    df = cast(pd._testing.makeDataFrame())
+    df = cast(makeDataFrame())
     assert isinstance(df, cast)
     df.hvplot(y=y, kind=kind)
 

--- a/hvplot/tests/testcharts.py
+++ b/hvplot/tests/testcharts.py
@@ -23,7 +23,7 @@ class TestChart2D(ComparisonTestCase):
         self.cat_df = pd.DataFrame([[1, 2, 'A'], [3, 4, 'B'], [5, 6, 'C']],
                                    columns=['x', 'y', 'category'])
         self.time_df = pd.DataFrame({
-            'time': pd.date_range('1/1/2000', periods=5*24, freq='1H', tz='UTC'),
+            'time': pd.date_range('1/1/2000', periods=5*24, freq='1h', tz='UTC'),
             'temp': np.sin(np.linspace(0, 5*2*np.pi, 5*24)).cumsum()})
 
     @parameterized.expand([('points', Points), ('paths', Path)])

--- a/hvplot/tests/testinteractive.py
+++ b/hvplot/tests/testinteractive.py
@@ -13,6 +13,7 @@ import xarray as xr
 from holoviews.util.transform import dim
 from hvplot import bind
 from hvplot.interactive import Interactive
+from hvplot.tests.util import makeDataFrame, makeMixedDataFrame
 from hvplot.xarray import XArrayInteractive
 from hvplot.util import bokeh3, param2
 
@@ -27,7 +28,7 @@ def series():
 
 @pytest.fixture(scope='module')
 def df():
-    return pd._testing.makeMixedDataFrame()
+    return makeMixedDataFrame()
 
 
 @pytest.fixture(scope='module')
@@ -194,7 +195,7 @@ def test_interactive_xarray_function(dataset):
 
 
 def test_interactive_nested_widgets():
-    df = pd._testing.makeDataFrame()
+    df = makeDataFrame()
     w = pn.widgets.RadioButtonGroup(value="A", options=list("ABC"))
 
     idf = Interactive(df)
@@ -214,7 +215,7 @@ def test_interactive_nested_widgets():
     reason="Needs holoviews 1.15.1",
 )
 def test_interactive_slice():
-    df = pd._testing.makeDataFrame()
+    df = makeDataFrame()
     w = pn.widgets.IntSlider(start=10, end=40)
 
     idf = Interactive(df)

--- a/hvplot/tests/testoperations.py
+++ b/hvplot/tests/testoperations.py
@@ -17,6 +17,7 @@ from holoviews.core.overlay import Overlay
 from holoviews.element.chart import Scatter
 from holoviews.element.comparison import ComparisonTestCase
 from hvplot.converter import HoloViewsConverter
+from hvplot.tests.util import makeTimeDataFrame
 from packaging.version import Version
 
 
@@ -152,15 +153,15 @@ class TestDatashader(ComparisonTestCase):
 
     @parameterized.expand([('scatter',), ('line',), ('area',)])
     def test_wide_charts_categorically_shaded_explicit_ys(self, kind):
-        df = pd._testing.makeTimeDataFrame()
-        plot = pd._testing.makeTimeDataFrame().hvplot(y=list(df.columns), datashade=True, kind=kind)
+        df = makeTimeDataFrame()
+        plot = makeTimeDataFrame().hvplot(y=list(df.columns), datashade=True, kind=kind)
         expected_cmap = HoloViewsConverter._default_cmaps['categorical']
         assert plot.callback.inputs[0].callback.operation.p.cmap == expected_cmap
         assert  plot.callback.inputs[0].callback.operation.p.aggregator.column == 'Variable'
 
     @parameterized.expand([('scatter',), ('line',), ('area',)])
     def test_wide_charts_categorically_shaded_implicit_ys(self, kind):
-        plot = pd._testing.makeTimeDataFrame().hvplot(datashade=True, kind=kind)
+        plot = makeTimeDataFrame().hvplot(datashade=True, kind=kind)
         expected_cmap = HoloViewsConverter._default_cmaps['categorical']
         assert plot.callback.inputs[0].callback.operation.p.cmap == expected_cmap
         assert  plot.callback.inputs[0].callback.operation.p.aggregator.column == 'Variable'

--- a/hvplot/tests/testplotting.py
+++ b/hvplot/tests/testplotting.py
@@ -12,6 +12,7 @@ from parameterized import parameterized
 
 from hvplot.converter import HoloViewsConverter
 from hvplot.plotting import plot
+from hvplot.tests.util import makeDataFrame
 
 no_args = ['line', 'area', 'hist', 'box', 'kde', 'density', 'bar', 'barh']
 x_y = ['scatter', 'hexbin']
@@ -65,6 +66,6 @@ class TestPandasHvplotPlotting(TestPandasHoloviewsPlotting):
 
 def test_plot_supports_polars():
     pl = pytest.importorskip("polars")
-    dfp = pl.DataFrame(pd._testing.makeDataFrame())
+    dfp = pl.DataFrame(makeDataFrame())
     out = plot(dfp, 'line')
     assert isinstance(out, hv.Curve)

--- a/hvplot/tests/util.py
+++ b/hvplot/tests/util.py
@@ -1,0 +1,85 @@
+import string
+
+from datetime import datetime
+
+import numpy as np
+import pandas as pd
+
+
+# Pandas removed its make<> test utilities in version 2.2.0.
+
+_N = 30
+_K = 4
+
+def getCols(k):
+    return string.ascii_uppercase[:k]
+
+
+def rands_array(
+    nchars, size, dtype="O", replace=True
+):
+    """
+    Generate an array of byte strings.
+    """
+    chars = np.array(list(string.ascii_letters + string.digits), dtype=(np.str_, 1))
+    retval = (
+        np.random.default_rng(2)
+        .choice(chars, size=nchars * np.prod(size), replace=replace)
+        .view((np.str_, nchars))
+        .reshape(size)
+    )
+    return retval.astype(dtype)
+
+
+def makeStringIndex(k=10, name=None):
+    return pd.Index(rands_array(nchars=10, size=k), name=name)
+
+
+def makeMixedDataFrame():
+    data = {
+        "A": [0.0, 1.0, 2.0, 3.0, 4.0],
+        "B": [0.0, 1.0, 0.0, 1.0, 0.0],
+        "C": ["foo1", "foo2", "foo3", "foo4", "foo5"],
+        "D": pd.bdate_range("1/1/2009", periods=5),
+    }
+    return pd.DataFrame(data)
+
+
+def getSeriesData():
+    index = makeStringIndex(_N)
+    return {
+        c: pd.Series(np.random.default_rng(i).standard_normal(_N), index=index)
+        for i, c in enumerate(getCols(_K))
+    }
+
+
+def makeDataFrame():
+    data = getSeriesData()
+    return pd.DataFrame(data)
+
+
+def makeDateIndex(
+    k=10, freq="B", name=None, **kwargs
+):
+    dt = datetime(2000, 1, 1)
+    dr = pd.bdate_range(dt, periods=k, freq=freq, name=name)
+    return pd.DatetimeIndex(dr, name=name, **kwargs)
+
+
+def makeTimeSeries(nper=None, freq="B", name=None):
+    if nper is None:
+        nper = _N
+    return pd.Series(
+        np.random.default_rng(2).standard_normal(nper),
+        index=makeDateIndex(nper, freq=freq),
+        name=name,
+    )
+
+
+def getTimeSeriesData(nper=None, freq="B"):
+    return {c: makeTimeSeries(nper, freq) for c in getCols(_K)}
+
+
+def makeTimeDataFrame(nper=None, freq="B"):
+    data = getTimeSeriesData(nper, freq)
+    return pd.DataFrame(data)


### PR DESCRIPTION
- Vendoring some of the `make<>` private testing utilities that were removed in Pandas 2.2
- Update a test to remove a FutureWarning