### PR TITLE
Fix calling special Pandas plotting methods with the hvplot backend

### DIFF
--- a/hvplot/tests/testplotting.py
+++ b/hvplot/tests/testplotting.py
@@ -17,7 +17,6 @@ frame_specials = [
     ('hist', hv.Histogram),
 ]
 series_specials = [('hist', hv.Histogram)]
-
 no_args_mapping = [
     (kind, el) for kind, el in HoloViewsConverter._kind_mapping.items() if kind in no_args
 ]
@@ -26,8 +25,12 @@ x_y_mapping = [(kind, el) for kind, el in HoloViewsConverter._kind_mapping.items
 
 @pytest.fixture(params=['holoviews', 'hvplot'])
 def plotting_backend(request):
+    initial_backend = pd.options.plotting.backend
     pd.options.plotting.backend = request.param
-    return request.param
+    try:
+        yield request.param
+    finally:
+        pd.options.plotting.backend = initial_backend
 
 
 @pytest.mark.parametrize('kind,el', no_args_mapping)

--- a/hvplot/tests/testplotting.py
+++ b/hvplot/tests/testplotting.py
@@ -13,10 +13,15 @@ from hvplot.tests.util import makeDataFrame
 no_args = ['line', 'area', 'hist', 'box', 'kde', 'density', 'bar', 'barh']
 x_y = ['scatter', 'hexbin']
 frame_specials = [
+    # delegates to boxplot_frame
     ('boxplot', hv.BoxWhisker),
+    # delegates to hist_frame
     ('hist', hv.Histogram),
 ]
-series_specials = [('hist', hv.Histogram)]
+series_specials = [
+    # delegates to hist_series
+    ('hist', hv.Histogram),
+]
 no_args_mapping = [
     (kind, el) for kind, el in HoloViewsConverter._kind_mapping.items() if kind in no_args
 ]

--- a/hvplot/tests/testplotting.py
+++ b/hvplot/tests/testplotting.py
@@ -16,6 +16,16 @@ from hvplot.converter import HoloViewsConverter
 
 no_args = ['line', 'area', 'hist', 'box', 'kde', 'density', 'bar', 'barh']
 x_y = ['scatter', 'hexbin']
+frame_specials = [
+    # delegates to boxplot_frame
+    ('boxplot', hv.BoxWhisker),
+    # delegates to hist_frame
+    ('hist', hv.Histogram),
+]
+series_specials = [
+    # delegates to hist_series
+    ('hist', hv.Histogram)
+]
 
 no_args_mapping = [
     (kind, el) for kind, el in HoloViewsConverter._kind_mapping.items() if kind in no_args
@@ -49,6 +59,18 @@ class TestPandasHoloviewsPlotting(TestCase):
         df = pd.DataFrame({'a': [0, 1, 2], 'b': [5, 7, 2]})
         with self.assertRaisesRegex(NotImplementedError, 'pie'):
             df.plot.pie(y='a')
+
+    @parameterized.expand(series_specials)
+    def test_pandas_series_specials_plot_return_holoviews_object(self, kind, el):
+        series = pd.Series([0, 1, 2])
+        plot = getattr(series, kind)()
+        self.assertIsInstance(plot, el)
+
+    @parameterized.expand(frame_specials)
+    def test_pandas_frame_specials_plot_return_holoviews_object(self, kind, el):
+        df = pd.DataFrame([0, 1, 2])
+        plot = getattr(df, kind)()
+        self.assertIsInstance(plot, el)
 
 
 class TestPandasHvplotPlotting(TestPandasHoloviewsPlotting):

--- a/hvplot/tests/testplotting.py
+++ b/hvplot/tests/testplotting.py
@@ -76,6 +76,55 @@ def test_pandas_frame_specials_plot_return_holoviews_object(plotting_backend, ki
     assert isinstance(plot, el)
 
 
+@pytest.mark.parametrize('backend', ['holoviews', 'hvplot'])
+@pytest.mark.parametrize('kind,el', no_args_mapping)
+def test_pandas_series_plot_explicit_returns_holoviews_object(backend, kind, el):
+    series = pd.Series([0, 1, 2])
+    plot = getattr(series.plot, kind)(backend=backend)
+    assert isinstance(plot, el)
+
+
+@pytest.mark.parametrize('backend', ['holoviews', 'hvplot'])
+@pytest.mark.parametrize('kind,el', no_args_mapping)
+def test_pandas_dataframe_plot_explicit_returns_holoviews_object(backend, kind, el):
+    df = pd.DataFrame([0, 1, 2])
+    plot = getattr(df.plot, kind)(backend=backend)
+    assert isinstance(plot, el)
+
+
+@pytest.mark.parametrize('backend', ['holoviews', 'hvplot'])
+@pytest.mark.parametrize('kind,el', x_y_mapping)
+def test_pandas_dataframe_plot_explicit_returns_holoviews_object_when_x_and_y_set(
+    backend, kind, el
+):
+    df = pd.DataFrame({'a': [0, 1, 2], 'b': [5, 7, 2]})
+    plot = getattr(df.plot, kind)(x='a', y='b', backend=backend)
+    assert isinstance(plot, el)
+
+
+@pytest.mark.parametrize('backend', ['holoviews', 'hvplot'])
+def test_pandas_dataframe_plot_explicit_does_not_implement_pie(backend):
+    df = pd.DataFrame({'a': [0, 1, 2], 'b': [5, 7, 2]})
+    with pytest.raises(NotImplementedError, match='pie'):
+        df.plot.pie(y='a', backend=backend)
+
+
+@pytest.mark.parametrize('backend', ['holoviews', 'hvplot'])
+@pytest.mark.parametrize('kind,el', series_specials)
+def test_pandas_series_specials_plot_explicit_return_holoviews_object(backend, kind, el):
+    series = pd.Series([0, 1, 2])
+    plot = getattr(series, kind)(backend=backend)
+    assert isinstance(plot, el)
+
+
+@pytest.mark.parametrize('backend', ['holoviews', 'hvplot'])
+@pytest.mark.parametrize('kind,el', frame_specials)
+def test_pandas_frame_specials_plot_explicit_return_holoviews_object(backend, kind, el):
+    df = pd.DataFrame([0, 1, 2])
+    plot = getattr(df, kind)(backend=backend)
+    assert isinstance(plot, el)
+
+
 def test_plot_supports_duckdb_relation():
     duckdb = pytest.importorskip('duckdb')
     connection = duckdb.connect(':memory:')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ dependencies = [
 
 [project.entry-points."pandas_plotting_backends"]
 holoviews = "hvplot:plotting"
+hvplot = "hvplot:plotting"
 
 [project.urls]
 Homepage = "https://hvplot.holoviz.org"


### PR DESCRIPTION
Fixes https://github.com/holoviz/hvplot/issues/1483

When a plotting backend is configured on pandas via e.g. `pd.options.plotting.backend =  '<backend>'`, Pandas has two ways to use it:

1. it will try to see if it is registered as an entry point and if so will load the registered module (`holoviews = "hvplot:plotting"` registers `holoviews` as an entry point pointing to the `hvplot.plotting` module).
2. if 1/ doesn't succeed, it will load the module as is

In both cases, the only check Pandas performs is to verify that the backend has a `plot` attribute.

https://github.com/holoviz/hvplot/pull/347 exposed the `plot` function from `hvplot.plotting` in the top-level module, allowing users to register the backend with `pd.options.plotting.backend = 'hvplot'` (leveraging 2/). However, that is not enough to give users access to the special plot methods Pandas expects like `boxplot` or `hist`.

This PR fixes that by adding another `hvplot` entry point.