### PR TITLE
Pin holoviews for test runs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -61,6 +61,7 @@ extras_require['tests_core'] = [
     'scipy',
     'ipywidgets',
     'dask',
+    'holoviews <1.18.0a0',  # Should be removed when we switch to 1.18
 ]
 
 # Optional tests dependencies, i.e. one should be able


### PR DESCRIPTION
Can see we are pulling in 1.18 alpha versions instead of 1.17.X, causing us to not see regression, spotted by Maxime.

 