### PR TITLE
Use bokeh_sampledata in CI

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -50,8 +50,6 @@ jobs:
         run: |
           echo "Deploying from ref ${GITHUB_REF#refs/*/}"
           echo "tag=${GITHUB_REF#refs/*/}" >> $GITHUB_OUTPUT
-      - name: bokeh sampledata
-        run: bokeh sampledata
       - name: install dev nbsite
         run: pip install --pre -U nbsite
       - name: conda info
@@ -115,8 +113,6 @@ jobs:
         run: |
           echo "Deploying from ref ${GITHUB_REF#refs/*/}"
           echo "tag=${GITHUB_REF#refs/*/}" >> $GITHUB_OUTPUT
-      - name: bokeh sampledata
-        run: bokeh sampledata
       - name: build docs
         run: sphinx-build -b html doc builtdocs
       - name: report failure

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -132,6 +132,7 @@ jobs:
       - name: conda list
         run: conda list
       - name: bokeh sampledata
+        if: python.version == '3.9'
         run: bokeh sampledata
       - name: unit tests
         run: pytest -v hvplot --cov=hvplot --cov-append
@@ -162,6 +163,7 @@ jobs:
       - name: pip list
         run: pip list
       - name: bokeh sampledata
+        if: python.version == '3.9'
         run: bokeh sampledata
       - name: unit tests
         run: pytest -v hvplot --cov=hvplot --cov-append

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -132,7 +132,7 @@ jobs:
       - name: conda list
         run: conda list
       - name: bokeh sampledata
-        if: python.version == '3.9'
+        if: ${{ matrix.python-version == '3.9'}}
         run: bokeh sampledata
       - name: unit tests
         run: pytest -v hvplot --cov=hvplot --cov-append
@@ -163,7 +163,7 @@ jobs:
       - name: pip list
         run: pip list
       - name: bokeh sampledata
-        if: python.version == '3.9'
+        if: ${{ matrix.python-version == '3.9'}}
         run: bokeh sampledata
       - name: unit tests
         run: pytest -v hvplot --cov=hvplot --cov-append

--- a/envs/py3.10-tests.yaml
+++ b/envs/py3.10-tests.yaml
@@ -15,6 +15,7 @@ channels:
 dependencies:
   - python=3.10
   - bokeh>=3.1
+  - bokeh_sampledata
   - cartopy
   - colorcet>=2
   - dask

--- a/envs/py3.11-docs.yaml
+++ b/envs/py3.11-docs.yaml
@@ -15,6 +15,7 @@ channels:
 dependencies:
   - python=3.11
   - bokeh>=3.1
+  - bokeh_sampledata
   - cartopy
   - colorcet>=2
   - dask>=2021.3.0

--- a/envs/py3.11-tests.yaml
+++ b/envs/py3.11-tests.yaml
@@ -15,6 +15,7 @@ channels:
 dependencies:
   - python=3.11
   - bokeh>=3.1
+  - bokeh_sampledata
   - cartopy
   - colorcet>=2
   - dask

--- a/envs/py3.12-tests.yaml
+++ b/envs/py3.12-tests.yaml
@@ -15,6 +15,7 @@ channels:
 dependencies:
   - python=3.12
   - bokeh>=3.1
+  - bokeh_sampledata
   - cartopy
   - colorcet>=2
   - dask

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,7 @@ tests-core = [
     "ruff",
     "scipy",
     "xarray",
-    "bokeh_sampledata; python_version != '3.9'",
+    "bokeh_sampledata; python_version >= '3.10'",
 ]
 # Optional tests dependencies, i.e. one should be able
 # to run and pass the test suite without installing any
@@ -127,7 +127,7 @@ examples = [
     "xarray >=0.18.2",
     "xyzservices >=2022.9.0",
     "geodatasets >=2023.12.0",
-    "bokeh_sampledata; python_version != '3.9'",
+    "bokeh_sampledata; python_version >= '3.10'",
 ]
 tests-nb = [
     "pytest-xdist",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,7 @@ tests-core = [
     "ruff",
     "scipy",
     "xarray",
+    "bokeh_sampledata; python_version != '3.9'",
 ]
 # Optional tests dependencies, i.e. one should be able
 # to run and pass the test suite without installing any
@@ -126,6 +127,7 @@ examples = [
     "xarray >=0.18.2",
     "xyzservices >=2022.9.0",
     "geodatasets >=2023.12.0",
+    "bokeh_sampledata; python_version != '3.9'",
 ]
 tests-nb = [
     "pytest-xdist",


### PR DESCRIPTION
With the latest dev releases of GeoViews we are now pulling in Bokeh 3.5, making the CI fail because of the removal of `bokeh sampledata`.