### PR TITLE
Check cmap type before comparing to categories

### DIFF
--- a/hvplot/converter.py
+++ b/hvplot/converter.py
@@ -1485,7 +1485,7 @@ class HoloViewsConverter:
         if 'color' in style_opts:
             color = style_opts['color']
         elif not isinstance(cmap, dict):
-            if cmap and any(c in cmap for c in categories):
+            if isinstance(cmap, str) and any(c in cmap for c in categories):
                 color = process_cmap(cmap or self._default_cmaps['categorical'], categorical=True)
             else:
                 color = cmap

--- a/hvplot/converter.py
+++ b/hvplot/converter.py
@@ -76,7 +76,7 @@ from .util import (
     process_derived_datetime_pandas,
     _convert_col_names_to_str,
     import_datashader,
-    _mpl_cmap,
+    is_mpl_cmap,
 )
 from .utilities import hvplot_extension
 
@@ -1486,8 +1486,12 @@ class HoloViewsConverter:
         if 'color' in style_opts:
             color = style_opts['color']
         elif not isinstance(cmap, dict):
-            if (isinstance(cmap, str) or _mpl_cmap(cmap)) and any(
-                c in getattr(cmap, 'name', cmap) for c in categorical_cmaps
+            # Checks if any of the categorical cmaps matches cmap;
+            # uses any() instead of `cmap in categorical_cmaps` to handle reversed colormaps (suffixed with `_r`).
+            # If cmap is LinearSegmentedColormap, get the name attr, else return the str typed cmap.
+            if (isinstance(cmap, str) or is_mpl_cmap(cmap)) and any(
+                categorical_cmap in getattr(cmap, 'name', cmap)
+                for categorical_cmap in categorical_cmaps
             ):
                 color = process_cmap(cmap or self._default_cmaps['categorical'], categorical=True)
             else:

--- a/hvplot/converter.py
+++ b/hvplot/converter.py
@@ -76,6 +76,7 @@ from .util import (
     process_derived_datetime_pandas,
     _convert_col_names_to_str,
     import_datashader,
+    _mpl_cmap,
 )
 from .utilities import hvplot_extension
 
@@ -1420,7 +1421,7 @@ class HoloViewsConverter:
             valid_opts = []
 
         cmap_opts = ('cmap', 'colormap', 'color_key')
-        categories = [
+        categorical_cmaps = [
             'accent',
             'category',
             'dark',
@@ -1485,7 +1486,9 @@ class HoloViewsConverter:
         if 'color' in style_opts:
             color = style_opts['color']
         elif not isinstance(cmap, dict):
-            if isinstance(cmap, str) and any(c in cmap for c in categories):
+            if (isinstance(cmap, str) or _mpl_cmap(cmap)) and any(
+                c in getattr(cmap, 'name', cmap) for c in categorical_cmaps
+            ):
                 color = process_cmap(cmap or self._default_cmaps['categorical'], categorical=True)
             else:
                 color = cmap

--- a/hvplot/tests/testcharts.py
+++ b/hvplot/tests/testcharts.py
@@ -606,3 +606,14 @@ class TestChart1DDask(TestChart1D):
 
     def test_table_multi_index_displayed(self):
         raise SkipTest('Dask does not support MultiIndex Dataframes.')
+
+
+def test_cmap_LinearSegmentedColormap():
+    # test for https://github.com/holoviz/hvplot/pull/1461
+    xr = pytest.importorskip('xarray')
+    mpl = pytest.importorskip('matplotlib')
+    import hvplot.xarray  # noqa
+
+    data = np.arange(25).reshape(5, 5)
+    xr_da = xr.DataArray(data)
+    xr_da.hvplot.image(cmap=mpl.colormaps['viridis'])

--- a/hvplot/util.py
+++ b/hvplot/util.py
@@ -752,7 +752,7 @@ def relabel_redim(hv_obj, relabel_kwargs, redim_kwargs):
     return hv_obj
 
 
-def _mpl_cmap(obj):
+def is_mpl_cmap(obj):
     """Check if the object is a Matplotlib LinearSegmentedColormap."""
     if 'matplotlib' not in sys.modules:
         return False

--- a/hvplot/util.py
+++ b/hvplot/util.py
@@ -750,3 +750,12 @@ def relabel_redim(hv_obj, relabel_kwargs, redim_kwargs):
     if redim_kwargs:
         hv_obj = hv_obj.redim(**redim_kwargs)
     return hv_obj
+
+
+def _mpl_cmap(obj):
+    """Check if the object is a Matplotlib LinearSegmentedColormap."""
+    if 'matplotlib' not in sys.modules:
+        return False
+    from matplotlib.colors import LinearSegmentedColormap
+
+    return isinstance(obj, LinearSegmentedColormap)


### PR DESCRIPTION
fixes #1461 where the use of matplotlib colormap objects as `cmap` argument results in "TypeError: argument of type 'LinearSegmentedColormap' is not iterable...."

```python
import hvplot.xarray  # noqa
from matplotlib import colormaps
import xarray as xr

ds = xr.tutorial.open_dataset("air_temperature")
da = ds.air.isel(time=0)

da.hvplot.image(cmap=colormaps['viridis'])
```

![image](https://github.com/user-attachments/assets/a2e92a98-022a-4941-a2c5-853278d22bd0)
