### PR TITLE
test: Mark `test_explorer_geo_revise_kind` with geo marker

### DIFF
--- a/hvplot/tests/testui.py
+++ b/hvplot/tests/testui.py
@@ -391,6 +391,7 @@ def test_explorer_xarray_multi_var_extra_dims_no_coord():
 
 
 @pytest.mark.parametrize('kind_tuple', [('scatter', 'points'), ('line', 'paths')])
+@pytest.mark.geo
 def test_explorer_geo_revise_kind(kind_tuple):
     da = ds_air_temperature['air'].isel(time=0)
     explorer = hvplot.explorer(da, x='lon', y='lat', kind=kind_tuple[0], geo=True)


### PR DESCRIPTION
Observed here: https://github.com/conda-forge/hvplot-feedstock/pull/30