### PR TITLE
Fix conda tests

### DIFF
--- a/doc/conftest.py
+++ b/doc/conftest.py
@@ -36,6 +36,7 @@ except RuntimeError:
     # hvplot.save() with bokeh
     collect_ignore_glob += [
         'user_guide/Viewing.ipynb',
+        'user_guide/NetworkX.ipynb',
     ]
 finally:
     webdriver_control.cleanup()

--- a/envs/py3.10-tests.yaml
+++ b/envs/py3.10-tests.yaml
@@ -22,6 +22,7 @@ dependencies:
   - datashader>=0.6.5
   - fiona
   - fugue
+  - fugue-sql-antlr>=0.2.0
   - geodatasets>=2023.12.0
   - geopandas
   - geoviews-core>=1.9.0
@@ -31,6 +32,7 @@ dependencies:
   - intake-xarray>=0.5.0
   - intake<2.0.0,>=0.6.5
   - ipywidgets
+  - jinja2
   - matplotlib
   - nbval
   - networkx>=2.6.3
@@ -53,6 +55,7 @@ dependencies:
   - pytest
   - pytest-cov
   - pytest-xdist
+  - qpd>=0.4.4
   - rasterio
   - rioxarray
   - ruff
@@ -63,6 +66,7 @@ dependencies:
   - selenium>=3.141.0
   - setuptools_scm>=6
   - spatialpandas>=0.4.3
+  - sqlglot
   - streamz>=0.3.0
   - xarray
   - xarray>=0.18.2

--- a/envs/py3.11-docs.yaml
+++ b/envs/py3.11-docs.yaml
@@ -21,6 +21,7 @@ dependencies:
   - datashader>=0.6.5
   - fiona
   - fugue
+  - fugue-sql-antlr>=0.2.0
   - geodatasets>=2023.12.0
   - geopandas
   - geoviews-core>=1.9.0
@@ -30,6 +31,7 @@ dependencies:
   - intake-xarray>=0.5.0
   - intake<2.0.0,>=0.6.5
   - ipywidgets
+  - jinja2
   - matplotlib
   - nbsite>=0.8.4
   - networkx>=2.6.3
@@ -46,6 +48,7 @@ dependencies:
   - pooch>=1.6.0
   - pygraphviz
   - pyproj
+  - qpd>=0.4.4
   - rasterio
   - rioxarray
   - s3fs>=2022.1.0
@@ -55,6 +58,7 @@ dependencies:
   - setuptools_scm>=6
   - spatialpandas>=0.4.3
   - sphinxext-rediraffe
+  - sqlglot
   - streamz>=0.3.0
   - xarray>=0.18.2
   - xyzservices>=2022.9.0

--- a/envs/py3.11-tests.yaml
+++ b/envs/py3.11-tests.yaml
@@ -22,6 +22,7 @@ dependencies:
   - datashader>=0.6.5
   - fiona
   - fugue
+  - fugue-sql-antlr>=0.2.0
   - geodatasets>=2023.12.0
   - geopandas
   - geoviews-core>=1.9.0
@@ -31,6 +32,7 @@ dependencies:
   - intake-xarray>=0.5.0
   - intake<2.0.0,>=0.6.5
   - ipywidgets
+  - jinja2
   - matplotlib
   - nbval
   - networkx>=2.6.3
@@ -53,6 +55,7 @@ dependencies:
   - pytest
   - pytest-cov
   - pytest-xdist
+  - qpd>=0.4.4
   - rasterio
   - rioxarray
   - ruff
@@ -63,6 +66,7 @@ dependencies:
   - selenium>=3.141.0
   - setuptools_scm>=6
   - spatialpandas>=0.4.3
+  - sqlglot
   - streamz>=0.3.0
   - xarray
   - xarray>=0.18.2

--- a/envs/py3.12-tests.yaml
+++ b/envs/py3.12-tests.yaml
@@ -22,6 +22,7 @@ dependencies:
   - datashader>=0.6.5
   - fiona
   - fugue
+  - fugue-sql-antlr>=0.2.0
   - geodatasets>=2023.12.0
   - geopandas
   - geoviews-core>=1.9.0
@@ -31,6 +32,7 @@ dependencies:
   - intake-xarray>=0.5.0
   - intake<2.0.0,>=0.6.5
   - ipywidgets
+  - jinja2
   - matplotlib
   - nbval
   - networkx>=2.6.3
@@ -53,6 +55,7 @@ dependencies:
   - pytest
   - pytest-cov
   - pytest-xdist
+  - qpd>=0.4.4
   - rasterio
   - rioxarray
   - ruff
@@ -63,6 +66,7 @@ dependencies:
   - selenium>=3.141.0
   - setuptools_scm>=6
   - spatialpandas>=0.4.3
+  - sqlglot
   - streamz>=0.3.0
   - xarray
   - xarray>=0.18.2

--- a/envs/py3.8-tests.yaml
+++ b/envs/py3.8-tests.yaml
@@ -22,6 +22,7 @@ dependencies:
   - datashader>=0.6.5
   - fiona
   - fugue
+  - fugue-sql-antlr>=0.2.0
   - geodatasets>=2023.12.0
   - geopandas
   - geoviews-core>=1.9.0
@@ -31,6 +32,7 @@ dependencies:
   - intake-xarray>=0.5.0
   - intake<2.0.0,>=0.6.5
   - ipywidgets
+  - jinja2
   - matplotlib
   - nbval
   - networkx>=2.6.3
@@ -53,6 +55,7 @@ dependencies:
   - pytest
   - pytest-cov
   - pytest-xdist
+  - qpd>=0.4.4
   - rasterio
   - rioxarray
   - ruff
@@ -63,6 +66,7 @@ dependencies:
   - selenium>=3.141.0
   - setuptools_scm>=6
   - spatialpandas>=0.4.3
+  - sqlglot
   - streamz>=0.3.0
   - xarray
   - xarray>=0.18.2

--- a/envs/py3.9-tests.yaml
+++ b/envs/py3.9-tests.yaml
@@ -22,6 +22,7 @@ dependencies:
   - datashader>=0.6.5
   - fiona
   - fugue
+  - fugue-sql-antlr>=0.2.0
   - geodatasets>=2023.12.0
   - geopandas
   - geoviews-core>=1.9.0
@@ -31,6 +32,7 @@ dependencies:
   - intake-xarray>=0.5.0
   - intake<2.0.0,>=0.6.5
   - ipywidgets
+  - jinja2
   - matplotlib
   - nbval
   - networkx>=2.6.3
@@ -53,6 +55,7 @@ dependencies:
   - pytest
   - pytest-cov
   - pytest-xdist
+  - qpd>=0.4.4
   - rasterio
   - rioxarray
   - ruff
@@ -63,6 +66,7 @@ dependencies:
   - selenium>=3.141.0
   - setuptools_scm>=6
   - spatialpandas>=0.4.3
+  - sqlglot
   - streamz>=0.3.0
   - xarray
   - xarray>=0.18.2

--- a/hvplot/tests/testfugue.py
+++ b/hvplot/tests/testfugue.py
@@ -9,6 +9,7 @@ hvplot.util._fugue_ipython = True
 
 try:
     import fugue.api as fa
+    import fugue_sql_antlr  # noqa: F401
     import hvplot.fugue  # noqa: F401
 except ImportError:
     pytest.skip(allow_module_level=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,8 +73,18 @@ tests-core = [
 tests = [
     "hvplot[tests-core]",
     "fugue[sql]",
+    "hvplot[fugue-sql]",
+    # end fugue
     "ibis-framework[duckdb]",  # ibis-duckdb on conda
     "polars",
+]
+# In 0.9 fugue added the sql extra but didn't add a fugue-sql package, removing the sql deps from fugue
+# Adding them manually here
+fugue-sql = [
+    "qpd >=0.4.4",
+    "fugue-sql-antlr >=0.2.0",
+    "sqlglot",
+    "jinja2",
 ]
 geo = [
     "cartopy",
@@ -95,6 +105,7 @@ examples = [
     "dask[dataframe] >=2021.3.0",
     "datashader >=0.6.5",
     "fugue[sql]",
+    "hvplot[fugue-sql]",
     "ibis-framework[duckdb]",  # ibis-duckdb on conda
     "intake-parquet >=0.2.3",
     "intake-xarray >=0.5.0",


### PR DESCRIPTION
fugue 0.9.0 no longer ships with the SQL deps required to run our tests. It's easy to pip install with `pip install fugue[sql]` but there's no equivalent conda way to do so, so for now the sql deps are listed explicitly.