### PR TITLE
Fix saving Panel objects with `hvplot.save`

### DIFF
--- a/hvplot/utilities.py
+++ b/hvplot/utilities.py
@@ -6,7 +6,64 @@ renderer = _hv.renderer('bokeh')
 
 output = _hv.output
 
-save = _hv.save
+
+def save(obj, filename, fmt='auto', backend=None, resources='cdn', toolbar=None, title=None, **kwargs):
+    """
+    Saves the supplied object to file.
+
+    This function delegates saving to `holoviews.util.save` when the
+    object is a HoloViews element, which is the type of object mostly
+    created by hvPlot. This function inherits the same signature and
+    docstring below. However, in some cases hvPlot creates Panel objects,
+    in which case saving is delegated to the method `panel.io.Viewable.save`.
+    It shares a few common parameters with `holoviews.util.save`, and extra
+    parameters can be passed as kwargs.
+
+    The available output formats depend on the backend being used. By
+    default and if the filename is a string the output format will be
+    inferred from the file extension. Otherwise an explicit format
+    will need to be specified. For ambiguous file extensions such as
+    html it may be necessary to specify an explicit fmt to override
+    the default, e.g. in the case of 'html' output the widgets will
+    default to fmt='widgets', which may be changed to scrubber widgets
+    using fmt='scrubber'.
+
+    Arguments
+    ---------
+    obj: HoloViews object
+        The HoloViews object to save to file
+    filename: string or IO object
+        The filename or BytesIO/StringIO object to save to
+    fmt: string
+        The format to save the object as, e.g. png, svg, html, or gif
+        and if widgets are desired either 'widgets' or 'scrubber'
+    backend: string
+        A valid HoloViews rendering backend, e.g. bokeh or matplotlib
+    resources: string or bokeh.resource.Resources
+        Bokeh resources used to load bokehJS components. Defaults to
+        CDN, to embed resources inline for offline usage use 'inline'
+        or bokeh.resources.INLINE.
+    toolbar: bool or None
+        Whether to include toolbars in the exported plot. If None,
+        display the toolbar unless fmt is `png` and backend is `bokeh`.
+        If `True`, always include the toolbar.  If `False`, do not include the
+        toolbar.
+    title: string
+        Custom title for exported HTML file
+    **kwargs: dict
+        Additional keyword arguments passed to the renderer,
+        e.g. fps for animations
+    """
+    if isinstance(obj, _hv.core.Dimensioned):
+        _hv.save(
+            obj, filename, fmt=fmt, backend=backend, resources=resources,
+            toolbar=toolbar, title=title, **kwargs
+        )
+    elif isinstance(obj, _pn.layout.Panel):
+        obj.save(filename, resources=resources, title=title, **kwargs)
+    else:
+        raise TypeError(f"Saving not supported for objects of type {type(obj)!r}")
+
 
 def show(obj, title=None, port=0, **kwargs):
     """


### PR DESCRIPTION
Fixes https://github.com/holoviz/hvplot/issues/796

`hvplot.save` was an alias for `holoviews.util.save` except that hvPlot sometimes creates Panel objects which the HoloViews function couldn't save. So we delegate to `<pn_obj>.save`. I also thought about just raising a clear error message but thought it'd make everyone's life simpler if it just worked directly. The real fix would be for hvPlot to no longer create Panel objects, but that's another issue.