### PR TITLE
Add `tiles_opts` parameter to customize the tiles

### DIFF
--- a/doc/user_guide/Customization.ipynb
+++ b/doc/user_guide/Customization.ipynb
@@ -195,7 +195,10 @@
     "    tiles (default=False):\n",
     "        Whether to overlay the plot on a tile source. Tiles sources\n",
     "        can be selected by name or a tiles object or class can be passed,\n",
-    "        the default is 'Wikipedia'."
+    "        the default is 'Wikipedia'.\n",
+    "    tiles_opts (default=None): dict\n",
+    "        Options to customize the tiles layer created when `tiles` is set,\n",
+    "        e.g. `dict(alpha=0.5)`."
    ]
   },
   {

--- a/doc/user_guide/Geographic_Data.ipynb
+++ b/doc/user_guide/Geographic_Data.ipynb
@@ -65,7 +65,7 @@
    "outputs": [],
    "source": [
     "airports.hvplot.points('Longitude', 'Latitude', geo=True, color='red', alpha=0.2,\n",
-    "                       xlim=(-180, -30), ylim=(0, 72), tiles='ESRI')"
+    "                       xlim=(-180, -30), ylim=(0, 72), tiles='ESRI', tiles_opts=dict(alpha=0.5))"
    ]
   },
   {

--- a/hvplot/converter.py
+++ b/hvplot/converter.py
@@ -247,6 +247,9 @@ class HoloViewsConverter:
         Whether to overlay the plot on a tile source. Tiles sources
         can be selected by name or a tiles object or class can be passed,
         the default is 'Wikipedia'.
+    tiles_opts (default=None): dict
+        Options to customize the tiles layer created when `tiles` is set
+        (e.g. `dict(alpha=0.5)`.
     """
 
     _gridded_types = [
@@ -392,7 +395,7 @@ class HoloViewsConverter:
         precompute=False, flip_xaxis=None, flip_yaxis=None,
         dynspread=False, hover_cols=[], x_sampling=None,
         y_sampling=None, project=False, tools=[], attr_labels=None,
-        coastline=False, tiles=False, sort_date=True,
+        coastline=False, tiles=False, tiles_opts=None, sort_date=True,
         check_symmetric_max=1000000, transforms={}, stream=None,
         cnorm=None, features=None, rescale_discrete_levels=None,
         autorange=None, **kwds
@@ -416,6 +419,7 @@ class HoloViewsConverter:
         self.coastline = coastline
         self.features = features
         self.tiles = tiles
+        self.tiles_opts = {} if tiles_opts is None else tiles_opts
         self.sort_date = sort_date
 
         # Import geoviews if geo-features requested
@@ -1443,13 +1447,13 @@ class HoloViewsConverter:
                     # overlay everything else
                     obj = obj * feature_obj.opts(projection=self.output_projection)
 
+        tiles = None
         if self.tiles and not self.geo:
             tiles = self._get_tiles(
                 self.tiles,
                 hv.element.tile_sources,
                 hv.element.tiles.Tiles
             )
-            obj = tiles * obj
         elif self.tiles and self.geo:
             import geoviews as gv
             tiles = self._get_tiles(
@@ -1457,7 +1461,8 @@ class HoloViewsConverter:
                 gv.tile_sources.tile_sources,
                 (gv.element.WMTS, hv.element.tiles.Tiles),
             )
-            obj = tiles * obj
+        if tiles is not None:
+            obj = tiles.opts(clone=True, **self.tiles_opts) * obj
         return obj
 
     def _get_tiles(self, source, sources, types):

--- a/hvplot/converter.py
+++ b/hvplot/converter.py
@@ -248,8 +248,8 @@ class HoloViewsConverter:
         can be selected by name or a tiles object or class can be passed,
         the default is 'Wikipedia'.
     tiles_opts (default=None): dict
-        Options to customize the tiles layer created when `tiles` is set
-        (e.g. `dict(alpha=0.5)`.
+        Options to customize the tiles layer created when `tiles` is set,
+        e.g. `dict(alpha=0.5)`.
     """
 
     _gridded_types = [

--- a/hvplot/converter.py
+++ b/hvplot/converter.py
@@ -419,7 +419,7 @@ class HoloViewsConverter:
         self.coastline = coastline
         self.features = features
         self.tiles = tiles
-        self.tiles_opts = {} if tiles_opts is None else tiles_opts
+        self.tiles_opts = tiles_opts or {}
         self.sort_date = sort_date
 
         # Import geoviews if geo-features requested

--- a/hvplot/tests/testgeo.py
+++ b/hvplot/tests/testgeo.py
@@ -199,6 +199,15 @@ class TestGeoAnnotation(TestCase):
         self.assertIsInstance(plot.get(0), hv.Tiles)
         self.assertIn('openstreetmap', plot.get(0).data)
 
+    def test_plot_with_tiles_with_tiles_opts(self):
+        plot = self.df.hvplot.points('x', 'y', geo=False, tiles=True, tiles_opts=dict(alpha=0.5))
+        assert len(plot) == 2
+        tiles = plot.get(0)
+        assert isinstance(tiles, hv.Tiles)
+        assert 'openstreetmap' in tiles.data
+        assert tiles.opts["alpha"] == 0.5
+
+
     def test_plot_with_tiles_with_geo(self):
         import geoviews as gv
 
@@ -206,6 +215,16 @@ class TestGeoAnnotation(TestCase):
         self.assertEqual(len(plot), 2)
         self.assertIsInstance(plot.get(0), gv.element.WMTS)
         self.assertIn('openstreetmap', plot.get(0).data)
+
+    def test_plot_with_tiles_with_tiles_opts_with_geo(self):
+        import geoviews as gv
+
+        plot = self.df.hvplot.points('x', 'y', geo=True, tiles=True, tiles_opts=dict(alpha=0.5))
+        assert len(plot) == 2
+        tiles = plot.get(0)
+        assert isinstance(tiles, gv.element.WMTS)
+        assert 'openstreetmap' in tiles.data
+        assert tiles.opts["alpha"] == 0.5
 
     def test_plot_with_specific_tiles(self):
         plot = self.df.hvplot.points('x', 'y', geo=False, tiles='ESRI')


### PR DESCRIPTION
Addresses https://github.com/holoviz/hvplot/issues/1293

An alternative implementation might have been overloading `tiles` to accept a dictionary like `{"tiles": "ESRI", "alpha": 0.5}`. Interested in what other maintainers think about the two different approaches.