### PR TITLE
Fix dask tiles regression

### DIFF
--- a/doc/user_guide/Customization.ipynb
+++ b/doc/user_guide/Customization.ipynb
@@ -249,7 +249,7 @@
     "    projection (default=None):\n",
     "        Coordinate reference system of the plot (output projection) specified as a string or integer EPSG code, a CRS or Proj pyproj object, a Cartopy CRS object or class name, a WKT string, or a proj.4 string. Defaults to PlateCarree.\n",
     "    tiles (default=False):\n",
-    "        Whether to overlay the plot on a tile source. If coordinate values fall within lat/lon bounds, auto-projects to EPSG:3857 unless `projection=False`. Tiles sources\n",
+    "        Whether to overlay the plot on a tile source. If coordinate values fall within lat/lon bounds, auto-projects to EPSG:3857 unless `projection=False` or if the data is lazily loaded (dask / ibis). Tiles sources\n",
     "        can be selected by name or a tiles object or class can be passed,\n",
     "        the default is 'Wikipedia'.\n",
     "    tiles_opts (default=None): dict\n",

--- a/doc/user_guide/Geographic_Data.ipynb
+++ b/doc/user_guide/Geographic_Data.ipynb
@@ -80,7 +80,7 @@
    "source": [
     "We'll first start by displaying the airports **without GeoViews** with tiles by setting `tiles=True`. \n",
     "\n",
-    "Under the hood, hvPlot projects lat/lon to easting/northing ([EPSG:4326](https://epsg.io/4326) to [EPSG:3857](https://epsg.io/3857)) coordinates without additional package dependencies if it detects that the values falls within expected lat/lon ranges.\n",
+    "Under the hood, hvPlot projects lat/lon to easting/northing ([EPSG:4326](https://epsg.io/4326) to [EPSG:3857](https://epsg.io/3857)) coordinates without additional package dependencies if it detects that the values falls within expected lat/lon ranges, **unless the data is lazily loaded (dask / ibis).**\n",
     "\n",
     "Note, **this feature is only available after `hvplot>=0.11.0`**; older versions, `hvplot<0.11.0`, require manual projection (see below)."
    ]
@@ -417,7 +417,7 @@
     "- `global_extent` (default=False): Whether to expand the plot extent to span the whole globe\n",
     "- `project` (default=False): Whether to project the data before plotting (adds initial overhead but avoids projecting data when plot is dynamically updated)\n",
     "- `projection` (default=None): Coordinate reference system of the plot (output projection) specified as a string or integer EPSG code, a CRS or Proj pyproj object, a Cartopy CRS object or class name, a WKT string, or a proj.4 string. Defaults to PlateCarree.\n",
-    "- `tiles` (default=False): Whether to overlay the plot on a tile source. If coordinate values fall within lat/lon bounds, auto-projects to EPSG:3857 unless `projection=False`. Accepts the following values:\n",
+    "- `tiles` (default=False): Whether to overlay the plot on a tile source. If coordinate values fall within lat/lon bounds, auto-projects to EPSG:3857 unless `projection=False` or if the data is lazily loaded (dask / ibis). Accepts the following values:\n",
     "    - `True`: OpenStreetMap layer\n",
     "    - `xyzservices.TileProvider` instance (requires [`xyzservices`](https://xyzservices.readthedocs.io/) to be installed)\n",
     "    - a map string name based on one of the default layers made available by [HoloViews](https://holoviews.org/reference/elements/bokeh/Tiles.html) ('CartoDark', 'CartoLight', 'EsriImagery', 'EsriNatGeo', 'EsriUSATopo', 'EsriTerrain', 'EsriStreet', 'EsriReference', 'OSM', 'OpenTopoMap') or [GeoViews](https://geoviews.org/user_guide/Working_with_Bokeh.html) ('CartoDark', 'CartoEco', 'CartoLight', 'CartoMidnight', 'EsriImagery', 'EsriNatGeo', 'EsriUSATopo', 'EsriTerrain', 'EsriReference', 'EsriOceanBase', 'EsriOceanReference', 'EsriWorldPhysical', 'EsriWorldShadedRelief', 'EsriWorldTopo', 'EsriWorldDarkGrayBase', 'EsriWorldDarkGrayReference', 'EsriWorldLightGrayBase', 'EsriWorldLightGrayReference', 'EsriWorldHillshadeDark', 'EsriWorldHillshade', 'EsriAntarcticImagery', 'EsriArcticImagery', 'EsriArcticOceanBase', 'EsriArcticOceanReference', 'EsriWorldBoundariesAndPlaces', 'EsriWorldBoundariesAndPlacesAlternate', 'EsriWorldTransportation', 'EsriDelormeWorldBaseMap', 'EsriWorldNavigationCharts', 'EsriWorldStreetMap', 'OSM', 'OpenTopoMap'). Note that Stamen tile sources require a Stadia account when not running locally; see [stadiamaps.com](https://stadiamaps.com/).\n",

--- a/hvplot/converter.py
+++ b/hvplot/converter.py
@@ -2173,16 +2173,13 @@ class HoloViewsConverter:
             if data.crs is not None:
                 data = data.to_crs(epsg=3857)
             return data, x, y
-        else:
+        elif not (is_dask(data) or is_ibis(data)):
+            # no dask/ibis as to prevent eager evaluation
+            # https://github.com/holoviz/hvplot/pull/1432/files#r1789862990
             min_x = np.min(data[x])
             max_x = np.max(data[x])
             min_y = np.min(data[y])
             max_y = np.max(data[y])
-
-            if hasattr(min_x, 'compute'):
-                min_x, max_x = min_x.compute(), max_x.compute()
-            if hasattr(min_y, 'compute'):
-                min_y, max_y = min_y.compute(), max_y.compute()
 
             x_within_bounds = -180 <= min_x <= 360 and -180 <= max_x <= 360
             y_within_bounds = -90 <= min_y <= 90 and -90 <= max_y <= 90

--- a/hvplot/converter.py
+++ b/hvplot/converter.py
@@ -2175,8 +2175,7 @@ class HoloViewsConverter:
                 data = data.to_crs(epsg=3857)
             return data, x, y
         elif not is_lazy_data(data):
-            # no dask/ibis as to prevent eager evaluation
-            # https://github.com/holoviz/hvplot/pull/1432/files#r1789862990
+            # To prevent eager evaluation: https://github.com/holoviz/hvplot/pull/1432
             min_x = np.min(data[x])
             max_x = np.max(data[x])
             min_y = np.min(data[y])

--- a/hvplot/converter.py
+++ b/hvplot/converter.py
@@ -60,6 +60,7 @@ from .util import (
     is_cudf,
     is_streamz,
     is_ibis,
+    is_lazy_data,
     is_xarray,
     is_xarray_dataarray,
     process_crs,
@@ -2173,7 +2174,7 @@ class HoloViewsConverter:
             if data.crs is not None:
                 data = data.to_crs(epsg=3857)
             return data, x, y
-        elif not (is_dask(data) or is_ibis(data)):
+        elif not is_lazy_data(data):
             # no dask/ibis as to prevent eager evaluation
             # https://github.com/holoviz/hvplot/pull/1432/files#r1789862990
             min_x = np.min(data[x])

--- a/hvplot/converter.py
+++ b/hvplot/converter.py
@@ -2178,6 +2178,12 @@ class HoloViewsConverter:
             max_x = np.max(data[x])
             min_y = np.min(data[y])
             max_y = np.max(data[y])
+
+            if hasattr(min_x, 'compute'):
+                min_x, max_x = min_x.compute(), max_x.compute()
+            if hasattr(min_y, 'compute'):
+                min_y, max_y = min_y.compute(), max_y.compute()
+
             x_within_bounds = -180 <= min_x <= 360 and -180 <= max_x <= 360
             y_within_bounds = -90 <= min_y <= 90 and -90 <= max_y <= 90
             if x_within_bounds and y_within_bounds:

--- a/hvplot/tests/testgeowithoutgv.py
+++ b/hvplot/tests/testgeowithoutgv.py
@@ -76,9 +76,9 @@ class TestAnnotationNotGeo:
     @pytest.mark.skipif(dd is None, reason='dask not installed')
     def test_plot_with_dask(self, simple_df):
         ddf = dd.from_pandas(simple_df, npartitions=2)
-        plot = ddf.hvplot.points('x', 'y')
-        assert 'x_' in plot.get(1).data
-        assert 'y_' in plot.get(1).data
+        plot = ddf.hvplot.points('x', 'y', tiles=True)
+        assert 'x_' not in plot.get(1).data
+        assert 'y_' not in plot.get(1).data
         assert len(plot) == 2
         assert isinstance(plot.get(0), hv.Tiles)
         bk_plot = bk_renderer.get_plot(plot)

--- a/hvplot/tests/testgeowithoutgv.py
+++ b/hvplot/tests/testgeowithoutgv.py
@@ -8,6 +8,12 @@ import numpy as np
 import pandas as pd
 import pytest
 
+try:
+    import dask.dataframe as dd
+    import hvplot.dask  # noqa
+except ImportError:
+    dd = None
+
 
 bk_renderer = hv.Store.renderers['bokeh']
 
@@ -64,5 +70,16 @@ class TestAnnotationNotGeo:
         assert len(plot) == 2
         assert isinstance(plot.get(0), hv.Tiles)
         assert isinstance(plot.get(0).data, xyzservices.TileProvider)
+        bk_plot = bk_renderer.get_plot(plot)
+        assert bk_plot.projection == 'mercator'
+
+    @pytest.mark.skipif(dd is None, reason='dask not installed')
+    def test_plot_with_dask(self, simple_df):
+        ddf = dd.from_pandas(simple_df, npartitions=2)
+        plot = ddf.hvplot.points('x', 'y')
+        assert 'x_' in plot.get(1).data
+        assert 'y_' in plot.get(1).data
+        assert len(plot) == 2
+        assert isinstance(plot.get(0), hv.Tiles)
         bk_plot = bk_renderer.get_plot(plot)
         assert bk_plot.projection == 'mercator'

--- a/hvplot/util.py
+++ b/hvplot/util.py
@@ -447,6 +447,11 @@ def is_xarray(data):
 
 
 def is_lazy_data(data):
+    """Check if data is lazy
+
+    This checks if the datatype is Dask, Ibis, or Polars' LazyFrame.
+    It is useful to avoid eager evaluation of the data.
+    """
     if is_dask(data) or is_ibis(data):
         return True
     elif is_polars(data):

--- a/hvplot/util.py
+++ b/hvplot/util.py
@@ -446,6 +446,16 @@ def is_xarray(data):
     return isinstance(data, (DataArray, Dataset))
 
 
+def is_lazy_data(data):
+    if is_dask(data) or is_ibis(data):
+        return True
+    elif is_polars(data):
+        import polars as pl
+
+        return isinstance(data, pl.LazyFrame)
+    return False
+
+
 def is_xarray_dataarray(data):
     if not check_library(data, 'xarray'):
         return False


### PR DESCRIPTION
Closes https://github.com/holoviz/hvplot/issues/1431
```python
import dask.dataframe as dd
import hvplot.dask  # noqa
import pandas as pd

data = {"x": [-9700947, -9584977], "y": [3890186, 3824923]}
df = dd.from_pandas(pd.DataFrame(data), npartitions=2)
df.hvplot.points("x", "y", tiles=True)
```

<img width="1084" alt="image" src="https://github.com/user-attachments/assets/216adeca-6c05-4895-bd78-4e43d1f84763">

