### PR TITLE
doc: add nb_interactivity_warning extension

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -58,6 +58,7 @@ html_favicon = '_static/favicon.ico'
 extensions += [  # noqa
     'nbsite.gallery',
     'nbsite.analytics',
+    'nbsite.nb_interactivity_warning',
     'sphinx_copybutton',
     'sphinxext.rediraffe',
 ]

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -115,7 +115,7 @@ nb_execution_excludepatterns = [
     'user_guide/Streaming.ipynb',
 ]
 # cell execution timeout in seconds (-1 to ignore, 30 by default)
-nb_execution_timeout = 120
+nb_execution_timeout = 240
 
 if os.getenv('HVPLOT_REFERENCE_GALLERY') not in ('False', 'false', '0'):
     rediraffe_redirects.update(

--- a/envs/py3.11-docs.yaml
+++ b/envs/py3.11-docs.yaml
@@ -36,7 +36,7 @@ dependencies:
   - ipywidgets
   - jinja2
   - matplotlib
-  - nbsite>=0.8.4
+  - nbsite>=0.8.6
   - networkx>=2.6.3
   - notebook>=5.4
   - numba>=0.51.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -146,7 +146,7 @@ examples-tests = [
 # Additional packages required to build the docs
 doc = [
     "hvplot[examples]",
-    "nbsite >=0.8.4",
+    "nbsite >=0.8.6",
     "sphinxext-rediraffe",
 ]
 # Trick to let pip know we want to install dev dependencies


### PR DESCRIPTION
To display the interactivity warning message on pages built from a Notebook or executable Markdown.