### PR TITLE
Ensure date sorting of multi index Pandas dataframes

### DIFF
--- a/hvplot/converter.py
+++ b/hvplot/converter.py
@@ -2056,12 +2056,16 @@ class HoloViewsConverter:
             from pandas.api.types import is_datetime64_any_dtype as is_datetime
 
             if x in self.indexes:
-                index = self.indexes.index(x)
-                if is_datetime(data.axes[index]):
-                    data = data.sort_index(axis=self.indexes.index(x))
-            elif x in data.columns:
-                if is_datetime(data[x]):
-                    data = data.sort_values(x)
+                if isinstance(data.index, MultiIndex):
+                    idx_vals = data.index.get_level_values(x)
+                    sort_kwargs = {'level': x}
+                else:
+                    idx_vals = data.index
+                    sort_kwargs = {}
+                if is_datetime(idx_vals):
+                    data = data.sort_index(**sort_kwargs)
+            elif x in data.columns and is_datetime(data[x]):
+                data = data.sort_values(x)
 
         # set index to column if needed in hover_cols
         if self.use_index and any(

--- a/hvplot/tests/testcharts.py
+++ b/hvplot/tests/testcharts.py
@@ -363,6 +363,42 @@ class TestChart1D(ComparisonTestCase):
         assert (time == scrambled.index).all().all()
         assert len(time.unique()) == len(time)
 
+    def test_time_df_sorts_on_plot_multiindex(self):
+        df = self.time_df.set_index(['B', 'time'])
+        scrambled = df.sample(frac=1)
+        plot = scrambled.hvplot(x='time')
+        time = plot.data.index.get_level_values('time')
+        assert plot.kdims == ['time']
+        assert (time == df.index.get_level_values('time')).all()
+        assert len(time.unique()) == len(time)
+
+    def testtime_df_does_not_sort_on_plot_if_sort_date_off_multiindex(self):
+        df = self.time_df.set_index(['B', 'time'])
+        scrambled = df.sample(frac=1)
+        plot = scrambled.hvplot(x='time', sort_date=False)
+        time = plot.data.index.get_level_values('time')
+        assert plot.kdims == ['time']
+        assert (time == scrambled.index.get_level_values('time')).all().all()
+        assert len(time.unique()) == len(time)
+
+    def test_time_df_sorts_on_plot_using_multiindex_level0_as_x(self):
+        df = self.time_df.set_index(['time', 'B'])
+        scrambled = df.sample(frac=1)
+        plot = scrambled.hvplot()
+        time = plot.data.index.get_level_values('time')
+        assert plot.kdims == ['time']
+        assert (time == df.index.get_level_values('time')).all()
+        assert len(time.unique()) == len(time)
+
+    def testtime_df_does_not_sort_on_plot_if_sort_date_off_using_multiindex_level0_as_x(self):
+        df = self.time_df.set_index(['time', 'B'])
+        scrambled = df.sample(frac=1)
+        plot = scrambled.hvplot(sort_date=False)
+        time = plot.data.index.get_level_values('time')
+        assert plot.kdims == ['time']
+        assert (time == scrambled.index.get_level_values('time')).all().all()
+        assert len(time.unique()) == len(time)
+
     def test_time_df_with_groupby_as_derived_datetime(self):
         plot = self.time_df.hvplot(groupby='time.dayofweek', dynamic=False)
         assert list(plot.keys()) == [0, 1, 2, 3, 4, 5, 6]

--- a/hvplot/tests/testcharts.py
+++ b/hvplot/tests/testcharts.py
@@ -351,8 +351,7 @@ class TestChart1D(ComparisonTestCase):
         df = self.time_df.set_index('time')
         scrambled = df.sample(frac=1)
         plot = scrambled.hvplot()
-        # HoloViews 1.18 uses reset_index and 1.19 does not.
-        time = plot.data.time if 'time' in plot.data.columns else plot.data.index
+        time = plot.data.index
         assert (time == df.index).all()
         assert len(time.unique()) == len(time)
 
@@ -360,8 +359,7 @@ class TestChart1D(ComparisonTestCase):
         df = self.time_df.set_index('time')
         scrambled = df.sample(frac=1)
         plot = scrambled.hvplot(sort_date=False)
-        # HoloViews 1.18 uses reset_index and 1.19 does not.
-        time = plot.data.time if 'time' in plot.data.columns else plot.data.index
+        time = plot.data.index
         assert (time == scrambled.index).all().all()
         assert len(time.unique()) == len(time)
 

--- a/hvplot/tests/testcharts.py
+++ b/hvplot/tests/testcharts.py
@@ -1,7 +1,8 @@
-import numpy as np
-
 from unittest import SkipTest, expectedFailure
 from parameterized import parameterized
+
+import numpy as np
+import pandas as pd
 
 from holoviews.core.dimension import Dimension
 from holoviews import NdLayout, NdOverlay, Store, dim, render
@@ -13,10 +14,6 @@ from ..util import is_dask
 
 class TestChart2D(ComparisonTestCase):
     def setUp(self):
-        try:
-            import pandas as pd
-        except ImportError:
-            raise SkipTest('Pandas not available')
         import hvplot.pandas  # noqa
 
         self.df = pd.DataFrame([[1, 2], [3, 4], [5, 6]], columns=['x', 'y'])
@@ -117,10 +114,6 @@ class TestChart2DDask(TestChart2D):
 
 class TestChart1D(ComparisonTestCase):
     def setUp(self):
-        try:
-            import pandas as pd
-        except ImportError:
-            raise SkipTest('Pandas not available')
         import hvplot.pandas  # noqa
 
         self.df = pd.DataFrame([[1, 2], [3, 4], [5, 6]], columns=['x', 'y'])

--- a/hvplot/tests/testoptions.py
+++ b/hvplot/tests/testoptions.py
@@ -440,8 +440,6 @@ class TestOptions:
             assert opts.get('fig_size') == pytest.approx(50.0)
 
     def test_symmetric_dataframe(self, backend):
-        import pandas as pd
-
         df = pd.DataFrame([[1, 2, -1], [3, 4, 0], [5, 6, 1]], columns=['x', 'y', 'number'])
         plot = df.hvplot.scatter('x', 'y', c='number')
         plot_opts = Store.lookup_options(backend, plot, 'plot')

--- a/hvplot/tests/testpanel.py
+++ b/hvplot/tests/testpanel.py
@@ -2,7 +2,9 @@
 Tests for panel widgets and param objects as arguments
 """
 
-from unittest import TestCase, SkipTest
+from unittest import TestCase
+
+import panel as pn
 
 from hvplot.util import process_xarray  # noqa
 
@@ -11,8 +13,6 @@ def look_for_class(panel, classname, items=None):
     """
     Descend a panel object and find any instances of the given class
     """
-    import panel as pn
-
     if items is None:
         items = []
     if isinstance(panel, pn.layout.ListPanel):
@@ -25,20 +25,13 @@ def look_for_class(panel, classname, items=None):
 
 class TestPanelObjects(TestCase):
     def setUp(self):
-        try:
-            import panel as pn  # noqa
-            import hvplot.pandas  # noqa
-        except ImportError:
-            raise SkipTest('panel not available')
-
+        import hvplot.pandas  # noqa
         from bokeh.sampledata.iris import flowers
 
         self.flowers = flowers
         self.cols = list(self.flowers.columns[:-1])
 
     def test_using_explicit_widgets_works(self):
-        import panel as pn
-
         x = pn.widgets.Select(name='x', value='sepal_length', options=self.cols)
         y = pn.widgets.Select(name='y', value='sepal_width', options=self.cols)
         kind = pn.widgets.Select(name='kind', value='scatter', options=['bivariate', 'scatter'])
@@ -52,8 +45,6 @@ class TestPanelObjects(TestCase):
         self.flowers.hvplot(x, y=y, kind=kind.param.value, c=color)
 
     def test_casting_widgets_to_different_classes(self):
-        import panel as pn
-
         pane = self.flowers.hvplot.scatter(
             groupby='species', legend='top_right', widgets={'species': pn.widgets.DiscreteSlider}
         )
@@ -61,8 +52,6 @@ class TestPanelObjects(TestCase):
         assert len(look_for_class(pane, pn.widgets.DiscreteSlider)) == 1
 
     def test_using_explicit_widgets_with_groupby_does_not_raise_error(self):
-        import panel as pn
-
         x = pn.widgets.Select(name='x', value='sepal_length', options=self.cols)
         y = pn.widgets.Select(name='y', value='sepal_width', options=self.cols)
 

--- a/hvplot/tests/testpatch.py
+++ b/hvplot/tests/testpatch.py
@@ -5,6 +5,7 @@ Tests patching of supported libraries
 from unittest import TestCase, SkipTest
 
 import numpy as np
+import pandas as pd
 
 from hvplot.plotting import hvPlotTabular, hvPlot
 
@@ -14,14 +15,10 @@ class TestPatchPandas(TestCase):
         import hvplot.pandas  # noqa
 
     def test_pandas_series_patched(self):
-        import pandas as pd
-
         series = pd.Series([0, 1, 2])
         self.assertIsInstance(series.hvplot, hvPlotTabular)
 
     def test_pandas_dataframe_patched(self):
-        import pandas as pd
-
         df = pd.DataFrame([[1, 2], [3, 4], [5, 6]], columns=['x', 'y'])
         self.assertIsInstance(df.hvplot, hvPlotTabular)
 
@@ -35,7 +32,6 @@ class TestPatchDask(TestCase):
         import hvplot.dask  # noqa
 
     def test_dask_series_patched(self):
-        import pandas as pd
         import dask.dataframe as dd
 
         series = pd.Series([0, 1, 2])
@@ -43,7 +39,6 @@ class TestPatchDask(TestCase):
         self.assertIsInstance(dseries.hvplot, hvPlotTabular)
 
     def test_dask_dataframe_patched(self):
-        import pandas as pd
         import dask.dataframe as dd
 
         df = pd.DataFrame([[1, 2], [3, 4], [5, 6]], columns=['x', 'y'])

--- a/hvplot/tests/testutil.py
+++ b/hvplot/tests/testutil.py
@@ -4,6 +4,7 @@ Tests  utilities to convert data and projections
 
 import numpy as np
 import pandas as pd
+import panel as pn
 import pytest
 
 from unittest import TestCase, SkipTest
@@ -22,9 +23,8 @@ class TestProcessXarray(TestCase):
     def setUp(self):
         try:
             import xarray as xr
-            import pandas as pd  # noqa
         except ImportError:
-            raise SkipTest('xarray or pandas not available')
+            raise SkipTest('xarray not available')
         self.default_kwargs = {
             'value_label': 'value',
             'label': None,
@@ -41,7 +41,6 @@ class TestProcessXarray(TestCase):
 
     def test_process_1d_xarray_dataarray_with_no_coords(self):
         import xarray as xr
-        import pandas as pd
 
         da = xr.DataArray(data=[1, 2, 3])
 
@@ -54,7 +53,6 @@ class TestProcessXarray(TestCase):
 
     def test_process_1d_xarray_dataarray_with_coords(self):
         import xarray as xr
-        import pandas as pd
 
         da = xr.DataArray(data=[1, 2, 3], coords={'day': [5, 6, 7]}, dims=['day'])
 
@@ -67,7 +65,6 @@ class TestProcessXarray(TestCase):
 
     def test_process_1d_xarray_dataarray_with_coords_and_name(self):
         import xarray as xr
-        import pandas as pd
 
         da = xr.DataArray(data=[1, 2, 3], coords={'day': [5, 6, 7]}, dims=['day'], name='temp')
 
@@ -80,7 +77,6 @@ class TestProcessXarray(TestCase):
 
     def test_process_2d_xarray_dataarray_with_no_coords(self):
         import xarray as xr
-        import pandas as pd
 
         da = xr.DataArray(np.random.randn(4, 5))
 
@@ -126,8 +122,6 @@ class TestProcessXarray(TestCase):
         assert not groupby
 
     def test_process_3d_xarray_dataset_with_coords(self):
-        import pandas as pd
-
         data, x, y, by, groupby = process_xarray(data=self.ds, **self.default_kwargs)
         assert isinstance(data, pd.DataFrame)
         assert x == 'time'
@@ -164,8 +158,6 @@ class TestProcessXarray(TestCase):
         assert groupby == ['time']
 
     def test_process_xarray_dataset_with_by_as_derived_datetime(self):
-        import pandas as pd
-
         data = self.ds.mean(dim=['lat', 'lon'])
         kwargs = self.default_kwargs
         kwargs.update(gridded=False, y='air', by=['time.hour'])
@@ -178,8 +170,6 @@ class TestProcessXarray(TestCase):
         assert not groupby
 
     def test_process_xarray_dataset_with_x_as_derived_datetime(self):
-        import pandas as pd
-
         data = self.ds.mean(dim=['lat', 'lon'])
         kwargs = self.default_kwargs
         kwargs.update(gridded=False, y='air', x='time.dayofyear')
@@ -193,14 +183,7 @@ class TestProcessXarray(TestCase):
 
 
 class TestDynamicArgs(TestCase):
-    def setUp(self):
-        try:
-            import panel as pn  # noqa
-        except ImportError:
-            raise SkipTest('panel not available')
-
     def test_dynamic_and_static(self):
-        import panel as pn
         from ..util import process_dynamic_args
 
         x = 'sepal_width'
@@ -215,7 +198,6 @@ class TestDynamicArgs(TestCase):
         assert arg_deps == []
 
     def test_dynamic_kwds(self):
-        import panel as pn
         from ..util import process_dynamic_args
 
         x = 'sepal_length'
@@ -229,7 +211,6 @@ class TestDynamicArgs(TestCase):
         assert arg_deps == []
 
     def test_fn_kwds(self):
-        import panel as pn
         from ..util import process_dynamic_args
 
         x = 'sepal_length'


### PR DESCRIPTION
Fixes https://github.com/holoviz/hvplot/issues/1361

Also:

- Cleans up some imports in the test suite, since pandas and panel are direct dependencies of hvPlot their import doesn't need to be guarded
- Update some test code to HoloViews 1.19