### PR TITLE
Removed 'Home' from website index and replace hide-cell with remove-cell

### DIFF
--- a/doc/index.md
+++ b/doc/index.md
@@ -420,7 +420,6 @@ align: center
 :hidden:
 :maxdepth: 2
 
-Home <self>
 Getting Started <getting_started/index>
 User Guide <user_guide/index>
 Reference Gallery <reference/index>

--- a/doc/user_guide/Large_Timeseries.ipynb
+++ b/doc/user_guide/Large_Timeseries.ipynb
@@ -205,12 +205,12 @@
    "id": "39ff4ae1",
    "metadata": {
     "tags": [
-     "hide-cell"
+     "remove-cell"
     ]
    },
    "outputs": [],
    "source": [
-    "# Cell hidden on the website (hide-cell in tags)\n",
+    "# Cell hidden on the website (remove-cell in tags)\n",
     "from holoviews.operation.resample import ResampleOperation2D\n",
     "ResampleOperation2D.width=1200\n",
     "ResampleOperation2D.height=500"

--- a/doc/user_guide/Plotting.ipynb
+++ b/doc/user_guide/Plotting.ipynb
@@ -14,12 +14,12 @@
    "execution_count": null,
    "metadata": {
     "tags": [
-     "hide-cell"
+     "remove-cell"
     ]
    },
    "outputs": [],
    "source": [
-    "# Cell hidden on the website (hide-cell in tags)\n",
+    "# Cell hidden on the website (remove-cell in tags)\n",
     "# https://github.com/holoviz/holoviews/pull/6391\n",
     "import warnings\n",
     "\n",

--- a/doc/user_guide/Plotting_with_Matplotlib.ipynb
+++ b/doc/user_guide/Plotting_with_Matplotlib.ipynb
@@ -14,12 +14,12 @@
    "execution_count": null,
    "metadata": {
     "tags": [
-     "hide-cell"
+     "remove-cell"
     ]
    },
    "outputs": [],
    "source": [
-    "# Cell hidden on the website (hide-cell in tags)\n",
+    "# Cell hidden on the website (remove-cell in tags)\n",
     "# https://github.com/holoviz/holoviews/pull/6391\n",
     "import warnings\n",
     "\n",

--- a/doc/user_guide/Plotting_with_Plotly.ipynb
+++ b/doc/user_guide/Plotting_with_Plotly.ipynb
@@ -14,12 +14,12 @@
    "execution_count": null,
    "metadata": {
     "tags": [
-     "hide-cell"
+     "remove-cell"
     ]
    },
    "outputs": [],
    "source": [
-    "# Cell hidden on the website (hide-cell in tags)\n",
+    "# Cell hidden on the website (remove-cell in tags)\n",
     "# https://github.com/holoviz/holoviews/pull/6391\n",
     "import warnings\n",
     "\n",


### PR DESCRIPTION
- [x] Removed `Home` from website index toctree. This reduces redundancy in the website seeing as clicking on the hvPlot image already redirects to the main homepage.
- [x] Changes all instance of `hide-cell` in the notebooks to `remove-cell`