### PR TITLE
Clarify CRS and output projection

### DIFF
--- a/examples/user_guide/Geographic_Data.ipynb
+++ b/examples/user_guide/Geographic_Data.ipynb
@@ -74,86 +74,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Geopandas\n",
-    "\n",
-    "Since a GeoPandas ``DataFrame`` is just a Pandas DataFrames with additional geographic information, it inherits the ``.hvplot`` method. We can thus easily load shapefiles and plot them on a map:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import geopandas as gpd\n",
-    "\n",
-    "cities = gpd.read_file(gpd.datasets.get_path('naturalearth_cities'))\n",
-    "\n",
-    "cities.hvplot(global_extent=True, frame_height=450, tiles=True)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "The GeoPandas support allows plotting ``GeoDataFrames`` containing ``'Point'``, ``'Polygon'``, ``'LineString'`` and ``'LineRing'`` geometries, but not ones containing a mixture of different geometry types. Calling ``.hvplot`` will automatically figure out the geometry type to plot, but it also possible to call ``.hvplot.points``, ``.hvplot.polygons``, and ``.hvplot.paths`` explicitly.\n",
-    "\n",
-    "To draw multiple GeoDataFrames onto the same plot, use the ``*`` operator:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "world = gpd.read_file(gpd.datasets.get_path('naturalearth_lowres'))\n",
-    "\n",
-    "world.hvplot(geo=True) * cities.hvplot(geo=True, color='orange')"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "It is possible to declare a specific column to use as color with the ``c`` keyword:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "world.hvplot(geo=True) + world.hvplot(c='continent', geo=True)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Spatialpandas\n",
-    "\n",
-    "Spatialpandas is another powerful library for working with geometries and is optimized for rendering with datashader, making it possible to plot millions of individual geometries very quickly:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import spatialpandas as spd\n",
-    "\n",
-    "spd_world = spd.GeoDataFrame(world)\n",
-    "\n",
-    "spd_world.hvplot(datashade=True, project=True, aggregator='count_cat', c='continent', color_key='Category10')"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "### Declaring an output projection"
    ]
   },
@@ -247,6 +167,86 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "### Geopandas\n",
+    "\n",
+    "Since a GeoPandas ``DataFrame`` is just a Pandas DataFrames with additional geographic information, it inherits the ``.hvplot`` method. We can thus easily load shapefiles and plot them on a map:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import geopandas as gpd\n",
+    "\n",
+    "cities = gpd.read_file(gpd.datasets.get_path('naturalearth_cities'))\n",
+    "\n",
+    "cities.hvplot(global_extent=True, frame_height=450, tiles=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The GeoPandas support allows plotting ``GeoDataFrames`` containing ``'Point'``, ``'Polygon'``, ``'LineString'`` and ``'LineRing'`` geometries, but not ones containing a mixture of different geometry types. Calling ``.hvplot`` will automatically figure out the geometry type to plot, but it also possible to call ``.hvplot.points``, ``.hvplot.polygons``, and ``.hvplot.paths`` explicitly.\n",
+    "\n",
+    "To draw multiple GeoDataFrames onto the same plot, use the ``*`` operator:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "world = gpd.read_file(gpd.datasets.get_path('naturalearth_lowres'))\n",
+    "\n",
+    "world.hvplot(geo=True) * cities.hvplot(geo=True, color='orange')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "It is possible to declare a specific column to use as color with the ``c`` keyword:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "world.hvplot(geo=True) + world.hvplot(c='continent', geo=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import spatialpandas as spd\n",
+    "\n",
+    "spd_world = spd.GeoDataFrame(world)\n",
+    "\n",
+    "spd_world.hvplot(datashade=True, project=True, aggregator='count_cat', c='continent', color_key='Category10')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Spatialpandas\n",
+    "\n",
+    "Spatialpandas is another powerful library for working with geometries and is optimized for rendering with datashader, making it possible to plot millions of individual geometries very quickly:"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "As you can see, hvPlot makes it simple to work with geographic data visually.  For more complex plot types and additional details, see the [GeoViews](https://geoviews.org) documentation."
    ]
   },
@@ -259,7 +259,8 @@
     "The API provides various geo-specific options:\n",
     "\n",
     "- ``coastline`` (default=False): Whether to display a coastline on top of the plot, setting ``coastline='10m'/'50m'/'110m'`` specifies a specific scale\n",
-    "- ``crs`` (default=None): Coordinate reference system of the data specified as Cartopy CRS object, proj.4 string or EPSG code\n",
+    "- ``crs`` (default=None): Coordinate reference system of the data (input projection) specified as Cartopy CRS object or name, proj.4 string or EPSG code \n",
+    "- ``projection`` (default=None): Coordinate reference system of the plot (output projection) specified as Cartopy CRS object or name, proj.4 string or EPSG code\n",
     "- ``features`` features (default=None): A list of features or a dictionary of features and the scale at which to render it. Available features include 'borders', 'coastline', 'lakes', 'land', 'ocean', 'rivers' and 'states'. Available scales include '10m'/'50m'/'110m'.\n",
     "- ``geo`` (default=False): Whether the plot should be treated as geographic (and assume PlateCarree, i.e. lat/lon coordinates)\n",
     "- ``global_extent`` (default=False): Whether to expand the plot extent to span the whole globe\n",


### PR DESCRIPTION
A user brought this to my attention and mentioned that it was hard to figure out crs and projection.

Turns out the section `Declaring an output projection` was hidden under Spatialpandas
<img width="1075" alt="image" src="https://github.com/holoviz/hvplot/assets/15331990/ebeb764b-51ea-4939-99f1-176e02b6c9ed">

This fixes it by reducing the heading of Spatialpandas from `##` to `###`, moving "Declaring an output projection" under "Declaring an output projection".

Lastly, it clarifies the role of crs / projection and adds `projection` to the missing geographic options