### PR TITLE
Fix typo in MATPLOTLIB_TRANSFORMS

### DIFF
--- a/hvplot/backend_transforms.py
+++ b/hvplot/backend_transforms.py
@@ -145,7 +145,7 @@ MATPLOTLIB_TRANSFORMS = {
     'style': {
         'bar_width': UNSET,
         'size': lambda k, v: ('s', v),
-        'fill_color': lambda k, v: ('facecolor', v),
+        'fill_color': lambda k, v: ('facecolors', v),
         'fill_alpha': UNSET,
         'line_alpha': UNSET,
         'line_cap': lambda k, v: ('capstyle', _line_cap_bk_mpl_mapping.get(v, UNSET)),


### PR DESCRIPTION
I was using these transforms manually (because I've had other issues with `hvplot.extension(compatibility)` not working) and I've encountered, at least one typo/renamed option. I did not look into other ones if there are more typos there.

I have encountered a few other issues that could be addressed here:
- Missing `markers` compatibility. Reference [1][2]
- (marker) `size` is inconsistent, I am multiplying by `20` and seems alright?
- Edges are not color linked by default. Don't know how to address this

[1]: https://docs.bokeh.org/en/latest/docs/reference/models/glyphs/scatter.html#bokeh.models.Scatter
[2]: https://matplotlib.org/stable/gallery/lines_bars_and_markers/marker_reference.html#marker-reference