### PR TITLE
Pin dask<2025.1.0

### DIFF
--- a/doc/conftest.py
+++ b/doc/conftest.py
@@ -46,9 +46,10 @@ finally:
     webdriver_control.cleanup()
 
 
-# From Dask 2024.3.0 they now use `dask_expr` by default
-# https://github.com/dask/dask/issues/10995
-dask.config.set({'dataframe.query-planning': False})
+if Version(dask.__version__).release < (2025, 1, 0):
+    # From Dask 2024.3.0 they now use `dask_expr` by default
+    # https://github.com/dask/dask/issues/10995
+    dask.config.set({'dataframe.query-planning': False})
 
 
 # https://github.com/pydata/xarray/pull/9182

--- a/envs/py3.10-tests.yaml
+++ b/envs/py3.10-tests.yaml
@@ -19,7 +19,8 @@ dependencies:
   - cartopy
   - colorcet>=2
   - dask
-  - dask>=2021.3.0
+  - dask<2025.1.0
+  - dask<2025.1.0,>=2021.3.0
   - datashader>=0.6.5
   - duckdb
   - fiona

--- a/envs/py3.11-docs.yaml
+++ b/envs/py3.11-docs.yaml
@@ -19,7 +19,7 @@ dependencies:
   - bokeh_sampledata
   - cartopy
   - colorcet>=2
-  - dask>=2021.3.0
+  - dask<2025.1.0,>=2021.3.0
   - datashader>=0.6.5
   - duckdb
   - fiona

--- a/envs/py3.11-tests.yaml
+++ b/envs/py3.11-tests.yaml
@@ -19,7 +19,8 @@ dependencies:
   - cartopy
   - colorcet>=2
   - dask
-  - dask>=2021.3.0
+  - dask<2025.1.0
+  - dask<2025.1.0,>=2021.3.0
   - datashader>=0.6.5
   - duckdb
   - fiona

--- a/envs/py3.12-tests.yaml
+++ b/envs/py3.12-tests.yaml
@@ -19,7 +19,8 @@ dependencies:
   - cartopy
   - colorcet>=2
   - dask
-  - dask>=2021.3.0
+  - dask<2025.1.0
+  - dask<2025.1.0,>=2021.3.0
   - datashader>=0.6.5
   - duckdb
   - fiona

--- a/envs/py3.9-tests.yaml
+++ b/envs/py3.9-tests.yaml
@@ -18,7 +18,8 @@ dependencies:
   - cartopy
   - colorcet>=2
   - dask
-  - dask>=2021.3.0
+  - dask<2025.1.0
+  - dask<2025.1.0,>=2021.3.0
   - datashader>=0.6.5
   - duckdb
   - fiona

--- a/hvplot/tests/conftest.py
+++ b/hvplot/tests/conftest.py
@@ -1,3 +1,4 @@
+from packaging.version import Version
 import dask
 
 optional_markers = {
@@ -37,6 +38,7 @@ def pytest_collection_modifyitems(config, items):
     items[:] = selected
 
 
-# From Dask 2024.3.0 they now use `dask_expr` by default
-# https://github.com/dask/dask/issues/10995
-dask.config.set({'dataframe.query-planning': False})
+if Version(dask.__version__).release < (2025, 1, 0):
+    # From Dask 2024.3.0 they now use `dask_expr` by default
+    # https://github.com/dask/dask/issues/10995
+    dask.config.set({'dataframe.query-planning': False})

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ HoloViz = "https://holoviz.org/"
 
 [project.optional-dependencies]
 tests-core = [
-    "dask[dataframe]",
+    "dask[dataframe] <2025.1.0",
     "ipywidgets",
     "matplotlib",
     "parameterized",
@@ -106,7 +106,7 @@ graphviz = [
 ]
 # Dependencies required to run the notebooks
 examples = [
-    "dask[dataframe] >=2021.3.0",
+    "dask[dataframe] >=2021.3.0,<2025.1.0",
     "datashader >=0.6.5",
     "duckdb",
     "fugue[sql]",


### PR DESCRIPTION
It breaks the test suite and is blocking the migration to pixi. Downstream not supporting it yet (datashader, spatialpandas, etc.).