### PR TITLE
Fix setting `group_label` when plotting a hist

### DIFF
--- a/hvplot/converter.py
+++ b/hvplot/converter.py
@@ -1946,7 +1946,7 @@ class HoloViewsConverter:
         for col in y:
             hist = histogram(ds, dimension=col, **hist_opts)
             hists.append((col, hist.relabel(**self._relabel)))
-        return (self._by_type(hists, sort=False)
+        return (self._by_type(hists, self.group_label, sort=False)
                 .redim(**self._redim)
                 .opts(cur_opts, backend='bokeh')
                 .opts(compat_opts, backend=self._backend_compat))

--- a/hvplot/tests/testcharts.py
+++ b/hvplot/tests/testcharts.py
@@ -268,6 +268,10 @@ class TestChart1D(ComparisonTestCase):
         opts = Store.lookup_options('bokeh', plot, 'plot')
         self.assertEqual(opts.kwargs['legend_position'], 'left')
 
+    def test_histogram_wide_set_group_label(self):
+        plot = self.df.hvplot.hist(group_label='Test')
+        assert plot.kdims[0].name == 'Test'
+
     def test_scatter_color_internally_set_to_dim(self):
         altered_df = self.cat_df.copy().rename(columns={'category': 'red'})
         plot = altered_df.hvplot.scatter('x', 'y', c='red')


### PR DESCRIPTION
Observed while reviewing https://github.com/holoviz-topics/examples/pull/376.

Before:
<img width="426" alt="image" src="https://github.com/holoviz/hvplot/assets/35924738/b69251fa-1191-4dcc-ab61-9187b44243d6">
<img width="1649" alt="image" src="https://github.com/holoviz/hvplot/assets/35924738/abda586d-9e7d-4dbd-b121-892c998fe07a">

After:
<img width="438" alt="image" src="https://github.com/holoviz/hvplot/assets/35924738/57d51c77-0ee7-4a67-9575-654e6dc92329">
<img width="1673" alt="image" src="https://github.com/holoviz/hvplot/assets/35924738/70f11879-a4a3-4918-bc8a-c10575feea08">
