### PR TITLE
do not mutate data

### DIFF
--- a/hvplot/converter.py
+++ b/hvplot/converter.py
@@ -2566,6 +2566,7 @@ class HoloViewsConverter:
         self._error_if_unavailable('labels')
         self.use_index = False
         data, x, y = self._process_chart_args(data, x, y, single_y=True)
+        data = data.copy()
 
         text = self.kwds.get('text')
         if not text:

--- a/hvplot/tests/testcharts.py
+++ b/hvplot/tests/testcharts.py
@@ -412,6 +412,7 @@ class TestChart1D(ComparisonTestCase):
         plot = self.df.hvplot('x', 'y', text='({x}, {y})', kind='labels')
         assert list(plot.dimensions()) == [Dimension('x'), Dimension('y'), Dimension('label')]
         assert list(plot.data['label']) == ['(1, 2)', '(3, 4)', '(5, 6)']
+        assert 'label' not in self.df
 
     def test_labels_no_format_edge_case(self):
         plot = self.edge_df.hvplot.labels('Longitude', 'Latitude')


### PR DESCRIPTION
I noticed that it previously mutated the data (e.g. added a `label` column).

```python
import hvplot.pandas
import pandas as pd

df = pd.DataFrame(
    {
        "City": ["Buenos Aires", "Brasilia", "Santiago", "Bogota", "Caracas"],
        "Country": ["Argentina", "Brazil", "Chile", "Colombia", "Venezuela"],
        "Latitude": [-34.58, -15.78, -33.45, 4.60, 10.48],
        "Longitude": [-58.66, -47.91, -70.66, -74.08, -66.86],
    }
)
df.hvplot.points("Longitude", "Latitude", by="City") * df.hvplot.labels(
    "Longitude", "Latitude", text="City ({Latitude:.1f}N, {Longitude:.1f}E)", by="City"
)
df
```
