### PR TITLE
Fix logic for no geoviews explorer

### DIFF
--- a/hvplot/converter.py
+++ b/hvplot/converter.py
@@ -76,7 +76,7 @@ from .util import (
     process_derived_datetime_pandas,
     _convert_col_names_to_str,
     import_datashader,
-    geoviews_is_available,
+    import_geoviews,
 )
 from .utilities import hvplot_extension
 
@@ -649,7 +649,7 @@ class HoloViewsConverter:
         self.geo = any([geo, crs, global_extent, projection, project, coastline, features])
         # Try importing geoviews if geo-features requested
         if self.geo or self.datatype == 'geopandas':
-            geoviews_is_available(raise_error=True)
+            import_geoviews()
 
         self.crs = self._process_crs(data, crs) if self.geo else None
         self.output_projection = self.crs

--- a/hvplot/converter.py
+++ b/hvplot/converter.py
@@ -76,6 +76,7 @@ from .util import (
     process_derived_datetime_pandas,
     _convert_col_names_to_str,
     import_datashader,
+    geoviews_is_available,
 )
 from .utilities import hvplot_extension
 
@@ -646,6 +647,10 @@ class HoloViewsConverter:
 
         self.dynamic = dynamic
         self.geo = any([geo, crs, global_extent, projection, project, coastline, features])
+        # Try importing geoviews if geo-features requested
+        if self.geo or self.datatype == 'geopandas':
+            geoviews_is_available(raise_error=True)
+
         self.crs = self._process_crs(data, crs) if self.geo else None
         self.output_projection = self.crs
         self.project = project
@@ -655,17 +660,6 @@ class HoloViewsConverter:
         self.tiles_opts = tiles_opts or {}
         self.sort_date = sort_date
 
-        # Import geoviews if geo-features requested
-        if self.geo or self.datatype == 'geopandas':
-            try:
-                import geoviews  # noqa
-            except ImportError:
-                raise ImportError(
-                    'In order to use geo-related features '
-                    'the geoviews library must be available. '
-                    'It can be installed with:\n  conda '
-                    'install geoviews'
-                )
         if self.geo:
             if self.kind not in self._geo_types:
                 param.main.param.warning(

--- a/hvplot/tests/testui.py
+++ b/hvplot/tests/testui.py
@@ -1,5 +1,6 @@
 import re
 from textwrap import dedent
+from unittest.mock import patch
 
 import numpy as np
 import holoviews as hv
@@ -419,4 +420,5 @@ def test_max_rows_sample():
 
 def test_explorer_geo_no_import_error_when_false():
     da = ds_air_temperature['air'].isel(time=0)
-    assert hvplot.explorer(da, x='lon', y='lat', geo=False)
+    with patch('hvplot.util.geoviews_is_available', return_value=False):
+        assert hvplot.explorer(da, x='lon', y='lat', geo=False)

--- a/hvplot/tests/testui.py
+++ b/hvplot/tests/testui.py
@@ -420,5 +420,5 @@ def test_max_rows_sample():
 
 def test_explorer_geo_no_import_error_when_false():
     da = ds_air_temperature['air'].isel(time=0)
-    with patch('hvplot.util.geoviews_is_available', return_value=False):
+    with patch('hvplot.util.import_geoviews', return_value=None):
         assert hvplot.explorer(da, x='lon', y='lat', geo=False)

--- a/hvplot/tests/testui.py
+++ b/hvplot/tests/testui.py
@@ -415,3 +415,8 @@ def test_max_rows_sample():
     ui = hvplot.explorer(df, x='x', y='y', by=['#'], kind='scatter')
     assert len(ui._data) == MAX_ROWS
     assert not ui._data.equals(df.head(MAX_ROWS))
+
+
+def test_explorer_geo_no_import_error_when_false():
+    da = ds_air_temperature['air'].isel(time=0)
+    assert hvplot.explorer(da, x='lon', y='lat', geo=False)

--- a/hvplot/tests/testutil.py
+++ b/hvplot/tests/testutil.py
@@ -2,6 +2,7 @@
 Tests  utilities to convert data and projections
 """
 
+from unittest.mock import patch
 import numpy as np
 import pandas as pd
 import panel as pn
@@ -18,6 +19,7 @@ from unittest import TestCase, SkipTest
 
 from hvplot.util import (
     check_crs,
+    geoviews_is_available,
     is_list_like,
     process_crs,
     process_xarray,
@@ -383,3 +385,22 @@ def test_is_geodataframe_spatialpandas_dask():
 def test_is_geodataframe_classic_dataframe():
     df = pd.DataFrame({'geometry': [None, None], 'name': ['A', 'B']})
     assert not is_geodataframe(df)
+
+
+@pytest.mark.geo
+def test_geoviews_is_available():
+    assert geoviews_is_available(raise_error=True)
+
+
+def test_geoviews_is_available_no_raise():
+    with patch('hvplot.util.geoviews_is_available', side_effect=ImportError):
+        result = geoviews_is_available(raise_error=False)
+        assert result is False
+
+
+def test_geoviews_is_available_with_raise():
+    with patch('hvplot.util.geoviews_is_available', side_effect=ImportError):
+        with pytest.raises(
+            ImportError, match='GeoViews must be installed to enable the geographic options.'
+        ):
+            geoviews_is_available(raise_error=True)

--- a/hvplot/tests/testutil.py
+++ b/hvplot/tests/testutil.py
@@ -2,7 +2,6 @@
 Tests  utilities to convert data and projections
 """
 
-from unittest.mock import patch
 import numpy as np
 import pandas as pd
 import panel as pn
@@ -19,7 +18,7 @@ from unittest import TestCase, SkipTest
 
 from hvplot.util import (
     check_crs,
-    geoviews_is_available,
+    import_geoviews,
     is_list_like,
     process_crs,
     process_xarray,
@@ -389,18 +388,4 @@ def test_is_geodataframe_classic_dataframe():
 
 @pytest.mark.geo
 def test_geoviews_is_available():
-    assert geoviews_is_available(raise_error=True)
-
-
-def test_geoviews_is_available_no_raise():
-    with patch('hvplot.util.find_spec', return_value=None):
-        result = geoviews_is_available(raise_error=False)
-        assert result is False
-
-
-def test_geoviews_is_available_with_raise():
-    with patch('hvplot.util.find_spec', return_value=None):
-        with pytest.raises(
-            ImportError, match='GeoViews must be installed to enable the geographic options.'
-        ):
-            geoviews_is_available(raise_error=True)
+    assert import_geoviews()

--- a/hvplot/tests/testutil.py
+++ b/hvplot/tests/testutil.py
@@ -393,13 +393,13 @@ def test_geoviews_is_available():
 
 
 def test_geoviews_is_available_no_raise():
-    with patch('hvplot.util.geoviews_is_available', side_effect=ImportError):
+    with patch('hvplot.util.find_spec', return_value=None):
         result = geoviews_is_available(raise_error=False)
         assert result is False
 
 
 def test_geoviews_is_available_with_raise():
-    with patch('hvplot.util.geoviews_is_available', side_effect=ImportError):
+    with patch('hvplot.util.find_spec', return_value=None):
         with pytest.raises(
             ImportError, match='GeoViews must be installed to enable the geographic options.'
         ):

--- a/hvplot/ui.py
+++ b/hvplot/ui.py
@@ -10,7 +10,7 @@ from panel.viewable import Viewer
 
 from .converter import HoloViewsConverter as _hvConverter
 from .plotting import hvPlot as _hvPlot
-from .util import is_geodataframe, is_xarray, instantiate_crs_str
+from .util import is_geodataframe, is_xarray, instantiate_crs_str, geoviews_is_available
 
 # Defaults
 KINDS = {
@@ -361,17 +361,9 @@ class Geographic(Controls):
     _widgets_kwargs = {'geo': {'type': pn.widgets.Toggle}}
 
     def __init__(self, data, **params):
-        gv_available = False
-        try:
-            import geoviews  # noqa
-
-            gv_available = True
-        except ImportError:
-            pass
-
         geo_params = GEO_KEYS + ['geo']
-        if not gv_available and any(params.get(p) for p in geo_params):
-            raise ImportError('GeoViews must be installed to enable the geographic options.')
+        gv_available = geoviews_is_available(raise_error=any(params.get(p) for p in geo_params))
+
         super().__init__(data, **params)
         if not gv_available:
             for p in geo_params:

--- a/hvplot/ui.py
+++ b/hvplot/ui.py
@@ -10,7 +10,7 @@ from panel.viewable import Viewer
 
 from .converter import HoloViewsConverter as _hvConverter
 from .plotting import hvPlot as _hvPlot
-from .util import is_geodataframe, is_xarray, instantiate_crs_str, geoviews_is_available
+from .util import is_geodataframe, is_xarray, instantiate_crs_str, import_geoviews
 
 # Defaults
 KINDS = {
@@ -362,8 +362,9 @@ class Geographic(Controls):
 
     def __init__(self, data, **params):
         geo_params = GEO_KEYS + ['geo']
-        gv_available = geoviews_is_available(raise_error=any(params.get(p) for p in geo_params))
-
+        gv_available = None
+        if any(params.get(p) for p in geo_params):
+            gv_available = import_geoviews()
         super().__init__(data, **params)
         if not gv_available:
             for p in geo_params:

--- a/hvplot/ui.py
+++ b/hvplot/ui.py
@@ -370,7 +370,7 @@ class Geographic(Controls):
             pass
 
         geo_params = GEO_KEYS + ['geo']
-        if not gv_available and any(p in params and params[p] for p in geo_params):
+        if not gv_available and any(params.get(p) for p in geo_params):
             raise ImportError('GeoViews must be installed to enable the geographic options.')
         super().__init__(data, **params)
         if not gv_available:

--- a/hvplot/ui.py
+++ b/hvplot/ui.py
@@ -665,8 +665,8 @@ class hvPlotExplorer(Viewer):
         if kwargs.get('geo'):
             if 'crs' not in kwargs:
                 xmax = np.max(np.abs(self.xlim()))
-                self.geographic.crs = 'PlateCarree' if xmax <= 360 else 'GOOGLE_MERCATOR'
-                kwargs['crs'] = self.geographic.crs
+                # self.geographic.crs = 'PlateCarree' if xmax <= 360 else 'GOOGLE_MERCATOR'
+                kwargs['crs'] = 'PlateCarree' if xmax <= 360 else 'GOOGLE_MERCATOR'
             for key in ['crs', 'projection']:
                 if key not in kwargs:
                     continue

--- a/hvplot/ui.py
+++ b/hvplot/ui.py
@@ -665,8 +665,8 @@ class hvPlotExplorer(Viewer):
         if kwargs.get('geo'):
             if 'crs' not in kwargs:
                 xmax = np.max(np.abs(self.xlim()))
-                # self.geographic.crs = 'PlateCarree' if xmax <= 360 else 'GOOGLE_MERCATOR'
-                kwargs['crs'] = 'PlateCarree' if xmax <= 360 else 'GOOGLE_MERCATOR'
+                self.geographic.crs = 'PlateCarree' if xmax <= 360 else 'GOOGLE_MERCATOR'
+                kwargs['crs'] = self.geographic.crs
             for key in ['crs', 'projection']:
                 if key not in kwargs:
                     continue

--- a/hvplot/ui.py
+++ b/hvplot/ui.py
@@ -370,7 +370,7 @@ class Geographic(Controls):
             pass
 
         geo_params = GEO_KEYS + ['geo']
-        if not gv_available and any(p in params for p in geo_params):
+        if not gv_available and any(p in params and params[p] for p in geo_params):
             raise ImportError('GeoViews must be installed to enable the geographic options.')
         super().__init__(data, **params)
         if not gv_available:

--- a/hvplot/util.py
+++ b/hvplot/util.py
@@ -4,6 +4,7 @@ Provides utilities to convert data and projections
 
 import sys
 import types
+import typing
 
 from collections.abc import Hashable
 
@@ -730,7 +731,7 @@ def import_datashader():
     return datashader
 
 
-def import_geoviews() -> types.ModuleType | None:
+def import_geoviews() -> typing.Union[types.ModuleType, None]:
     geoviews = None
     try:
         import geoviews

--- a/hvplot/util.py
+++ b/hvplot/util.py
@@ -2,6 +2,7 @@
 Provides utilities to convert data and projections
 """
 
+from importlib.util import find_spec
 import sys
 
 from collections.abc import Hashable
@@ -756,15 +757,8 @@ def geoviews_is_available(raise_error: bool = False):
     """
     Check if GeoViews is available and raise an ImportError if not.
     """
-    try:
-        import geoviews  # noqa
-
-        gv_available = True
-    except ImportError:
-        gv_available = False
-
-    if not raise_error:
-        return gv_available
+    gv_available = find_spec('geoviews') is not None
 
     if not gv_available and raise_error:
         raise ImportError('GeoViews must be installed to enable the geographic options.')
+    return gv_available

--- a/hvplot/util.py
+++ b/hvplot/util.py
@@ -2,8 +2,8 @@
 Provides utilities to convert data and projections
 """
 
-from importlib.util import find_spec
 import sys
+import types
 
 from collections.abc import Hashable
 
@@ -730,6 +730,18 @@ def import_datashader():
     return datashader
 
 
+def import_geoviews() -> types.ModuleType | None:
+    geoviews = None
+    try:
+        import geoviews
+    except ModuleNotFoundError:
+        raise ModuleNotFoundError(
+            'The `geoviews` package must be installed in order to use '
+            'geographic features. Install it with pip or conda.'
+        ) from None
+    return geoviews
+
+
 def relabel(hv_obj, **kwargs):
     """Conditionally relabel a HoloViews object"""
     if kwargs:
@@ -751,14 +763,3 @@ def relabel_redim(hv_obj, relabel_kwargs, redim_kwargs):
     if redim_kwargs:
         hv_obj = hv_obj.redim(**redim_kwargs)
     return hv_obj
-
-
-def geoviews_is_available(raise_error: bool = False):
-    """
-    Check if GeoViews is available and raise an ImportError if not.
-    """
-    gv_available = find_spec('geoviews') is not None
-
-    if not gv_available and raise_error:
-        raise ImportError('GeoViews must be installed to enable the geographic options.')
-    return gv_available

--- a/hvplot/util.py
+++ b/hvplot/util.py
@@ -3,8 +3,6 @@ Provides utilities to convert data and projections
 """
 
 import sys
-import types
-import typing
 
 from collections.abc import Hashable
 
@@ -731,7 +729,7 @@ def import_datashader():
     return datashader
 
 
-def import_geoviews() -> typing.Union[types.ModuleType, None]:
+def import_geoviews():
     geoviews = None
     try:
         import geoviews

--- a/hvplot/util.py
+++ b/hvplot/util.py
@@ -750,3 +750,21 @@ def relabel_redim(hv_obj, relabel_kwargs, redim_kwargs):
     if redim_kwargs:
         hv_obj = hv_obj.redim(**redim_kwargs)
     return hv_obj
+
+
+def geoviews_is_available(raise_error: bool = False):
+    """
+    Check if GeoViews is available and raise an ImportError if not.
+    """
+    try:
+        import geoviews  # noqa
+
+        gv_available = True
+    except ImportError:
+        gv_available = False
+
+    if not raise_error:
+        return gv_available
+
+    if not gv_available and raise_error:
+        raise ImportError('GeoViews must be installed to enable the geographic options.')


### PR DESCRIPTION
Even though `geo=False`, explorer would raise `raise ImportError('GeoViews must be installed to enable the geographic options.')`

```python
import pandas as pd
import hvplot.pandas
df = pd.DataFrame({'a': [1,2,3], 'b': [4,5,6]})

df.hvplot.explorer(geo=False)
```

Not sure how to add a test for this because the dev dependencies installs geoviews.