### PR TITLE
Support datashade points hover

### DIFF
--- a/hvplot/converter.py
+++ b/hvplot/converter.py
@@ -1830,6 +1830,11 @@ class HoloViewsConverter:
 
         # a workaround to show hover info for datashaded points
         if self.hover and self.datashade and self.kind == 'points':
+            if self.hover_mode != 'mouse':
+                param.main.param.warning(
+                    f'Got unsupported hover_mode={self.hover_mode!r} for '
+                    f"datashaded points; reverting to 'mouse'."
+                )
             inspector = inspect_points.instance(
                 streams=[PointerXY], transform=self._datashade_hover_transform
             )

--- a/hvplot/converter.py
+++ b/hvplot/converter.py
@@ -45,7 +45,7 @@ from holoviews.element import (
 from holoviews.plotting.bokeh import OverlayPlot, colormap_generator
 from holoviews.plotting.util import process_cmap
 from holoviews.operation import histogram, apply_when
-from holoviews.streams import Buffer, Pipe, PointerXY
+from holoviews.streams import Buffer, Pipe, Tap, PointerXY
 from holoviews.util.transform import dim, lon_lat_to_easting_northing
 from pandas import DatetimeIndex, MultiIndex
 
@@ -1835,8 +1835,14 @@ class HoloViewsConverter:
                     f'Got unsupported hover_mode={self.hover_mode!r} for '
                     f"datashaded points; reverting to 'mouse'."
                 )
+
+            stream = Tap if len(self.data) > 10000 else PointerXY
+            param.main.param.warning(
+                'Hovering over datashaded points is slow for large datasets; '
+                'tap on the plot to see a hover tooltip over desired point.'
+            )
             inspector = inspect_points.instance(
-                streams=[PointerXY], transform=self._datashade_hover_transform
+                streams=[stream], transform=self._datashade_hover_transform
             )
             processed *= inspector(processed).opts(
                 size=10,

--- a/hvplot/tests/testoperations.py
+++ b/hvplot/tests/testoperations.py
@@ -156,11 +156,6 @@ class TestDatashader(ComparisonTestCase):
         opts = Store.lookup_options('bokeh', plot[()], 'plot').kwargs
         assert 'hover' not in opts.get('tools')
 
-    def test_when_datashade_is_true_hover_can_still_be_true(self):
-        plot = self.df.hvplot(x='x', y='y', datashade=True, hover=True)
-        opts = Store.lookup_options('bokeh', plot[()], 'plot').kwargs
-        assert 'hover' in opts.get('tools')
-
     def test_xlim_affects_x_range(self):
         data = pd.DataFrame(np.random.randn(100).cumsum())
         img = data.hvplot(xlim=(0, 20000), datashade=True, dynamic=False)

--- a/hvplot/tests/testoperations.py
+++ b/hvplot/tests/testoperations.py
@@ -8,7 +8,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from holoviews import Store, render
+from holoviews import Store, render, renderer
 from holoviews.element import Image, QuadMesh, Points
 from holoviews.core.spaces import DynamicMap
 from holoviews.core.overlay import Overlay
@@ -323,6 +323,23 @@ class TestDatashader(ComparisonTestCase):
         element = overlay.get(1)
         assert isinstance(element, eltype)
         assert len(element) == 0
+
+    @parameterized.expand([(None,), (True,), ('vline',), ('hline',)])
+    def test_include_inspect_point_hover(self, hover):
+        df = pd.DataFrame(
+            np.random.multivariate_normal((0, 0), [[0.1, 0.1], [0.1, 1.0]], (5000,))
+        ).rename({0: 'x', 1: 'y'}, axis=1)
+
+        p = df.hvplot.points(datashade=True, hover=hover)
+        assert renderer('bokeh').get_plot(p).name.startswith('Overlay')
+
+    def test_include_inspect_point_no_hover(self):
+        df = pd.DataFrame(
+            np.random.multivariate_normal((0, 0), [[0.1, 0.1], [0.1, 1.0]], (5000,))
+        ).rename({0: 'x', 1: 'y'}, axis=1)
+
+        p = df.hvplot.points(datashade=True, hover=False)
+        assert renderer('bokeh').get_plot(p).name.startswith('RGB')
 
 
 class TestChart2D(ComparisonTestCase):


### PR DESCRIPTION
Adds support for hovering over datashaded points

Closes https://github.com/holoviz/hvplot/issues/1428

```python
import pandas as pd
import hvplot.pandas
import datashader as ds

df = pd.DataFrame(
    {
        "lon": [-86.75, -86.75, -86.25, -86.25],
        "lat": [33.75, 34.0, 34.49, 34.5],
        "population": [100, 200, 300, 400],
        "c": ["A", "B", "A", "B"],
    }
)

p = df.hvplot.points(
    "lon",
    "lat",
    hover_cols="all",
    datashade=True,
    dynspread=True,
    aggregator=ds.count_cat("c"),
    hover_tooltips=["lat", "lon", ("Population", "@population"), ("Alpha", "@A"), ("Beta", "@B")],  # not necessary
    padding=0.2
)
p
```

https://github.com/user-attachments/assets/a8a71946-5745-42c6-ba14-e40ca51b2865

