### PR TITLE
Deprecate handling DuckDB objects in the plot function

### DIFF
--- a/doc/ref/deprecations.md
+++ b/doc/ref/deprecations.md
@@ -4,6 +4,7 @@ List of currently deprecated APIs:
 
 | Warning | Description |
 |-|-|
+| `FutureWarning` since `0.12.0` | Passing DuckDB objects to `hvplot.plotting.plot`, use `import hvplot.duckdb` instead. |
 | `FutureWarning` since `0.12.0` | `debug` argument |
 
 List (created after the release of version `0.12.0`) of removed APIs:

--- a/hvplot/converter.py
+++ b/hvplot/converter.py
@@ -79,6 +79,7 @@ from .util import (
     import_datashader,
     import_geoviews,
     is_mpl_cmap,
+    _find_stack_level,
 )
 from .utilities import hvplot_extension
 
@@ -808,6 +809,7 @@ class HoloViewsConverter:
             warnings.warn(
                 '`debug` has been deprecated and will be removed in a future version.',
                 FutureWarning,
+                stacklevel=_find_stack_level(),
             )
 
         # Process data and related options

--- a/hvplot/plotting/__init__.py
+++ b/hvplot/plotting/__init__.py
@@ -1,3 +1,5 @@
+import warnings
+
 import holoviews as hv
 from ..util import with_hv_extension, is_duckdb, is_polars
 
@@ -36,6 +38,12 @@ def plot(data, kind, **kwargs):
         return hvPlotTabularPolars(data)(kind=kind, **no_none_kwargs)
 
     elif is_duckdb(data):
+        warnings.warn(
+            'Allowing to pass DuckDB data objects to the plot function is '
+            'deprecated and will be removed in a future version. '
+            'Use `import hvplot.duckdb` instead.',
+            FutureWarning,
+        )
         from .core import hvPlotTabularDuckDB
 
         return hvPlotTabularDuckDB(data)(kind=kind, **no_none_kwargs)

--- a/hvplot/plotting/__init__.py
+++ b/hvplot/plotting/__init__.py
@@ -1,7 +1,7 @@
 import warnings
 
 import holoviews as hv
-from ..util import with_hv_extension, is_duckdb, is_polars
+from ..util import with_hv_extension, is_duckdb, is_polars, _find_stack_level
 
 from .core import hvPlot, hvPlotTabular  # noqa
 
@@ -43,6 +43,7 @@ def plot(data, kind, **kwargs):
             'deprecated and will be removed in a future version. '
             'Use `import hvplot.duckdb` instead.',
             FutureWarning,
+            stacklevel=_find_stack_level(),
         )
         from .core import hvPlotTabularDuckDB
 

--- a/hvplot/tests/testdeprecations.py
+++ b/hvplot/tests/testdeprecations.py
@@ -6,9 +6,19 @@ import pandas as pd
 import pytest
 
 from hvplot.converter import HoloViewsConverter
+from hvplot.plotting import plot
+from hvplot.tests.util import makeDataFrame
 
 
 def test_converter_argument_debug(disable_param_warnings_as_exceptions):
     df = pd.DataFrame({'x': [0, 1], 'y': [0, 1]})
     with pytest.warns(FutureWarning):
         HoloViewsConverter(df, 'x', 'y', debug=True)
+
+
+def test_plotting_plot_duckdb():
+    duckdb = pytest.importorskip('duckdb')
+    connection = duckdb.connect(':memory:')
+    relation = duckdb.from_df(makeDataFrame(), connection=connection)
+    with pytest.warns(FutureWarning):
+        plot(relation, 'line')


### PR DESCRIPTION
Resolves https://github.com/holoviz/hvplot/issues/1492

This function is originally designed to be the entry point for the Pandas plotting backend (i.e. when setting `pd.options.plotting.backend = 'hvplot'` and calling `df.plot(...)`). We don't recommend using this function directly.