### PR TITLE
Add version as input for docs versioning

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -17,6 +17,9 @@ on:
         - dryrun
         required: true
         default: dryrun
+    version:
+      description: 'Version tag (required if target is main)'
+      required: false
   schedule:
     - cron: '0 15 * * SUN'
 


### PR DESCRIPTION
This is to test the Github interface with this flag for https://github.com/holoviz/hvplot/pull/1533. It can always be reverted.