### PR TITLE
Refactor and improve patching of the plotting methods docstring and signature

### DIFF
--- a/hvplot/__init__.py
+++ b/hvplot/__init__.py
@@ -58,24 +58,22 @@ To ask the community go to https://discourse.holoviz.org/.
 To report issues go to https://github.com/holoviz/holoviews.
 """
 
-import inspect
 import os
 import sys
-import textwrap
 
 import panel as _pn
 import holoviews as _hv
 
-from holoviews import Store, render  # noqa
+from holoviews import render  # noqa
 
 
-from .converter import HoloViewsConverter
+from .converter import HoloViewsConverter  # noqa
 from .interactive import Interactive
 from .ui import explorer  # noqa
-from .util import _in_ipython
-from .utilities import hvplot_extension, output, save, show  # noqa
+from .util import _PatchHvplotDocstrings, _in_ipython
+from .utilities import help, hvplot_extension, output, save, show  # noqa
 from .plotting import (
-    hvPlot,
+    hvPlot,  # noqa
     hvPlotTabular,  # noqa
     andrews_curves,  # noqa
     lag_plot,  # noqa
@@ -145,110 +143,6 @@ try:
 except Exception:
     pass
 
-_METHOD_DOCS = {}
-
-
-def _get_doc_and_signature(
-    cls, kind, completions=False, docstring=True, generic=True, style=True, signature=None
-):
-    converter = HoloViewsConverter
-    method = getattr(cls, kind)
-    kind_opts = converter._kind_options.get(kind, [])
-    eltype = converter._kind_mapping[kind]
-
-    formatter = ''
-    if completions:
-        formatter = 'hvplot.{kind}({completions})'
-    if docstring:
-        if formatter:
-            formatter += '\n'
-        formatter += '{docstring}'
-    if generic:
-        if formatter:
-            formatter += '\n'
-        formatter += '{options}'
-
-    if isinstance(style, str):
-        backend = style
-    else:
-        # Bokeh is the default backend
-        backend = hvplot_extension.compatibility or Store.current_backend
-    if eltype in Store.registry[backend]:
-        valid_opts = Store.registry[backend][eltype].style_opts
-        if style:
-            formatter += '\n{style}'
-    else:
-        valid_opts = []
-
-    style_opts = 'Style options\n-------------\n\n' + '\n'.join(sorted(valid_opts))
-
-    parameters = []
-    extra_kwargs = _hv.core.util.unique_iterator(
-        valid_opts
-        + kind_opts
-        + converter._axis_config_options
-        + converter._size_layout_options
-        + converter._grid_legend_options
-        + converter._resample_options
-    )
-
-    sig = signature or inspect.signature(method)
-    for name, p in list(sig.parameters.items())[1:]:
-        if p.kind == 1:
-            parameters.append((name, p.default))
-
-    filtered_signature = [
-        p for p in sig.parameters.values() if p.kind != inspect.Parameter.VAR_KEYWORD
-    ]
-    extra_params = [
-        inspect.Parameter(k, inspect.Parameter.KEYWORD_ONLY)
-        for k in extra_kwargs
-        if k not in [p.name for p in filtered_signature]
-    ]
-    all_params = (
-        filtered_signature
-        + extra_params
-        + [inspect.Parameter('kwargs', inspect.Parameter.VAR_KEYWORD)]
-    )
-    signature = inspect.Signature(all_params)
-
-    parameters += [(o, None) for o in extra_kwargs]
-    completions = ', '.join([f'{n}={v}' for n, v in parameters])
-    options = textwrap.dedent(converter.__doc__)
-    method_doc = _METHOD_DOCS.get(kind, method.__doc__)
-    _METHOD_DOCS[kind] = method_doc
-    docstring = formatter.format(
-        kind=kind,
-        completions=completions,
-        docstring=textwrap.dedent(method_doc),
-        options=options,
-        style=style_opts,
-    )
-    return docstring, signature
-
-
-def help(kind=None, docstring=True, generic=True, style=True):
-    """
-    Provide a docstring with all valid options which apply to the plot
-    type.
-
-    Parameters
-    ----------
-    kind: str, optional
-        The kind of plot to provide help for.
-    docstring: boolean, default=True
-        Whether to display the docstring.
-    generic: boolean, default=True
-        Whether to provide list of generic options.
-    style: str or boolean, default=True
-        Plotting backend used to get the styling options. True by default
-        to automatically infer it based on the loaded extension.
-    """
-    doc, sig = _get_doc_and_signature(
-        cls=hvPlot, kind=kind, docstring=docstring, generic=generic, style=style
-    )
-    print(doc)
-
 
 def post_patch(extension='bokeh', logo=False, check_loaded=False):
     if not check_loaded:
@@ -257,48 +151,19 @@ def post_patch(extension='bokeh', logo=False, check_loaded=False):
         hvplot_extension(extension, logo=logo)
 
 
-def _patch_doc(cls, kind, signature=None):
-    method = getattr(cls, kind)
-    docstring, signature = _get_doc_and_signature(cls, kind, False, signature=signature)
-    method.__doc__ = docstring
-    method.__signature__ = signature
-
-
-class _PatchHvplotDocstrings:
-    def __init__(self):
-        # Store the original signatures because the method signatures
-        # are going to be patched every time an extension is changed.
-        signatures = {}
-        for cls in [hvPlot, hvPlotTabular]:
-            for _kind in HoloViewsConverter._kind_mapping:
-                if hasattr(cls, _kind):
-                    method = getattr(cls, _kind)
-                    sig = inspect.signature(method)
-                    signatures[(cls, _kind)] = sig
-        self.orig_signatures = signatures
-
-    def __call__(self):
-        for cls in [hvPlot, hvPlotTabular]:
-            for _kind in HoloViewsConverter._kind_mapping:
-                if hasattr(cls, _kind):
-                    signature = self.orig_signatures[(cls, _kind)]
-                    _patch_doc(cls, _kind, signature=signature)
-
-
 if _PATCH_PLOT_SIGNATURES:
+    from holoviews import Store
+
     _patch_hvplot_docstrings = _PatchHvplotDocstrings()
     _patch_hvplot_docstrings()
 
+    def _hook_patch_docstrings(backend):
+        # Patch or re-patch the docstrings/signatures to display
+        # the right styling options.
+        from . import _patch_hvplot_docstrings
 
-def _hook_patch_docstrings(backend):
-    # Patch or re-patch the docstrings/signatures to display
-    # the right styling options.
-    from . import _patch_hvplot_docstrings
+        _patch_hvplot_docstrings()
 
-    _patch_hvplot_docstrings()
-
-
-if _PATCH_PLOT_SIGNATURES:
     Store._backend_switch_hooks.append(_hook_patch_docstrings)
 
 extension = hvplot_extension

--- a/hvplot/converter.py
+++ b/hvplot/converter.py
@@ -182,7 +182,7 @@ class HoloViewsConverter:
     value_label (default='value'): str
         Label for the data values, typically used for the y-axis or in legends.
 
-    Geographic options
+    Geographic Options
     ------------------
     coastline (default=False):
         Whether to display a coastline on top of the plot, setting
@@ -224,7 +224,7 @@ class HoloViewsConverter:
         Options to customize the tiles layer created when `tiles` is set,
         e.g. `dict(alpha=0.5)`.
 
-    Size and Layout options
+    Size and Layout Options
     -----------------------
     fontscale: number
         Scales the size of all fonts by the same amount, e.g. fontscale=1.5
@@ -250,7 +250,7 @@ class HoloViewsConverter:
         width and height or width and aspect are set the plot is set
         to a fixed size, ignoring any responsive option.
 
-    Axis options
+    Axis Options
     ------------
     aspect (default=None): str or float
         The aspect ratio mode of the plot. By default, a plot may
@@ -305,7 +305,7 @@ class HoloViewsConverter:
         Ticks along x-axis, y-axis, and colorbar specified as an integer, list of
         ticks positions, or list of tuples of the tick positions and labels
 
-    Grid and Legend options
+    Grid and Legend Options
     -----------------------
     colorbar (default=False): boolean
         Enables a colorbar
@@ -315,7 +315,7 @@ class HoloViewsConverter:
         Whether to show a legend, or a legend position
         ('top', 'bottom', 'left', 'right')
 
-    Interactivity options
+    Interactivity Options
     ---------------------
     hover : boolean
         Whether to show hover tooltips, default is True unless datashade is
@@ -330,7 +330,7 @@ class HoloViewsConverter:
     tools (default=[]): list
         List of tool instances or strings (e.g. ['tap', 'box_select'])
 
-    Style options
+    Style Options
     -------------
     bgcolor (default=None): str
         Background color of the data area of the plot
@@ -349,7 +349,7 @@ class HoloViewsConverter:
         thus avoiding washout of the lower values.  Has no effect if
         `cnorm!=`eq_hist`.
 
-    Resampling options
+    Resampling Options
     ------------------
     aggregator (default=None):
         Aggregator to use when applying rasterize or datashade operation
@@ -414,7 +414,7 @@ class HoloViewsConverter:
         Specifies the smallest allowed sampling interval along the x/y axis.
         Used when rasterizing or datashading.
 
-    Streaming options
+    Streaming Options
     -----------------
     backlog (default=1000): int
         Maximum number of rows to keep in the stream buffer when using a streaming data source.
@@ -559,6 +559,30 @@ class HoloViewsConverter:
         'backlog',
         'stream',
     ]
+
+    _docstring_sections = {
+        'data': 'Data Options',
+        'geographic': 'Geographic Options',
+        'size_layout': 'Size and Layout Options',
+        'axis': 'Axis Options',
+        'grid_legend': 'Grid and Legend Options',
+        'interactivity': 'Interactivity Options',
+        'style': 'Style Options',
+        'resampling': 'Resampling Options',
+        'streaming': 'Streaming Options',
+    }
+
+    _options_groups = {
+        'data': _data_options,
+        'geographic': _geo_options,
+        'size_layout': _size_layout_options,
+        'axis': _axis_config_options,
+        'grid_legend': _grid_legend_options,
+        'interactivity': _interactivity_options,
+        'style': _style_options,
+        'resampling': _resample_options,
+        'streaming': _stream_options,
+    }
 
     # Options specific to a particular plot type
     _kind_options = {

--- a/hvplot/tests/testhelp.py
+++ b/hvplot/tests/testhelp.py
@@ -25,7 +25,7 @@ def test_help_style_extension_output(reset_default_backend):
         style=True,
         signature=None,
     )
-    assert docstring == '\nStyle options\n-------------\n\n' + '\n'.join(
+    assert docstring == '\nStyle options\n-------------\n' + '\n'.join(
         sorted(Store.registry['bokeh'][Curve].style_opts)
     )
 
@@ -40,7 +40,7 @@ def test_help_style_extension_output(reset_default_backend):
         style=True,
         signature=None,
     )
-    assert docstring == '\nStyle options\n-------------\n\n' + '\n'.join(
+    assert docstring == '\nStyle options\n-------------\n' + '\n'.join(
         sorted(Store.registry['matplotlib'][Curve].style_opts)
     )
 
@@ -55,7 +55,7 @@ def test_help_style_extension_output(reset_default_backend):
         style=True,
         signature=None,
     )
-    assert docstring == '\nStyle options\n-------------\n\n' + '\n'.join(
+    assert docstring == '\nStyle options\n-------------\n' + '\n'.join(
         sorted(Store.registry['plotly'][Curve].style_opts)
     )
 
@@ -72,6 +72,6 @@ def test_help_style_compatibility(reset_default_backend):
         style=True,
         signature=None,
     )
-    assert docstring == '\nStyle options\n-------------\n\n' + '\n'.join(
+    assert docstring == '\nStyle options\n-------------\n' + '\n'.join(
         sorted(Store.registry['matplotlib'][Curve].style_opts)
     )

--- a/hvplot/tests/testhelp.py
+++ b/hvplot/tests/testhelp.py
@@ -4,6 +4,8 @@ import pytest
 from holoviews.core import Store
 from holoviews.element import Curve
 
+from hvplot.util import _get_doc_and_signature
+
 
 @pytest.fixture
 def reset_default_backend():
@@ -14,7 +16,7 @@ def reset_default_backend():
 
 def test_help_style_extension_output(reset_default_backend):
     # default, after e.g. import hvplot.pandas
-    docstring, signature = hvplot._get_doc_and_signature(
+    docstring, signature = _get_doc_and_signature(
         cls=hvplot.hvPlot,
         kind='line',
         completions=False,
@@ -29,7 +31,7 @@ def test_help_style_extension_output(reset_default_backend):
 
     # The current backend becomes matplotlib
     hvplot.extension('matplotlib', 'plotly')
-    docstring, signature = hvplot._get_doc_and_signature(
+    docstring, signature = _get_doc_and_signature(
         cls=hvplot.hvPlot,
         kind='line',
         completions=False,
@@ -44,7 +46,7 @@ def test_help_style_extension_output(reset_default_backend):
 
     # The current backend becomes plotly
     hvplot.output(backend='plotly')
-    docstring, signature = hvplot._get_doc_and_signature(
+    docstring, signature = _get_doc_and_signature(
         cls=hvplot.hvPlot,
         kind='line',
         completions=False,
@@ -61,7 +63,7 @@ def test_help_style_extension_output(reset_default_backend):
 def test_help_style_compatibility(reset_default_backend):
     # The current backend is plotly but the style options are those of matplotlib
     hvplot.extension('plotly', 'matplotlib', compatibility='matplotlib')
-    docstring, signature = hvplot._get_doc_and_signature(
+    docstring, signature = _get_doc_and_signature(
         cls=hvplot.hvPlot,
         kind='line',
         completions=False,

--- a/hvplot/tests/testpatchsignature.py
+++ b/hvplot/tests/testpatchsignature.py
@@ -1,0 +1,53 @@
+import subprocess
+import sys
+
+from hvplot.util import _in_ipython
+
+
+def run_script(script, env_vars=None):
+    process = subprocess.run(
+        [sys.executable, '-c', script],
+        text=True,
+        capture_output=True,
+        env=env_vars or {},
+    )
+    if process.returncode != 0:
+        raise RuntimeError(f'Subprocess failed: {process.stderr}')
+    return process.stdout.strip()
+
+
+def test_no_automatic_patching():
+    script = """
+import inspect
+from hvplot import hvPlot
+
+print(inspect.signature(hvPlot.line))
+"""
+    assert not _in_ipython()
+    out = run_script(script)
+    assert out == '(self, x=None, y=None, **kwds)'
+
+
+def test_no_automatic_patching_extension_import():
+    script = """
+import inspect
+import hvplot.pandas
+
+print(inspect.signature(hvplot.hvPlot.line))
+"""
+    assert not _in_ipython()
+    out = run_script(script)
+    assert out == '(self, x=None, y=None, **kwds)'
+
+
+def test_patching_env_var():
+    script = """
+import inspect
+from hvplot import hvPlot
+
+print(inspect.signature(hvPlot.line))
+"""
+    assert not _in_ipython()
+    out = run_script(script, {'HVPLOT_PATCH_PLOT_DOCSTRING_SIGNATURE': 'true'})
+    assert out != '(self, x=None, y=None, **kwds)'
+    assert 'xlim' in out

--- a/hvplot/util.py
+++ b/hvplot/util.py
@@ -815,17 +815,17 @@ def _get_doc_and_signature(
         # Bokeh is the default backend
         backend = hvplot_extension.compatibility or hv.Store.current_backend
     if eltype in hv.Store.registry[backend]:
-        valid_opts = hv.Store.registry[backend][eltype].style_opts
+        backend_style_opts = hv.Store.registry[backend][eltype].style_opts
         if style:
             formatter += '\n{style}'
     else:
-        valid_opts = []
+        backend_style_opts = []
 
-    style_opts = 'Style options\n-------------\n\n' + '\n'.join(sorted(valid_opts))
+    style_opts = 'Style options\n-------------\n\n' + '\n'.join(sorted(backend_style_opts))
 
     parameters = []
     extra_kwargs = hv.core.util.unique_iterator(
-        valid_opts
+        backend_style_opts
         + kind_opts
         + converter._axis_config_options
         + converter._size_layout_options

--- a/hvplot/util.py
+++ b/hvplot/util.py
@@ -50,6 +50,14 @@ def get_ipy():
     return ip
 
 
+def _in_ipython():
+    try:
+        get_ipython  # noqa
+        return True
+    except NameError:
+        return False
+
+
 def check_crs(crs):
     """
     Checks if the crs represents a valid grid, projection or ESPG string.

--- a/hvplot/utilities.py
+++ b/hvplot/utilities.py
@@ -110,6 +110,8 @@ class hvplot_extension(_hv.extension):
     logo = param.Boolean(default=False)
 
     def __call__(self, *args, **params):
+        from . import _PATCH_PLOT_SIGNATURES
+
         # importing e.g. hvplot.pandas always loads the bokeh extension.
         # so hvplot.extension('matplotlib', compatibility='bokeh') doesn't
         # require the user or the code to explicitly load bokeh.
@@ -122,8 +124,9 @@ class hvplot_extension(_hv.extension):
                 'not yet implemented. Defaults to bokeh.'
             )
         hvplot_extension.compatibility = compatibility
-        # Patch or re-patch the docstrings/signatures to display
-        # the right styling options.
-        from . import _patch_hvplot_docstrings
+        if _PATCH_PLOT_SIGNATURES:
+            # Patch or re-patch the docstrings/signatures to display
+            # the right styling options.
+            from . import _patch_hvplot_docstrings
 
-        _patch_hvplot_docstrings()
+            _patch_hvplot_docstrings()

--- a/hvplot/utilities.py
+++ b/hvplot/utilities.py
@@ -2,9 +2,36 @@ import panel as _pn
 import param
 import holoviews as _hv
 
+from .util import _get_doc_and_signature
+
 renderer = _hv.renderer('bokeh')
 
 output = _hv.output
+
+
+def help(kind=None, docstring=True, generic=True, style=True):
+    """
+    Provide a docstring with all valid options which apply to the plot
+    type.
+
+    Parameters
+    ----------
+    kind: str, optional
+        The kind of plot to provide help for.
+    docstring: boolean, default=True
+        Whether to display the docstring.
+    generic: boolean, default=True
+        Whether to provide list of generic options.
+    style: str or boolean, default=True
+        Plotting backend used to get the styling options. True by default
+        to automatically infer it based on the loaded extension.
+    """
+    from .plotting.core import hvPlot
+
+    doc, sig = _get_doc_and_signature(
+        cls=hvPlot, kind=kind, docstring=docstring, generic=generic, style=style
+    )
+    print(doc)
 
 
 def save(


### PR DESCRIPTION
- Patching only done on import when in IPython or when the env var `HVPLOT_PATCH_PLOT_DOCSTRING_SIGNATURE` is non falsy
- Move the utility functions from the top-level `__init__.py` to the `util.py` module
- Ensure the signature and docstring contain the right options, moving the backend styling options last
