### PR TITLE
Promote Andrew (@ahuang11) as a Maintainer

### DIFF
--- a/doc/governance/project-docs/MEMBERS.md
+++ b/doc/governance/project-docs/MEMBERS.md
@@ -11,3 +11,4 @@ The hvPlot Project’s equivalently named documents take precedence over any ext
 | Philipp Rudiger | Project Director | [philippjfr](https://github.com/philippjfr) |
 | Maxime Liquet | Lead Maintainer | [maximlt](https://github.com/maximlt) |
 | Simon Høxbro Hansen | Maintainer | [hoxbro](https://github.com/hoxbro) |
+| Andrew Huang | Maintainer | [ahuang11](https://github.com/ahuang11) |


### PR DESCRIPTION
Andrew has a long track of contributions to [hvPlot](https://github.com/holoviz/hvplot/pulls?q=is%3Apr+is%3Aclosed+author%3Aahuang11) (and [HoloViews](https://github.com/holoviz/holoviews/pulls?q=is%3Apr+is%3Aclosed+author%3Aahuang11)), dating back to 2018, with an increased activity since October 2023. His background in climate science helps bring some useful domain knowledge, his coding is sharp and he's a pleasure to work with.

I'm calling a vote to promote him to a well-deserved Maintainer role. @philippjfr @Hoxbro this PR will be merged when we all approve it.