### PR TITLE
Deprecate the debug argument

### DIFF
--- a/doc/ref/deprecations.md
+++ b/doc/ref/deprecations.md
@@ -1,0 +1,13 @@
+# Deprecations and Removals
+
+List of currently deprecated APIs:
+
+| Warning | Description |
+|-|-|
+| `DeprecationWarning` since `0.12.0` | `debug` argument |
+
+List (created after the release of version `0.12.0`) of removed APIs:
+
+| Removed in | Warning | Description |
+|-|-|-|
+| | | |

--- a/doc/ref/deprecations.md
+++ b/doc/ref/deprecations.md
@@ -4,7 +4,7 @@ List of currently deprecated APIs:
 
 | Warning | Description |
 |-|-|
-| `DeprecationWarning` since `0.12.0` | `debug` argument |
+| `FutureWarning` since `0.12.0` | `debug` argument |
 
 List (created after the release of version `0.12.0`) of removed APIs:
 

--- a/doc/ref/index.md
+++ b/doc/ref/index.md
@@ -13,4 +13,5 @@ Supported plotting extensions <plotting_extensions>
 Plotting options <plotting_options/index>
 API <api/index>
 API compatibility <api_compatibility/index>
+Deprecations/Removals <deprecations>
 ```

--- a/hvplot/converter.py
+++ b/hvplot/converter.py
@@ -807,7 +807,7 @@ class HoloViewsConverter:
         if debug:
             warnings.warn(
                 '`debug` has been deprecated and will be removed in a future version.',
-                DeprecationWarning,
+                FutureWarning,
             )
 
         # Process data and related options

--- a/hvplot/converter.py
+++ b/hvplot/converter.py
@@ -1,5 +1,6 @@
 import difflib
 import sys
+import warnings
 from functools import partial
 
 import param
@@ -803,6 +804,12 @@ class HoloViewsConverter:
         subcoordinate_y=None,
         **kwds,
     ):
+        if debug:
+            warnings.warn(
+                '`debug` has been deprecated and will be removed in a future version.',
+                DeprecationWarning,
+            )
+
         # Process data and related options
         self._redim = fields
         self.use_index = use_index

--- a/hvplot/tests/testdeprecations.py
+++ b/hvplot/tests/testdeprecations.py
@@ -1,0 +1,14 @@
+"""
+Tests for deprecation warnings.
+"""
+
+import pandas as pd
+import pytest
+
+from hvplot.converter import HoloViewsConverter
+
+
+def test_converter_argument_debug(disable_param_warnings_as_exceptions):
+    df = pd.DataFrame({'x': [0, 1], 'y': [0, 1]})
+    with pytest.warns(DeprecationWarning):
+        HoloViewsConverter(df, 'x', 'y', debug=True)

--- a/hvplot/tests/testdeprecations.py
+++ b/hvplot/tests/testdeprecations.py
@@ -10,5 +10,5 @@ from hvplot.converter import HoloViewsConverter
 
 def test_converter_argument_debug(disable_param_warnings_as_exceptions):
     df = pd.DataFrame({'x': [0, 1], 'y': [0, 1]})
-    with pytest.warns(DeprecationWarning):
+    with pytest.warns(FutureWarning):
         HoloViewsConverter(df, 'x', 'y', debug=True)


### PR DESCRIPTION
Resolves https://github.com/holoviz/hvplot/issues/1512

- Already at the `FutureWarning` level as this was an entirely undocumented argument
- Added a `deprecations.md` like on Param (hvPlot will need to deprecate stuff to prepare for 1.0 so that will be useful)