### PR TITLE
Allow algorithm as str input to `downsample` operation

### DIFF
--- a/hvplot/converter.py
+++ b/hvplot/converter.py
@@ -209,19 +209,23 @@ class HoloViewsConverter:
         Controls the application of downsampling to the plotted data,
         which is particularly useful for large timeseries datasets to
         reduce the amount of data sent to browser and improve
-        visualization performance. Requires HoloViews >= 1.16. Acceptable
-        values: - False: No downsampling is applied. - True: Applies
-        downsampling using HoloViews' default algorithm
+        visualization performance. Requires HoloViews >= 1.16. Additional
+        dependencies: Installing the `tsdownsampler` library is required
+        for using any downsampling methods other than the default 'lttb'.
+        Acceptable values:
+        - False: No downsampling is applied.
+        - True: Applies downsampling using HoloViews' default algorithm
             (LTTB - Largest Triangle Three Buckets).
         - 'lttb': Explicitly applies the Largest Triangle Three Buckets
           algorithm.
         - 'minmax': Applies the MinMax algorithm, selecting the minimum
-          and maximum values in each bin.
+          and maximum values in each bin. Requires `tsdownsampler`.
         - 'm4': Applies the M4 algorithm, selecting the minimum, maximum,
-          first, and last values in each bin.
+          first, and last values in each bin. Requires `tsdownsampler`.
         - 'minmax-lttb': Combines MinMax and LTTB algorithms for
           downsampling, first applying MinMax to reduce to a preliminary
-          set of points, then LTTB for further reduction.
+          set of points, then LTTB for further reduction. Requires
+          `tsdownsampler`.
         Other string values corresponding to supported algorithms in
         HoloViews may also be used.
     dynspread (default=False):

--- a/hvplot/converter.py
+++ b/hvplot/converter.py
@@ -210,7 +210,7 @@ class HoloViewsConverter:
         which is particularly useful for large timeseries datasets to
         reduce the amount of data sent to browser and improve
         visualization performance. Requires HoloViews >= 1.16. Additional
-        dependencies: Installing the `tsdownsampler` library is required
+        dependencies: Installing the `tsdownsample` library is required
         for using any downsampling methods other than the default 'lttb'.
         Acceptable values:
         - False: No downsampling is applied.
@@ -219,13 +219,13 @@ class HoloViewsConverter:
         - 'lttb': Explicitly applies the Largest Triangle Three Buckets
           algorithm.
         - 'minmax': Applies the MinMax algorithm, selecting the minimum
-          and maximum values in each bin. Requires `tsdownsampler`.
+          and maximum values in each bin. Requires `tsdownsample`.
         - 'm4': Applies the M4 algorithm, selecting the minimum, maximum,
-          first, and last values in each bin. Requires `tsdownsampler`.
+          first, and last values in each bin. Requires `tsdownsample`.
         - 'minmax-lttb': Combines MinMax and LTTB algorithms for
           downsampling, first applying MinMax to reduce to a preliminary
           set of points, then LTTB for further reduction. Requires
-          `tsdownsampler`.
+          `tsdownsample`.
         Other string values corresponding to supported algorithms in
         HoloViews may also be used.
     dynspread (default=False):

--- a/hvplot/converter.py
+++ b/hvplot/converter.py
@@ -206,9 +206,24 @@ class HoloViewsConverter:
         the Datashader library, returning an RGB object instead of
         individual points
     downsample (default=False):
-        Whether to apply LTTB (Largest Triangle Three Buckets)
-        downsampling to the element (note this is only well behaved for
-        timeseries data). Requires HoloViews >= 1.16.
+        Controls the application of downsampling to the plotted data,
+        which is particularly useful for large timeseries datasets to
+        reduce the amount of data sent to browser and improve
+        visualization performance. Requires HoloViews >= 1.16. Acceptable
+        values: - False: No downsampling is applied. - True: Applies
+        downsampling using HoloViews' default algorithm
+            (LTTB - Largest Triangle Three Buckets).
+        - 'lttb': Explicitly applies the Largest Triangle Three Buckets
+          algorithm.
+        - 'minmax': Applies the MinMax algorithm, selecting the minimum
+          and maximum values in each bin.
+        - 'm4': Applies the M4 algorithm, selecting the minimum, maximum,
+          first, and last values in each bin.
+        - 'minmax-lttb': Combines MinMax and LTTB algorithms for
+          downsampling, first applying MinMax to reduce to a preliminary
+          set of points, then LTTB for further reduction.
+        Other string values corresponding to supported algorithms in
+        HoloViews may also be used.
     dynspread (default=False):
         For plots generated with datashade=True or rasterize=True,
         automatically increase the point size when the data is sparse
@@ -1320,6 +1335,11 @@ class HoloViewsConverter:
                 from holoviews.operation.downsample import downsample1d
             except ImportError:
                 raise ImportError('Downsampling requires HoloViews >=1.16')
+
+            # Let HoloViews choose the default algo if 'downsample' is True.
+            # Otherwise, user-specified algorithm
+            if isinstance(self.downsample, str):
+                opts['algorithm'] = self.downsample
 
             if self.x_sampling:
                 opts['x_sampling'] = self.x_sampling

--- a/hvplot/tests/testoperations.py
+++ b/hvplot/tests/testoperations.py
@@ -326,4 +326,4 @@ class TestDownsample(ComparisonTestCase):
         plot = self.df.hvplot.line(downsample='minmax')
 
         assert isinstance(plot.callback.operation, downsample1d)
-        assert plot.callback.operation.algorithm == 'minmax'
+        assert plot.callback.operation_kwargs['algorithm'] == 'minmax'

--- a/hvplot/tests/testoperations.py
+++ b/hvplot/tests/testoperations.py
@@ -319,3 +319,11 @@ class TestDownsample(ComparisonTestCase):
         assert plot.callback.operation.p.height == 50
         assert plot.callback.operation.p.x_sampling == 5
         assert plot.callback.operation.p.x_range == (0, 5)
+
+    def test_downsample_algorithm_minmax(self):
+        from holoviews.operation.downsample import downsample1d
+
+        plot = self.df.hvplot.line(downsample='minmax')
+
+        assert isinstance(plot.callback.operation, downsample1d)
+        assert plot.callback.operation.algorithm == 'minmax'


### PR DESCRIPTION
fixes #1312

This pull request updates the handling of the `downsample` parameter in hvPlot. Previously, the parameter only accepted a boolean value. With these changes, users can now specify the downsampling algorithm directly, provided they have 'tsdownsample' library installed.

```python
"""
downsample (default=False):
        Controls the application of downsampling to the plotted data,
        which is particularly useful for large timeseries datasets to
        reduce the amount of data sent to browser and improve
        visualization performance. Requires HoloViews >= 1.16. Additional
        dependencies: Installing the `tsdownsample` library is required
        for using any downsampling methods other than the default 'lttb'.
        Acceptable values:
        - False: No downsampling is applied.
        - True: Applies downsampling using HoloViews' default algorithm
            (LTTB - Largest Triangle Three Buckets).
        - 'lttb': Explicitly applies the Largest Triangle Three Buckets
          algorithm.
        - 'minmax': Applies the MinMax algorithm, selecting the minimum
          and maximum values in each bin. Requires `tsdownsample`.
        - 'm4': Applies the M4 algorithm, selecting the minimum, maximum,
          first, and last values in each bin. Requires `tsdownsample`.
        - 'minmax-lttb': Combines MinMax and LTTB algorithms for
          downsampling, first applying MinMax to reduce to a preliminary
          set of points, then LTTB for further reduction. Requires
          `tsdownsample`.
        Other string values corresponding to supported algorithms in
        HoloViews may also be used.
"""
```

- [x] add tests
- [x] add docs (already in large timeseries nb)
