### PR TITLE
ImageStack support and aggregator fixes

### DIFF
--- a/hvplot/util.py
+++ b/hvplot/util.py
@@ -614,3 +614,15 @@ def instantiate_crs_str(crs_str: str, **kwargs):
     if crs_str.upper() == 'GOOGLE_MERCATOR':
         return ccrs.GOOGLE_MERCATOR
     return getattr(ccrs, crs_str)(**kwargs)
+
+
+def import_datashader():
+    datashader = None
+    try:
+        import datashader
+    except ModuleNotFoundError:
+        raise ModuleNotFoundError(
+            'The `datashader` package must be installed in order to use '
+            'datashading features. Install it with pip or conda.'
+        ) from None
+    return datashader


### PR DESCRIPTION
Fixes https://github.com/holoviz/hvplot/issues/1315

With these changes:

- `rasterize=True, by='cat'` is equivalent to `rasterize=True, aggregator=ds.count_cat('cat')`
- the value of `eltype` is correctly set to `ImageStack` when an ImageStack should be returned, so the options are correctly applied to the output of the operation

I've moved the logic that infers whether a datashaded plot is categorical or not and the aggregator to a method that is used in two places.

```python
import datashader as ds
import numpy as np
import pandas as pd
import hvplot.pandas

num=10000

dists = {cat: pd.DataFrame(dict([('x',np.random.normal(x,s,num)), 
                                 ('y',np.random.normal(y,s,num)), 
                                 ('val',val), 
                                 ('cat',cat)]))      
         for x,  y,  s,  val, cat in 
         [(  2,  2, 0.03, 10, "d1"), 
          (  2, -2, 0.10, 20, "d2"), 
          ( -2, -2, 0.50, 30, "d3"), 
          ( -2,  2, 1.00, 40, "d4"), 
          (  0,  0, 3.00, 50, "d5")] }

df = pd.concat(dists,ignore_index=True)
df["cat"]=df["cat"].astype("category")

p = df.hvplot.scatter('x', 'y', rasterize=True, aggregator=ds.count_cat('cat'), width=800)
p
```

![image](https://github.com/holoviz/hvplot/assets/35924738/68898f6f-ef29-464c-94f6-0f8df8160251)
