### PR TITLE
Run unit tests with param warnings as exceptions by default

### DIFF
--- a/hvplot/tests/conftest.py
+++ b/hvplot/tests/conftest.py
@@ -1,5 +1,10 @@
-from packaging.version import Version
 import dask
+import param
+import pytest
+
+from packaging.version import Version
+
+param.parameterized.warnings_as_exceptions = True
 
 optional_markers = {
     'geo': {
@@ -42,3 +47,13 @@ if Version(dask.__version__).release < (2025, 1, 0):
     # From Dask 2024.3.0 they now use `dask_expr` by default
     # https://github.com/dask/dask/issues/10995
     dask.config.set({'dataframe.query-planning': False})
+
+
+@pytest.fixture
+def disable_param_warnings_as_exceptions():
+    original = param.parameterized.warnings_as_exceptions
+    param.parameterized.warnings_as_exceptions = False
+    try:
+        yield
+    finally:
+        param.parameterized.warnings_as_exceptions = original

--- a/hvplot/tests/testhelp.py
+++ b/hvplot/tests/testhelp.py
@@ -60,6 +60,7 @@ def test_help_style_extension_output(reset_default_backend):
     )
 
 
+@pytest.mark.usefixtures('disable_param_warnings_as_exceptions')
 def test_help_style_compatibility(reset_default_backend):
     # The current backend is plotly but the style options are those of matplotlib
     hvplot.extension('plotly', 'matplotlib', compatibility='matplotlib')

--- a/hvplot/tests/testoverrides.py
+++ b/hvplot/tests/testoverrides.py
@@ -2,6 +2,7 @@ from collections import OrderedDict
 
 import numpy as np
 import pandas as pd
+import pytest
 import xarray as xr
 
 from hvplot.plotting import hvPlot, hvPlotTabular
@@ -44,6 +45,7 @@ class TestOverrides(ComparisonTestCase):
         self.assertNotEqual(opts.options.get('width'), 42)
         self.assertNotEqual(opts.options.get('height'), 42)
 
+    @pytest.mark.usefixtures('disable_param_warnings_as_exceptions')
     def test_attempt_to_override_kind_on_method(self):
         hvplot = hvPlotTabular(self.df, {'scatter': {'kind': 'line'}})
         self.assertIsInstance(hvplot.scatter(y='y'), Scatter)

--- a/hvplot/tests/testui.py
+++ b/hvplot/tests/testui.py
@@ -392,6 +392,7 @@ def test_explorer_xarray_multi_var_extra_dims_no_coord():
     assert ds.hvplot.explorer()
 
 
+@pytest.mark.usefixtures('disable_param_warnings_as_exceptions')
 @pytest.mark.parametrize('kind_tuple', [('scatter', 'points'), ('line', 'paths')])
 @pytest.mark.geo
 def test_explorer_geo_revise_kind(kind_tuple):

--- a/hvplot/tests/testui.py
+++ b/hvplot/tests/testui.py
@@ -123,6 +123,7 @@ def test_explorer_kwargs_controls():
     assert explorer.axes.width == 200
 
 
+@pytest.mark.usefixtures('disable_param_warnings_as_exceptions')
 def test_explorer_kwargs_controls_error_not_supported():
     with pytest.raises(
         TypeError,
@@ -399,6 +400,7 @@ def test_explorer_geo_revise_kind(kind_tuple):
     assert explorer.kind == kind_tuple[1]
 
 
+@pytest.mark.usefixtures('disable_param_warnings_as_exceptions')
 def test_max_rows_curve():
     N = 100001
     x = np.linspace(0.0, 6.4, num=N)
@@ -408,6 +410,7 @@ def test_max_rows_curve():
     assert ui._data.equals(df.head(MAX_ROWS))
 
 
+@pytest.mark.usefixtures('disable_param_warnings_as_exceptions')
 def test_max_rows_sample():
     N = 100001
     x = np.linspace(0.0, 6.4, num=N)

--- a/hvplot/ui.py
+++ b/hvplot/ui.py
@@ -553,9 +553,11 @@ class hvPlotExplorer(Viewer):
         if 'y' in params:
             params['y_multi'] = params.pop('y') if isinstance(params['y'], list) else [params['y']]
         statusbar_params = {k: params.pop(k) for k in params.copy() if k in StatusBar.param}
+        opts_kwargs = params.pop('opts', {})
         converter = _hvConverter(
             df, x, y, **{k: v for k, v in params.items() if k not in ('x', 'y', 'y_multi')}
         )
+        params['opts'] = opts_kwargs
         # Collect kwargs passed to the constructor but meant for the controls
         extras = {k: params.pop(k) for k in params.copy() if k not in self.param}
         super().__init__(**params)


### PR DESCRIPTION
With one small code change in the explorer, avoiding passing `opts` to the converter as `opts` is not a kwarg the converter knows about.