### PR TITLE
Allow to set the background color with `bgcolor`

### DIFF
--- a/doc/reference/tabular/area.ipynb
+++ b/doc/reference/tabular/area.ipynb
@@ -47,8 +47,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "data.hvplot.area(x='Year', y='Computer Science', label='% of Computer Science Degrees Earned by Women',\n",
-    "                 ylim=(0, 100), width=500, height=400).opts(bgcolor='goldenrod')"
+    "data.hvplot.area(\n",
+    "    x='Year', y='Computer Science',\n",
+    "    label='% of Computer Science Degrees Earned by Women',\n",
+    "    ylim=(0, 100), width=500, height=400, bgcolor='goldenrod',\n",
+    ")"
    ]
   },
   {

--- a/doc/user_guide/Customization.ipynb
+++ b/doc/user_guide/Customization.ipynb
@@ -42,6 +42,8 @@
     "\n",
     "The generic set of options which may apply to all plot types include:\n",
     "\n",
+    "    bgcolor: str\n",
+    "        Background color of the data area of the plot\n",
     "    clim: tuple\n",
     "        Lower and upper bound of the color scale\n",
     "    cnorm (default='linear'): str\n",

--- a/hvplot/converter.py
+++ b/hvplot/converter.py
@@ -290,7 +290,7 @@ class HoloViewsConverter:
         'yaxis', 'xformatter', 'yformatter', 'xlabel', 'ylabel',
         'clabel', 'padding', 'responsive', 'max_height', 'max_width',
         'min_height', 'min_width', 'frame_height', 'frame_width',
-        'aspect', 'data_aspect', 'fontscale'
+        'aspect', 'data_aspect', 'fontscale', 'bgcolor',
     ]
 
     _style_options = [

--- a/hvplot/converter.py
+++ b/hvplot/converter.py
@@ -86,6 +86,8 @@ class HoloViewsConverter:
     autorange (default=None): Literal['x', 'y'] | None
         Whether to enable auto-ranging along the x- or y-axis when
         zooming. Requires HoloViews >= 1.16.
+    bgcolor (default=None): str
+        Background color of the data area of the plot
     clim: tuple
         Lower and upper bound of the color scale
     cnorm (default='linear'): str
@@ -546,7 +548,7 @@ class HoloViewsConverter:
                    'height', 'width', 'frame_height', 'frame_width',
                    'min_width', 'min_height', 'max_width', 'max_height',
                    'fontsize', 'fontscale', 'responsive', 'shared_axes',
-                   'aspect', 'data_aspect']
+                   'aspect', 'data_aspect', 'bgcolor']
         for plotwd in plotwds:
             if plotwd in kwds:
                 plot_opts[plotwd] = kwds.pop(plotwd)

--- a/hvplot/tests/testoptions.py
+++ b/hvplot/tests/testoptions.py
@@ -460,6 +460,11 @@ class TestOptions:
         assert opts.kwargs['cut'] == 1
         assert opts.kwargs['filled'] is True
 
+    def test_bgcolor(self, df, backend):
+        plot = df.hvplot.scatter('x', 'y', bgcolor='black')
+        opts = Store.lookup_options(backend, plot, 'plot')
+        assert opts.kwargs['bgcolor'] == 'black'
+
 
 @pytest.fixture(scope='module')
 def da():


### PR DESCRIPTION
Implements https://github.com/holoviz/hvplot/issues/636

@droumis FYI I have noticed that the converter `__init__` signature does not include this kind of plot options passed down to HoloViews. Perhaps they should be added to the signature to later be included in some API reference docs.