### PR TITLE
compat: Add upper pin for intake-xarray

### DIFF
--- a/envs/py3.10-tests.yaml
+++ b/envs/py3.10-tests.yaml
@@ -31,7 +31,7 @@ dependencies:
   - holoviews>=1.19.0
   - ibis-duckdb
   - intake-parquet>=0.2.3
-  - intake-xarray>=0.5.0
+  - intake-xarray<2,>=0.5.0
   - intake<2.0.0,>=0.6.5
   - ipywidgets
   - jinja2

--- a/envs/py3.11-docs.yaml
+++ b/envs/py3.11-docs.yaml
@@ -31,7 +31,7 @@ dependencies:
   - holoviews>=1.19.0
   - ibis-duckdb
   - intake-parquet>=0.2.3
-  - intake-xarray>=0.5.0
+  - intake-xarray<2,>=0.5.0
   - intake<2.0.0,>=0.6.5
   - ipywidgets
   - jinja2

--- a/envs/py3.11-tests.yaml
+++ b/envs/py3.11-tests.yaml
@@ -31,7 +31,7 @@ dependencies:
   - holoviews>=1.19.0
   - ibis-duckdb
   - intake-parquet>=0.2.3
-  - intake-xarray>=0.5.0
+  - intake-xarray<2,>=0.5.0
   - intake<2.0.0,>=0.6.5
   - ipywidgets
   - jinja2

--- a/envs/py3.12-tests.yaml
+++ b/envs/py3.12-tests.yaml
@@ -31,7 +31,7 @@ dependencies:
   - holoviews>=1.19.0
   - ibis-duckdb
   - intake-parquet>=0.2.3
-  - intake-xarray>=0.5.0
+  - intake-xarray<2,>=0.5.0
   - intake<2.0.0,>=0.6.5
   - ipywidgets
   - jinja2

--- a/envs/py3.9-tests.yaml
+++ b/envs/py3.9-tests.yaml
@@ -30,7 +30,7 @@ dependencies:
   - holoviews>=1.19.0
   - ibis-duckdb
   - intake-parquet>=0.2.3
-  - intake-xarray>=0.5.0
+  - intake-xarray<2,>=0.5.0
   - intake<2.0.0,>=0.6.5
   - ipywidgets
   - jinja2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,7 +113,7 @@ examples = [
     "hvplot[fugue-sql]",
     "ibis-framework[duckdb]",  # ibis-duckdb on conda
     "intake-parquet >=0.2.3",
-    "intake-xarray >=0.5.0",
+    "intake-xarray >=0.5.0,<2",
     "intake >=0.6.5,<2.0.0",
     "ipywidgets",
     "networkx >=2.6.3",


### PR DESCRIPTION
intake-xarray 2.0 has been released, see https://pypi.org/project/intake-xarray/#history

Failing the current examples on conda. 

![image](https://github.com/user-attachments/assets/3728174d-9fdb-4489-b2f7-c4e1fc3544da)
