### PR TITLE
Support labels by

### DIFF
--- a/hvplot/converter.py
+++ b/hvplot/converter.py
@@ -2592,10 +2592,13 @@ class HoloViewsConverter:
         kdims, vdims = self._get_dimensions([x, y], [text])
         cur_opts, compat_opts = self._get_compat_opts('Labels')
         element = self._get_element('labels')
-        return (
-            element(data, kdims, vdims)
-            .redim(**self._redim)
-            .apply(self._set_backends_opts, cur_opts=cur_opts, compat_opts=compat_opts)
+        if self.by:
+            labels = Dataset(data).to(element, kdims, vdims, self.by)
+            labels = labels.layout() if self.subplots else labels.overlay(sort=False)
+        else:
+            labels = element(data, kdims, vdims)
+        return labels.redim(**self._redim).apply(
+            self._set_backends_opts, cur_opts=cur_opts, compat_opts=compat_opts
         )
 
     ##########################

--- a/hvplot/tests/testcharts.py
+++ b/hvplot/tests/testcharts.py
@@ -4,7 +4,7 @@ from unittest import SkipTest, expectedFailure
 from parameterized import parameterized
 
 from holoviews.core.dimension import Dimension
-from holoviews import NdOverlay, Store, dim, render
+from holoviews import NdLayout, NdOverlay, Store, dim, render
 from holoviews.element import Curve, Area, Scatter, Points, Path, HeatMap
 from holoviews.element.comparison import ComparisonTestCase
 
@@ -438,6 +438,16 @@ class TestChart1D(ComparisonTestCase):
             'Longitude', 'Latitude', text='{Longitude:.1f}E {Latitude:.2f}N', by='Volume {m3}'
         )
         assert isinstance(plot, NdOverlay)
+
+    def test_labels_by_subplots(self):
+        plot = self.edge_df.hvplot.labels(
+            'Longitude',
+            'Latitude',
+            text='{Longitude:.1f}E {Latitude:.2f}N',
+            by='Volume {m3}',
+            subplots=True,
+        )
+        assert isinstance(plot, NdLayout)
 
 
 class TestChart1DDask(TestChart1D):

--- a/hvplot/tests/testcharts.py
+++ b/hvplot/tests/testcharts.py
@@ -433,6 +433,12 @@ class TestChart1D(ComparisonTestCase):
         ]
         assert list(plot.data['label']) == ['-58.7E -34.58N', '-47.9E -15.78N', '-70.7E -33.45N']
 
+    def test_labels_by(self):
+        plot = self.edge_df.hvplot.labels(
+            'Longitude', 'Latitude', text='{Longitude:.1f}E {Latitude:.2f}N', by='Volume {m3}'
+        )
+        assert isinstance(plot, NdOverlay)
+
 
 class TestChart1DDask(TestChart1D):
     def setUp(self):


### PR DESCRIPTION
Closes https://github.com/holoviz/hvplot/issues/1094

```
import hvplot.pandas
import pandas as pd

df = pd.DataFrame(
    {'City': ['Buenos Aires', 'Brasilia', 'Santiago'],
     'Country': ['Argentina', 'Brazil', 'Chile'],
     'Latitude': [-34.58, -15.78, -33.45],
     'Longitude': [-58.66, -47.91, -70.66]})
df.hvplot.labels("Longitude", "Latitude", "City", by="City")
```

<img width="905" alt="image" src="https://github.com/holoviz/hvplot/assets/15331990/7d8aae4f-d03a-462f-a447-68560e76cfbf">


