### PR TITLE
Set OHLC x-axis tooltip to datetime format

### DIFF
--- a/hvplot/converter.py
+++ b/hvplot/converter.py
@@ -2632,7 +2632,9 @@ class HoloViewsConverter:
         if 'hover' in tools:
             x_data = data[x] if x in data.columns else data.index
             if pd.api.types.is_datetime64_any_dtype(x_data):
-                x_tooltip = f'@{x}{{%F}}'
+                # %F %T: strftime code for %Y-%m-%d %H:%M:%S.
+                # See https://man7.org/linux/man-pages/man3/strftime.3.html
+                x_tooltip = f'@{x}{{%F %T}}'
                 formatter = {f'@{x}': 'datetime'}
             else:
                 x_tooltip = f'@{x}'

--- a/hvplot/converter.py
+++ b/hvplot/converter.py
@@ -2630,10 +2630,17 @@ class HoloViewsConverter:
         seg_cur_opts, seg_compat_opts = self._get_compat_opts('Segments')
         tools = seg_cur_opts.pop('tools', [])
         if 'hover' in tools:
+            x_data = data[x] if x in data.columns else data.index
+            if np.issubdtype(x_data.dtype, np.datetime64):
+                x_tooltip = f'@{x}{{%F}}'
+                formatter = {f'@{x}': 'datetime'}
+            else:
+                x_tooltip = f'@{x}'
+                formatter = {}
             tools[tools.index('hover')] = HoverTool(
-                formatters={f'@{x}': 'datetime'},
+                formatters=formatter,
                 tooltips=[
-                    (x, f'@{x}{{%F}}'),
+                    (x, x_tooltip),
                     ('Open', f'@{o}'),
                     ('High', f'@{h}'),
                     ('Low', f'@{l}'),

--- a/hvplot/converter.py
+++ b/hvplot/converter.py
@@ -2631,7 +2631,7 @@ class HoloViewsConverter:
         tools = seg_cur_opts.pop('tools', [])
         if 'hover' in tools:
             x_data = data[x] if x in data.columns else data.index
-            if np.issubdtype(x_data.dtype, np.datetime64):
+            if pd.api.types.is_datetime64_any_dtype(x_data):
                 x_tooltip = f'@{x}{{%F}}'
                 formatter = {f'@{x}': 'datetime'}
             else:

--- a/hvplot/converter.py
+++ b/hvplot/converter.py
@@ -2631,14 +2631,15 @@ class HoloViewsConverter:
         tools = seg_cur_opts.pop('tools', [])
         if 'hover' in tools:
             tools[tools.index('hover')] = HoverTool(
+                formatters={f'@{x}': 'datetime'},
                 tooltips=[
-                    (x, f'@{x}'),
+                    (x, f'@{x}{{%F}}'),
                     ('Open', f'@{o}'),
                     ('High', f'@{h}'),
                     ('Low', f'@{l}'),
                     ('Close', f'@{c}'),
                 ]
-                + [(hc, f'@{hc}') for hc in vdims[4:]]
+                + [(hc, f'@{hc}') for hc in vdims[4:]],
             )
         seg_cur_opts['tools'] = tools
         seg_cur_opts['color'] = self.kwds.get('line_color', 'black')

--- a/hvplot/tests/plotting/testohlc.py
+++ b/hvplot/tests/plotting/testohlc.py
@@ -44,3 +44,27 @@ def test_ohlc_date_tooltip_format():
     formatter_key = '@' + x_label
     formatter = hover_tool.formatters
     assert formatter.get(formatter_key) == 'datetime'
+
+
+def test_ohlc_non_datetime_x_axis():
+    df = pd.DataFrame(
+        {
+            'Open': [100.00, 101.25, 102.75],
+            'High': [104.10, 105.50, 110.00],
+            'Low': [94.00, 97.10, 99.20],
+            'Close': [101.15, 99.70, 109.50],
+            'Volume': [10012, 5000, 18000],
+        },
+        index=[1, 2, 3],
+    )
+
+    ohlc_cols = ['Open', 'High', 'Low', 'Close']
+
+    plot = df.hvplot.ohlc(y=ohlc_cols)
+    segments = plot.Segments.I
+    hover_tool = segments.opts.get('plot').kwargs['tools'][0]
+    tooltips = hover_tool.tooltips
+    x_label, x_tooltip = tooltips[0]
+    assert '{%F}' not in x_tooltip
+    formatter_key = '@' + x_label
+    assert formatter_key not in hover_tool.formatters

--- a/hvplot/tests/plotting/testohlc.py
+++ b/hvplot/tests/plotting/testohlc.py
@@ -40,10 +40,10 @@ def test_ohlc_date_tooltip_format():
     hover_tool = segments.opts.get('plot').kwargs['tools'][0]
     tooltips = hover_tool.tooltips
     x_label, x_tooltip = tooltips[0]
-    assert '{%F}' in x_tooltip
+    assert '{%F %T}' in x_tooltip
     formatter_key = '@' + x_label
     formatter = hover_tool.formatters
-    assert formatter.get(formatter_key) == 'datetime'
+    assert formatter[formatter_key] == 'datetime'
 
 
 def test_ohlc_non_datetime_x_axis():
@@ -68,3 +68,26 @@ def test_ohlc_non_datetime_x_axis():
     assert '{%F}' not in x_tooltip
     formatter_key = '@' + x_label
     assert formatter_key not in hover_tool.formatters
+
+
+def test_ohlc_non_index_date_col():
+    df = pd.DataFrame(
+        {
+            'Date': [
+                pd.Timestamp('2022-08-01'),
+                pd.Timestamp('2022-08-03'),
+                pd.Timestamp('2022-08-04'),
+            ],
+            'Open': [100.00, 101.25, 102.75],
+            'High': [104.10, 105.50, 110.00],
+            'Low': [94.00, 97.10, 99.20],
+            'Close': [101.15, 99.70, 109.50],
+            'Volume': [10012, 5000, 18000],
+        },
+    )
+    plot = df.hvplot.ohlc(hover_cols='all', use_index=False)
+    segments = plot.Segments.I
+    hover_tool = segments.opts.get('plot').kwargs['tools'][0]
+    tooltips = hover_tool.tooltips
+    assert len(tooltips) == len(df.columns)
+    assert tooltips[0] == ('Date', '@Date{%F %T}')

--- a/hvplot/tests/plotting/testohlc.py
+++ b/hvplot/tests/plotting/testohlc.py
@@ -32,3 +32,15 @@ def test_ohlc_hover_cols_all():
     tooltips = segments.opts.get('plot').kwargs['tools'][0].tooltips
     assert len(tooltips) == len(df.columns) + 1
     assert tooltips[-1] == ('Volume', '@Volume')
+
+
+def test_ohlc_date_tooltip_format():
+    plot = df.hvplot.ohlc(y=ohlc_cols)
+    segments = plot.Segments.I
+    hover_tool = segments.opts.get('plot').kwargs['tools'][0]
+    tooltips = hover_tool.tooltips
+    x_label, x_tooltip = tooltips[0]
+    assert '{%F}' in x_tooltip
+    formatter_key = '@' + x_label
+    formatter = hover_tool.formatters
+    assert formatter.get(formatter_key) == 'datetime'


### PR DESCRIPTION
- [x] fixes #1487 
- [x] Added tests

```python
import pandas as pd
import hvplot.pandas  # noqa
from bokeh.sampledata import stocks

df = pd.DataFrame(stocks.AAPL)
df['date'] = pd.to_datetime(df.date)

df.iloc[-50:].hvplot.ohlc(grid=True)
```

![image](https://github.com/user-attachments/assets/31cfb0e1-1ae5-4e1e-9d7f-9a11c771ecb0)
