### PR TITLE
Add support to `xyzservices` tiles

### DIFF
--- a/doc/user_guide/Geographic_Data.ipynb
+++ b/doc/user_guide/Geographic_Data.ipynb
@@ -13,10 +13,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import xarray as xr\n",
     "import hvplot.pandas  # noqa\n",
     "import hvplot.xarray  # noqa\n",
-    "import cartopy.crs as ccrs\n",
+    "import xarray as xr\n",
     "\n",
     "from bokeh.sampledata.airport_routes import airports"
    ]
@@ -25,19 +24,45 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Installation\n",
+    "## Introduction\n",
     "\n",
-    "The plot API also has support for geographic data built on top of Cartopy and GeoViews. Both can be installed using conda with:\n",
+    "hvPlot can display geographic data and can be used to add contextualisation layers:\n",
     "\n",
-    "    conda install geoviews\n",
-    "    \n",
-    "or with pip:\n",
+    "- Overlay the data over a tiled web map\n",
+    "- Overlay the data over geographic/administrative features\n",
+    "- Plot the data in a specific projection\n",
     "\n",
-    "    pip install geoviews\n",
+    "Many, but not all, of these features require [GeoViews](https://geoviews.org) to be installed, which is the geographic extension of HoloViews built on [Cartopy](https://scitools.org.uk/cartopy) and [pyproj](https://pyproj4.github.io/pyproj). You can install GeoViews with `pip install geoviews` or `conda install geoviews`.\n",
     "\n",
-    "## Usage\n",
+    "Before plotting geographical data, you should know in which [coordinate system](https://en.wikipedia.org/wiki/Spatial_reference_system) the data is represented. This is important for a few reasons:\n",
     "\n",
-    "Only certain hvPlot types support geographic coordinates, currently including: 'points', 'polygons', 'paths', 'image', 'quadmesh', 'contour', and 'contourf'. As an initial example, consider a dataframe of all US airports (including military bases overseas):"
+    "- The data may have to be [projected](https://en.wikipedia.org/wiki/Map_projection) to another coordinate system, and to do so you may have to provide the orinal coordinate system.\n",
+    "- Projecting data can be a computationally expensive operation and you should be aware of when this operation happens, to perhaps optimize it.\n",
+    "\n",
+    "Here are two common coordinate systems you will encounter when dealing with geographic data and using hvPlot:\n",
+    "\n",
+    "- Data represented by latitude/longitude (lat/lon) coordinates are often tied to the WGS84 geographic coordinate system ([EPSG:4326](https://epsg.io/4326)), that's how GPS data are located on the Earth. For example, the coordinates of Paris in this system are `(lat=48.856697, lon=2.351462)`.\n",
+    "- Tiled web maps are displayed in the Web Mercator projection (also known as Pseudo-Mercator or Google Mercator, [EPSG:3857](https://epsg.io/3857)). Unlike WGS84 which expresses coordinates in lat/long decimal degrees, Web Mercator expresses them in easting (X) /northing (Y) metric units. For example, the coordinates of Paris in this system are `(easting=261763.552, northing=6250580.761)`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Supported plot types\n",
+    "\n",
+    "Only certain hvPlot types support geographic coordinates, currently including: `points`, `polygons`, `paths`, `image`, `quadmesh`, `contour`, and `contourf`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Tiled web map\n",
+    "\n",
+    "A [tiled web map](https://en.wikipedia.org/wiki/Tiled_web_map), or tile map, is an interactive map displayed on a web browser that is divided into small, pre-rendered image tiles, allowing for efficient loading and seamless navigation across various zoom levels and geographic areas. hvPlot allows to add a tile map as a basemap to a plot with the `tiles` parameter. Importantly, `tiles` is a parameter that can be used **without installing GeoViews if the data is already projected in Web Mercator**.\n",
+    "\n",
+    "We'll display this dataframe of all US airports (including military bases overseas), the points are expressed in latitude/longitude coordinates:"
    ]
   },
   {
@@ -53,9 +78,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Plotting points\n",
-    "\n",
-    "If we want to overlay our data on geographic maps or reproject it into a geographic plot, we can set ``geo=True``, which declares that the data will be plotted in a geographic coordinate system.  The default coordinate system is the ``PlateCarree`` projection, i.e., raw longitudes and latitudes. If the data is in another coordinate system, you will need to [declare an explicit ``crs``](#declaring-a-crs) as an argument, in which case `geo=True` is assumed.  Once hvPlot knows that your data is in geo coordinates, you can use the ``tiles`` option to overlay a the plot on top of map tiles."
+    "We'll first start by displaying the airports **without GeoViews**. To do so, we must convert the coordinates to Web Mercator, which can be easily achieved using the `lon_lat_to_easting_northing` function provided by HoloViews."
    ]
   },
   {
@@ -64,31 +87,126 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "airports.hvplot.points('Longitude', 'Latitude', geo=True, color='red', alpha=0.2,\n",
-    "                       xlim=(-180, -30), ylim=(0, 72), tiles='ESRI', tiles_opts=dict(alpha=0.5))"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Declaring a CRS\n",
+    "from holoviews.util.transform import lon_lat_to_easting_northing\n",
     "\n",
-    "To declare a geographic plot we have to supply a ``cartopy.crs.CRS`` (or coordinate reference system).  Coordinate reference systems are described in the [GeoViews documentation](https://geoviews.org/user_guide/Projections.html) and the full list of available CRSs is in the [cartopy documentation](https://scitools.org.uk/cartopy/docs/v0.15/crs/projections.html). "
+    "airports['x'], airports['y'] = lon_lat_to_easting_northing(airports.Longitude, airports.Latitude)\n",
+    "airports[['Latitude', 'Longitude', 'x', 'y']].head(3)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Declaring an output projection"
+    "We can now easily display the airports on a basemap by setting `tiles` to `True`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "airports.hvplot.points('x', 'y', tiles=True, color='red', alpha=0.2)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The ``crs=`` argument specifies the *input* projection, i.e. it declares how to interpret the incoming data values. You can independently choose any *output* projection, i.e. how you want to map the data points onto the screen for display, using the ``projection=`` argument. After loading the same temperature dataset explored in the [Gridded Data](Gridded_Data.ipynb) section, the data can be displayed on an Orthographic projection:"
+    "If GeoViews is installed, you can set `geo=True` to let hvPlot know that it can leverage it to display the data. With this set up, you can directly plot the airports without having to project the data yourself."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "airports.hvplot.points(\n",
+    "    'Longitude', 'Latitude', geo=True, tiles=True, color='red', alpha=0.2\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The easiest ways to set `tiles` include:\n",
+    "\n",
+    "- to `True` to get the default layer which currently is from OpenStreetMap (prefer an explicit definition if you care about reproducibility)\n",
+    "- with an `xyzservices.TileProvider` instance, as installing [`xyzservices`](https://xyzservices.readthedocs.io/) gives you access to hundreds of tiled web maps this package collects.\n",
+    "- with the name of one the layers shipped by HoloViews and GeoViews (when it's installed), like `'EsriTerrain'`.\n",
+    "\n",
+    "The tile map can be optionally configured by setting `tiles_opts`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import xyzservices.providers as xyz"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "airports.hvplot.points(\n",
+    "    'x', 'y', tiles=xyz.Esri.WorldPhysical, tiles_opts={'alpha': 0.5}, color='red', alpha=0.2\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Data and plot projections"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import cartopy.crs as ccrs "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "As we have seen in the previous section, you can set `geo=True` to let hvPlot know that your data is geographic. GeoViews **must be installed** when setting `geo=True`, or when any of the other geographic options is set, except `tiles`. In this mode hvPlot:\n",
+    "\n",
+    "1. Assumes the data is expressed in lat/lon coordinates. Internally, hvPlot assumes a [Plate Carrée](https://en.wikipedia.org/wiki/Equirectangular_projection) projection, also known as the *equirectangular projection*.\n",
+    "2. Displays the data in the projection *Plate Carrée* assumed in 1), or, if `tiles=True`, projects and displays the data in the Web Mercator projection.\n",
+    "\n",
+    "The *input* data projection assumed in step 1), and the *output* plot projection used in step 2) can both be overridden with the `crs` (for Coordinate Reference System) and `projection` parameters, respectively. Both parameters accept cartopy `CRS` objects (see the full list of values they accept in their definition). You can now see that that setting `geo=True, tiles=True` is strictly equivalent to setting `crs=ccrs.PlateCarree(), projection=ccrs.GOOGLE_MERCATOR`! Coordinate reference systems are described in more details in the [GeoViews documentation](https://geoviews.org/user_guide/Projections.html) and the full list of available CRSs is in the [cartopy documentation](https://scitools.org.uk/cartopy/docs/latest/reference/projections.html).\n",
+    "\n",
+    "Setting `projection`, we can display the airports on an Orthographic projection centered over North America."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "airports.hvplot.points(\n",
+    "    'Longitude', 'Latitude', color='red', alpha=0.2,\n",
+    "    coastline=True, projection=ccrs.Orthographic(-90, 30)\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Raster data"
    ]
   },
   {
@@ -98,19 +216,14 @@
    "outputs": [],
    "source": [
     "air_ds = xr.tutorial.open_dataset('air_temperature').load()\n",
-    "\n",
-    "air_ds.hvplot.quadmesh(\n",
-    "    'lon', 'lat', 'air', projection=ccrs.Orthographic(-90, 30),\n",
-    "    global_extent=True, frame_height=540, cmap='viridis',\n",
-    "    coastline=True\n",
-    ")"
+    "air_ds"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "If you don't need to pass any keyword arguments to a given projection and you don't have cartopy.crs (ccrs) imported, you can use the string representation: e.g. ``'LambertConformal'`` instead of ``ccrs.LambertConformal()``. Note that it is case sensitive!"
+    "When displaying raster data in a projection other than the one in which the data is stored, it is more accurate to render it as a `quadmesh` rather than an `image`. As you can see below, a QuadMesh will project each original bin or pixel into the correct non-rectangular shape determined by the projection, accurately showing the geographic extent covered by each sample. An Image, on the other hand, will always be rectangularly aligned in the 2D plane, which requires warping and resampling the data in a way that allows efficient display but loses accuracy at the pixel level."
    ]
   },
   {
@@ -119,18 +232,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "air_ds.hvplot.quadmesh(\n",
-    "    'lon', 'lat', 'air', projection='LambertConformal',\n",
-    ")"
+    "air_ds.isel(time=0).hvplot.quadmesh('lon', 'lat', 'air', projection=ccrs.LambertConformal())"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Note that when displaying raster data in a projection other than the one in which the data is stored, it is more accurate to render it as a ``quadmesh`` rather than an ``image``. As you can see above, a QuadMesh will project each original bin or pixel into the correct non-rectangular shape determined by the projection, accurately showing the geographic extent covered by each sample. An Image, on the other hand, will always be rectangularly aligned in the 2D plane, which requires warping and resampling the data in a way that allows efficient display but loses accuracy at the pixel level. Unfortunately, rendering a large QuadMesh using Bokeh can be very slow, but there are two useful alternatives for datasets too large to be practical as native QuadMeshes.\n",
+    "Unfortunately, rendering a large QuadMesh using Bokeh can be very slow, but there are two useful alternatives for datasets too large to be practical as native QuadMeshes.\n",
     "\n",
-    "The first is using the ``rasterize`` or ``datashade`` options to regrid the data before rendering it, i.e., rendering the data on the backend and then sending a more efficient image-based representation to the browser. One thing to note when using these operations is that it may be necessary to project the data **before** rasterizing it, e.g. to address wrapping issues. To do this provide ``project=True``, which will project the data before it is rasterized (this also works for other types and even when not using these operations). Another reason why this is important when rasterizing the data is that if the CRS of the data does not match the displayed projection, all the data will be projected every time you zoom or pan, which can be very slow. Deciding whether to ``project`` is therefore a tradeoff between projecting the raw data ahead of time or accepting the overhead on dynamic zoom and pan actions."
+    "The first is using the `rasterize` or `datashade` options to regrid the data before rendering it, i.e., rendering the data on the backend and then sending a more efficient image-based representation to the browser. One thing to note when using these operations is that it may be necessary to project the data **before** rasterizing it, e.g. to address wrapping issues. To do this provide `project=True`, which will project the data before it is rasterized (this also works for other types and even when not using these operations). Another reason why this is important when rasterizing the data is that if the CRS of the data does not match the displayed projection, all the data will be projected every time you zoom or pan, which can be very slow. Deciding whether to `project` is therefore a tradeoff between projecting the raw data ahead of time or accepting the overhead on dynamic zoom and pan actions."
    ]
   },
   {
@@ -139,7 +250,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "rasm = xr.tutorial.open_dataset('rasm').load().isel(time=slice(0, 2))\n",
+    "rasm = xr.tutorial.open_dataset('rasm').load().isel(time=0)\n",
     "rasm"
    ]
   },
@@ -150,9 +261,9 @@
    "outputs": [],
    "source": [
     "rasm.hvplot.quadmesh(\n",
-    "    'xc', 'yc', crs=ccrs.PlateCarree(), projection=ccrs.PlateCarree(),\n",
-    "    xlim=(-20, 40), ylim=(30, 70), cmap='viridis', project=True, geo=True,\n",
-    "    rasterize=True, coastline=True, frame_width=400, dynamic=False,\n",
+    "    'xc', 'yc', crs=ccrs.PlateCarree(), projection=ccrs.GOOGLE_MERCATOR,\n",
+    "    tiles=xyz.Esri.WorldGrayCanvas, project=True, rasterize=True,\n",
+    "    xlim=(-20, 40), ylim=(30, 70), cmap='viridis', frame_width=400,\n",
     ")"
    ]
   },
@@ -160,7 +271,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Another option that's still relatively slow for larger data but avoids sending large data into your browser is to plot the data using ``contour`` and ``contourf`` visualizations, generating a line or filled contour with a discrete number of levels:"
+    "The second option that's still relatively slow for larger data but avoids sending large data into your browser is to plot the data using `contour` and `contourf` visualizations, generating a line or filled contour with a discrete number of levels:"
    ]
   },
   {
@@ -170,9 +281,9 @@
    "outputs": [],
    "source": [
     "rasm.hvplot.contourf(\n",
-    "    'xc', 'yc', crs=ccrs.PlateCarree(), projection=ccrs.PlateCarree(),\n",
-    "    xlim=(-20, 40), ylim=(30, 70), frame_width=400, cmap='viridis', levels=10,\n",
-    "    coastline=True\n",
+    "    'xc', 'yc', crs=ccrs.PlateCarree(), projection=ccrs.GOOGLE_MERCATOR,\n",
+    "    tiles=xyz.Esri.WorldGrayCanvas, levels=10,\n",
+    "    xlim=(-20, 40), ylim=(30, 70), cmap='viridis', frame_width=400,\n",
     ")"
    ]
   },
@@ -180,9 +291,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Geopandas\n",
+    "## Geopandas usage\n",
     "\n",
-    "Since a GeoPandas ``DataFrame`` is just a Pandas DataFrames with additional geographic information, it inherits the ``.hvplot`` method. We can thus easily load shapefiles and plot them on a map:"
+    "Since a GeoPandas `DataFrame` is just a Pandas DataFrames with additional geographic information, it inherits the `.hvplot` method. We can thus easily load geographic files (GeoJSON, Shapefiles, etc) and plot them on a map:"
    ]
   },
   {
@@ -192,19 +303,7 @@
    "outputs": [],
    "source": [
     "import geopandas as gpd\n",
-    "\n",
-    "cities = gpd.read_file(gpd.datasets.get_path('naturalearth_cities'))\n",
-    "\n",
-    "cities.hvplot(global_extent=True, frame_height=450, tiles=True)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "The GeoPandas support allows plotting ``GeoDataFrames`` containing ``'Point'``, ``'Polygon'``, ``'LineString'`` and ``'LineRing'`` geometries, but not ones containing a mixture of different geometry types. Calling ``.hvplot`` will automatically figure out the geometry type to plot, but it also possible to call ``.hvplot.points``, ``.hvplot.polygons``, and ``.hvplot.paths`` explicitly.\n",
-    "\n",
-    "To draw multiple GeoDataFrames onto the same plot, use the ``*`` operator:"
+    "import geodatasets"
    ]
   },
   {
@@ -213,16 +312,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "world = gpd.read_file(gpd.datasets.get_path('naturalearth_lowres'))\n",
-    "\n",
-    "world.hvplot(geo=True) * cities.hvplot(geo=True, color='orange')"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "It is possible to declare a specific column to use as color with the ``c`` keyword:"
+    "path = geodatasets.get_path(\"geoda.nyc_neighborhoods\")\n",
+    "path"
    ]
   },
   {
@@ -231,7 +322,33 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "world.hvplot(geo=True) + world.hvplot(c='continent', geo=True)"
+    "nyc = gpd.read_file(path)\n",
+    "nyc.head(3)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nyc.hvplot(geo=True, tiles=True, c=\"poptot\", alpha=0.8, tiles_opts={'alpha': 0.5})"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The GeoPandas support allows plotting `GeoDataFrames` containing `'Point'`, `'Polygon'`, `'LineString'` and `'LineRing'` geometries, but not ones containing a mixture of different geometry types. Calling `.hvplot` will automatically figure out the geometry type to plot, but it also possible to call `.hvplot.points`, `.hvplot.polygons`, and `.hvplot.paths` explicitly."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Spatialpandas usage\n",
+    "\n",
+    "Spatialpandas is another powerful library for working with geometries and is optimized for rendering with datashader, making it possible to plot millions of individual geometries very quickly:"
    ]
   },
   {
@@ -242,18 +359,19 @@
    "source": [
     "import spatialpandas as spd\n",
     "\n",
-    "spd_world = spd.GeoDataFrame(world)\n",
-    "\n",
-    "spd_world.hvplot(datashade=True, project=True, aggregator='count_cat', c='continent', color_key='Category10')"
+    "spd_nyc = spd.GeoDataFrame(nyc)"
    ]
   },
   {
-   "cell_type": "markdown",
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
    "source": [
-    "### Spatialpandas\n",
-    "\n",
-    "Spatialpandas is another powerful library for working with geometries and is optimized for rendering with datashader, making it possible to plot millions of individual geometries very quickly:"
+    "spd_nyc.hvplot(\n",
+    "    datashade=True, project=True, aggregator='count_cat',\n",
+    "    c='boroname', color_key='Category10'\n",
+    ")"
    ]
   },
   {
@@ -267,19 +385,23 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Geographic options\n",
+    "## Options\n",
     "\n",
     "The API provides various geo-specific options:\n",
     "\n",
-    "- ``coastline`` (default=False): Whether to display a coastline on top of the plot, setting ``coastline='10m'/'50m'/'110m'`` specifies a specific scale\n",
-    "- ``crs`` (default=None): Coordinate reference system of the data (input projection) specified as Cartopy CRS object or name, proj.4 string or EPSG code \n",
-    "- ``projection`` (default=None): Coordinate reference system of the plot (output projection) specified as Cartopy CRS object or name, proj.4 string or EPSG code\n",
-    "- ``features`` features (default=None): A list of features or a dictionary of features and the scale at which to render it. Available features include 'borders', 'coastline', 'lakes', 'land', 'ocean', 'rivers' and 'states'. Available scales include '10m'/'50m'/'110m'.\n",
-    "- ``geo`` (default=False): Whether the plot should be treated as geographic (and assume PlateCarree, i.e. lat/lon coordinates)\n",
-    "- ``global_extent`` (default=False): Whether to expand the plot extent to span the whole globe\n",
-    "- ``project`` (default=False): Whether to project the data before plotting (adds initial overhead but avoids projecting data when plot is dynamically updated)\n",
-    "- ``tiles`` (default=False): Whether to overlay the plot on a tile source. Tiles sources can be selected by name, the default is 'Wikipedia'.\n",
-    "Other options are: 'CartoDark', 'CartoEco', 'CartoLight', 'CartoMidnight', 'EsriImagery', 'EsriNatGeo', 'EsriReference''EsriTerrain', 'EsriUSATopo', 'OSM', 'StamenLabels', 'StamenTerrain', 'StamenTerrainRetina', 'StamenToner', 'StamenTonerBackground', 'StamenWatercolor'. Stamen tile sources require a Stadia account when not running locally; see [stadiamaps.com](https://stadiamaps.com/)."
+    "- `coastline` (default=False): Whether to display a coastline on top of the plot, setting `coastline='10m'/'50m'/'110m'` specifies a specific scale\n",
+    "- `crs` (default=None): Coordinate reference system of the data (input projection) specified as an EPSG code (int or string), pyproj CRS or Proj object, Cartopy CRS object, proj.4 string, or WKT string. Defaults to PlateCarree.\n",
+    "- `features` features (default=None): A list of features or a dictionary of features and the scale at which to render it. Available features include 'borders', 'coastline', 'lakes', 'land', 'ocean', 'rivers' and 'states'. Available scales include '10m'/'50m'/'110m'.\n",
+    "- `geo` (default=False): Whether the plot should be treated as geographic (and assume PlateCarree, i.e. lat/lon coordinates)\n",
+    "- `global_extent` (default=False): Whether to expand the plot extent to span the whole globe\n",
+    "- `project` (default=False): Whether to project the data before plotting (adds initial overhead but avoids projecting data when plot is dynamically updated)\n",
+    "- `projection` (default=None): Coordinate reference system of the plot (output projection) specified as Cartopy CRS object or name.\n",
+    "- `tiles` (default=False): Whether to overlay the plot on a tile source. Accept the following values:\n",
+    "    - `True`: OpenStreetMap layer\n",
+    "    - `xyzservices.TileProvider` instance (requires [`xyzservices`](https://xyzservices.readthedocs.io/) to be installed)\n",
+    "    - a map string name based on one of the default layers made available by [HoloViews](https://holoviews.org/reference/elements/bokeh/Tiles.html) ('CartoDark', 'CartoLight', 'EsriImagery', 'EsriNatGeo', 'EsriUSATopo', 'EsriTerrain', 'EsriStreet', 'EsriReference', 'OSM', 'OpenTopoMap') or [GeoViews](https://geoviews.org/user_guide/Working_with_Bokeh.html) ('CartoDark', 'CartoEco', 'CartoLight', 'CartoMidnight', 'EsriImagery', 'EsriNatGeo', 'EsriUSATopo', 'EsriTerrain', 'EsriReference', 'EsriOceanBase', 'EsriOceanReference', 'EsriWorldPhysical', 'EsriWorldShadedRelief', 'EsriWorldTopo', 'EsriWorldDarkGrayBase', 'EsriWorldDarkGrayReference', 'EsriWorldLightGrayBase', 'EsriWorldLightGrayReference', 'EsriWorldHillshadeDark', 'EsriWorldHillshade', 'EsriAntarcticImagery', 'EsriArcticImagery', 'EsriArcticOceanBase', 'EsriArcticOceanReference', 'EsriWorldBoundariesAndPlaces', 'EsriWorldBoundariesAndPlacesAlternate', 'EsriWorldTransportation', 'EsriDelormeWorldBaseMap', 'EsriWorldNavigationCharts', 'EsriWorldStreetMap', 'OSM', 'OpenTopoMap'). Note that Stamen tile sources require a Stadia account when not running locally; see [stadiamaps.com](https://stadiamaps.com/).\n",
+    "    - a `holoviews.Tiles` or `geoviews.WMTS` instance or class\n",
+    "- `tiles_opts` (default=None): Dictionary of plotting options to customize the tiles layer created when `tiles` is set, e.g. `dict(alpha=0.5)`."
    ]
   }
  ],

--- a/doc/user_guide/Geographic_Data.ipynb
+++ b/doc/user_guide/Geographic_Data.ipynb
@@ -36,7 +36,7 @@
     "\n",
     "Before plotting geographical data, you should know in which [coordinate system](https://en.wikipedia.org/wiki/Spatial_reference_system) the data is represented. This is important for a few reasons:\n",
     "\n",
-    "- The data may have to be [projected](https://en.wikipedia.org/wiki/Map_projection) to another coordinate system, and to do so you may have to provide the orinal coordinate system.\n",
+    "- The data may have to be [projected](https://en.wikipedia.org/wiki/Map_projection) to another coordinate system, and to do so you may have to provide the original coordinate system.\n",
     "- Projecting data can be a computationally expensive operation and you should be aware of when this operation happens, to perhaps optimize it.\n",
     "\n",
     "Here are two common coordinate systems you will encounter when dealing with geographic data and using hvPlot:\n",
@@ -78,7 +78,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We'll first start by displaying the airports **without GeoViews**. To do so, we must convert the coordinates to Web Mercator, which can be easily achieved using the `lon_lat_to_easting_northing` function provided by HoloViews."
+    "We'll first start by displaying the airports **without GeoViews**. To do so, we must convert the coordinates to Web Mercator, which can be easily achieved using the `lon_lat_to_easting_northing` function provided by HoloViews, that doesn't require installing any of the usual geo dependencies like `pyproj` or `cartopy`."
    ]
   },
   {
@@ -113,7 +113,26 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "If GeoViews is installed, you can set `geo=True` to let hvPlot know that it can leverage it to display the data. With this set up, you can directly plot the airports without having to project the data yourself."
+    "A common mistake is to display data referenced in WGS84 on a tile basemap without projecting the data to Web Mercator. In doing so, the data will be plotted around the [null island location](https://en.wikipedia.org/wiki/Null_Island), roughly 600km off the coast of West Africa."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "airports.hvplot.points(\n",
+    "    'Longitude', 'Latitude', tiles=True, color='red', alpha=0.2,\n",
+    "    xlim=(-1000000, 1000000), ylim=(-1000000, 1000000)\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "When **GeoViews** is installed, you can set `geo=True` to let hvPlot know that it can leverage it to display the data. You can directly plot the airports without having to project the data yourself, GeoViews will take care of projecting it to Web Mercator automatically."
    ]
   },
   {
@@ -133,11 +152,11 @@
    "source": [
     "The easiest ways to set `tiles` include:\n",
     "\n",
-    "- to `True` to get the default layer which currently is from OpenStreetMap (prefer an explicit definition if you care about reproducibility)\n",
-    "- with an `xyzservices.TileProvider` instance, as installing [`xyzservices`](https://xyzservices.readthedocs.io/) gives you access to hundreds of tiled web maps this package collects.\n",
+    "- to `True` to get the default layer which currently is from OpenStreetMap (prefer one of the explicit approaches below if you care about reproducibility)\n",
+    "- with an `xyzservices.TileProvider` instance that can be created from the optional dependency [xyzservices](https://xyzservices.readthedocs.io/) which gives you access to hundreds of tiled web maps\n",
     "- with the name of one the layers shipped by HoloViews and GeoViews (when it's installed), like `'EsriTerrain'`.\n",
     "\n",
-    "The tile map can be optionally configured by setting `tiles_opts`."
+    "The tile map can be additionally configured by setting `tiles_opts` with a dictionary of options that will be applied to the basemap layer."
    ]
   },
   {
@@ -183,11 +202,11 @@
     "As we have seen in the previous section, you can set `geo=True` to let hvPlot know that your data is geographic. GeoViews **must be installed** when setting `geo=True`, or when any of the other geographic options is set, except `tiles`. In this mode hvPlot:\n",
     "\n",
     "1. Assumes the data is expressed in lat/lon coordinates. Internally, hvPlot assumes a [Plate Carrée](https://en.wikipedia.org/wiki/Equirectangular_projection) projection, also known as the *equirectangular projection*.\n",
-    "2. Displays the data in the projection *Plate Carrée* assumed in 1), or, if `tiles=True`, projects and displays the data in the Web Mercator projection.\n",
+    "2. Displays the data in the projection *Plate Carrée* assumed in step (1), or, if `tiles=True`, projects and displays the data in the Web Mercator projection.\n",
     "\n",
-    "The *input* data projection assumed in step 1), and the *output* plot projection used in step 2) can both be overridden with the `crs` (for Coordinate Reference System) and `projection` parameters, respectively. Both parameters accept cartopy `CRS` objects (see the full list of values they accept in their definition). You can now see that that setting `geo=True, tiles=True` is strictly equivalent to setting `crs=ccrs.PlateCarree(), projection=ccrs.GOOGLE_MERCATOR`! Coordinate reference systems are described in more details in the [GeoViews documentation](https://geoviews.org/user_guide/Projections.html) and the full list of available CRSs is in the [cartopy documentation](https://scitools.org.uk/cartopy/docs/latest/reference/projections.html).\n",
+    "The *input* data projection assumed in step (1), and the *output* plot projection used in step (2) can both be overridden with the `crs` (for Coordinate Reference System) and `projection` parameters, respectively. Both parameters accept cartopy `CRS` objects (see the full list of values they accept in their definition). You can now see that that setting `geo=True, tiles=True` is strictly equivalent to setting `crs=ccrs.PlateCarree(), projection=ccrs.GOOGLE_MERCATOR`! Coordinate reference systems are described in more details in the [GeoViews documentation](https://geoviews.org/user_guide/Projections.html) and the full list of available CRSs is in the [cartopy documentation](https://scitools.org.uk/cartopy/docs/latest/reference/projections.html).\n",
     "\n",
-    "Setting `projection`, we can display the airports on an Orthographic projection centered over North America."
+    "For example, we can set `projection` to display the airports on an Orthographic projection centered over North America."
    ]
   },
   {

--- a/envs/py3.10-tests.yaml
+++ b/envs/py3.10-tests.yaml
@@ -24,6 +24,7 @@ dependencies:
   - fiona
   - flake8
   - fugue
+  - geodatasets>=2023.12.0
   - geopandas
   - geoviews-core>=1.9.0
   - holoviews>=1.11.0
@@ -65,6 +66,7 @@ dependencies:
   - streamz>=0.3.0
   - xarray
   - xarray>=0.18.2
+  - xyzservices>=2022.9.0
   - pip
   - pip:
     - -e ..

--- a/envs/py3.11-docs.yaml
+++ b/envs/py3.11-docs.yaml
@@ -21,6 +21,7 @@ dependencies:
   - datashader>=0.6.5
   - fiona
   - fugue
+  - geodatasets>=2023.12.0
   - geopandas
   - geoviews-core>=1.9.0
   - holoviews>=1.11.0
@@ -55,6 +56,7 @@ dependencies:
   - sphinxext-rediraffe
   - streamz>=0.3.0
   - xarray>=0.18.2
+  - xyzservices>=2022.9.0
   - pip
   - pip:
     - -e ..

--- a/envs/py3.11-tests.yaml
+++ b/envs/py3.11-tests.yaml
@@ -24,6 +24,7 @@ dependencies:
   - fiona
   - flake8
   - fugue
+  - geodatasets>=2023.12.0
   - geopandas
   - geoviews-core>=1.9.0
   - holoviews>=1.11.0
@@ -65,6 +66,7 @@ dependencies:
   - streamz>=0.3.0
   - xarray
   - xarray>=0.18.2
+  - xyzservices>=2022.9.0
   - pip
   - pip:
     - -e ..

--- a/envs/py3.12-tests.yaml
+++ b/envs/py3.12-tests.yaml
@@ -24,6 +24,7 @@ dependencies:
   - fiona
   - flake8
   - fugue
+  - geodatasets>=2023.12.0
   - geopandas
   - geoviews-core>=1.9.0
   - holoviews>=1.11.0
@@ -65,6 +66,7 @@ dependencies:
   - streamz>=0.3.0
   - xarray
   - xarray>=0.18.2
+  - xyzservices>=2022.9.0
   - pip
   - pip:
     - -e ..

--- a/envs/py3.8-tests.yaml
+++ b/envs/py3.8-tests.yaml
@@ -24,6 +24,7 @@ dependencies:
   - fiona
   - flake8
   - fugue
+  - geodatasets>=2023.12.0
   - geopandas
   - geoviews-core>=1.9.0
   - holoviews>=1.11.0
@@ -65,6 +66,7 @@ dependencies:
   - streamz>=0.3.0
   - xarray
   - xarray>=0.18.2
+  - xyzservices>=2022.9.0
   - pip
   - pip:
     - -e ..

--- a/envs/py3.9-tests.yaml
+++ b/envs/py3.9-tests.yaml
@@ -24,6 +24,7 @@ dependencies:
   - fiona
   - flake8
   - fugue
+  - geodatasets>=2023.12.0
   - geopandas
   - geoviews-core>=1.9.0
   - holoviews>=1.11.0
@@ -65,6 +66,7 @@ dependencies:
   - streamz>=0.3.0
   - xarray
   - xarray>=0.18.2
+  - xyzservices>=2022.9.0
   - pip
   - pip:
     - -e ..

--- a/hvplot/converter.py
+++ b/hvplot/converter.py
@@ -690,9 +690,11 @@ class HoloViewsConverter:
         if hasattr(data, 'rio') and data.rio.crs is not None:
             # if data is a rioxarray
             _crs = data.rio.crs.to_wkt()
-        else:
-            # get the proj string: either the value of data.attrs[crs] or crs itself
+        # get the proj string: either the value of data.attrs[crs] or crs itself
+        elif isinstance(crs, str):
             _crs = getattr(data, 'attrs', {}).get(crs or 'crs', crs)
+        else:
+            _crs = crs
 
         try:
             return process_crs(_crs)

--- a/hvplot/tests/testgeo.py
+++ b/hvplot/tests/testgeo.py
@@ -33,9 +33,10 @@ class TestGeo(TestCase):
             import rasterio  # noqa
             import geoviews  # noqa
             import cartopy.crs as ccrs  # noqa
+            import pyproj  # noqa
             import rioxarray as rxr
         except:
-            raise SkipTest('xarray, rasterio, geoviews, cartopy, or rioxarray not available')
+            raise SkipTest('xarray, rasterio, geoviews, cartopy, pyproj or rioxarray not available')
         import hvplot.xarray  # noqa
         import hvplot.pandas  # noqa
         self.da = rxr.open_rasterio(
@@ -276,6 +277,14 @@ class TestGeoAnnotation(TestCase):
         plot = self.df.hvplot.points('x', 'y', geo=True, tiles=gv.tile_sources.CartoDark)
         self.assertEqual(len(plot), 2)
         self.assertIsInstance(plot.get(0), gv.element.WMTS)
+
+    def test_plot_with_xyzservices_tiles(self):
+        xyzservices = pytest.importorskip("xyzservices")
+        import geoviews as gv
+        plot = self.df.hvplot.points('x', 'y', geo=True, tiles=xyzservices.providers.Esri.WorldImagery)
+        assert len(plot) == 2
+        assert isinstance(plot.get(0), gv.element.WMTS)
+        assert isinstance(plot.get(0).data, xyzservices.TileProvider)
 
     def test_plot_with_features_properly_overlaid_underlaid(self):
         # land should be under, borders should be over

--- a/hvplot/tests/testgeo.py
+++ b/hvplot/tests/testgeo.py
@@ -87,6 +87,13 @@ class TestProjections(TestGeo):
         plot = da.hvplot.image('x', 'y', crs='bar')
         self.assertCRS(plot)
 
+    def test_plot_with_crs_as_pyproj_Proj(self):
+        import pyproj
+        da = self.da.copy()
+        da.rio._crs = False  # To not treat it as a rioxarray
+        plot = da.hvplot.image('x', 'y', crs=pyproj.Proj(self.crs))
+        self.assertCRS(plot)
+
     def test_plot_with_crs_as_nonexistent_attr_str(self):
         da = self.da.copy()
         da.rio._crs = False  # To not treat it as a rioxarray

--- a/hvplot/tests/testgeowithoutgv.py
+++ b/hvplot/tests/testgeowithoutgv.py
@@ -48,3 +48,12 @@ class TestAnnotationNotGeo:
         assert 'ArcGIS' in plot.get(0).data
         bk_plot = bk_renderer.get_plot(plot)
         assert bk_plot.projection == 'mercator'
+
+    def test_plot_with_xyzservices_tileprovider(self, simple_df):
+        xyzservices = pytest.importorskip("xyzservices")
+        plot = simple_df.hvplot.points('x', 'y', tiles=xyzservices.providers.Esri.WorldImagery)
+        assert len(plot) == 2
+        assert isinstance(plot.get(0), hv.Tiles)
+        assert isinstance(plot.get(0).data, xyzservices.TileProvider)
+        bk_plot = bk_renderer.get_plot(plot)
+        assert bk_plot.projection == 'mercator'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,6 +115,8 @@ examples = [
     "selenium >=3.141.0",
     "streamz >=0.3.0",
     "xarray >=0.18.2",
+    "xyzservices >=2022.9.0",
+    "geodatasets >=2023.12.0",
 ]
 tests-nb = [
     "pytest-xdist",


### PR DESCRIPTION
Implements https://github.com/holoviz/hvplot/issues/1289

And also refactors the geographic guide to start by introducing the `tiles=True` usage without GeoViews installed, since this was not documented but is used a few times on examples.holoviz.org.