### PR TITLE
Fix geopandas type check

### DIFF
--- a/hvplot/converter.py
+++ b/hvplot/converter.py
@@ -1012,6 +1012,8 @@ class HoloViewsConverter:
             if kind is None:
                 if datatype == 'geopandas':
                     geom_types = {gt[5:] if gt and 'Multi' in gt else gt for gt in data.geom_type}
+                    if None in geom_types:
+                        geom_types.remove(None)
                 else:
                     geom_types = [
                         type(data.geometry.dtype)

--- a/hvplot/converter.py
+++ b/hvplot/converter.py
@@ -1011,7 +1011,7 @@ class HoloViewsConverter:
             self.data = data
             if kind is None:
                 if datatype == 'geopandas':
-                    geom_types = {gt[5:] if 'Multi' in gt else gt for gt in data.geom_type}
+                    geom_types = {gt[5:] if gt and 'Multi' in gt else gt for gt in data.geom_type}
                 else:
                     geom_types = [
                         type(data.geometry.dtype)

--- a/hvplot/tests/testgeo.py
+++ b/hvplot/tests/testgeo.py
@@ -438,6 +438,11 @@ class TestGeoPandas(TestCase):
         opts = hv.Store.lookup_options('bokeh', polygons, 'plot').kwargs
         assert 'hover' not in opts.get('tools')
 
+    def test_geometry_none(self):
+        polygons = self.polygons.copy()
+        polygons.geometry[1] = None
+        assert polygons.hvplot(geo=True)
+
 
 class TestGeoUtil(TestCase):
     def setUp(self):


### PR DESCRIPTION
If geometry is None, it crashes:
```python
import hvplot.pandas
import censusdis.data as ced
from censusdis.datasets import ACS5
from censusdis.counties.washington import KING
from censusdis.states import WA

GROUP = "B25008"

gdf_king = ced.download(
    ACS5,
    2020,
    # Instead of listing the variables, we can ask for a whole group.
    group=GROUP,
    state=WA,
    county=KING,
    tract="*",
    with_geometry=True,
    # An optional flag that produces better maps in coastal areas.
    # More on this in the next lesson.
    remove_water=True,
)
gdf_king
```