### PR TITLE
Minor fixes to Andrews Curves

### DIFF
--- a/hvplot/plotting/andrews_curves.py
+++ b/hvplot/plotting/andrews_curves.py
@@ -69,7 +69,7 @@ def andrews_curves(
 
     df = pd.DataFrame(
         {
-            't': np.tile(np.arange(samples), curves.shape[0]),
+            't': np.tile(t, curves.shape[0]),
             'sample': np.repeat(np.arange(curves.shape[0]), curves.shape[1]),
             'value': curves.ravel(),
             class_column: np.repeat(data[class_column], samples),

--- a/hvplot/plotting/andrews_curves.py
+++ b/hvplot/plotting/andrews_curves.py
@@ -59,7 +59,7 @@ def andrews_curves(
     t = np.linspace(-np.pi, np.pi, samples)
     vals = data.drop(class_column, axis=1).values.T
 
-    curves = np.outer(vals[0], np.ones_like(t))
+    curves = np.outer(vals[0] / np.sqrt(2), np.ones_like(t))
     for i in range(1, len(vals)):
         ft = ((i + 1) // 2) * t
         if i % 2 == 1:

--- a/hvplot/tests/plotting/testandrewscurves.py
+++ b/hvplot/tests/plotting/testandrewscurves.py
@@ -1,0 +1,24 @@
+import numpy as np
+import pandas as pd
+import pytest
+
+from hvplot.plotting import andrews_curves
+
+
+@pytest.fixture
+def df():
+    return pd.DataFrame(
+        {
+            'class': ['A', 'B', 'C'],
+            'x': [0, 2, 1],
+            'y': [1, 1, 2],
+            'z': [2, 1, 1],
+        }
+    )
+
+
+def test_andrews_curves_x_axis_data(df):
+    curves = andrews_curves(df, 'class')
+    assert len(curves) == len(df)
+    c1 = curves.get(('Curve', 'A'))
+    assert c1.data['t'].between(-np.pi, np.pi).all()


### PR DESCRIPTION
Fixes https://github.com/holoviz/hvplot/issues/1549

1. Ensures the x-axis is between -pi and pi as it is how Andrews curves are usually plotted
2. Modify the first coefficient to be `1/sqrt(2)` since this is what is described in the docstring

On 2), different types of transforms can be used to create Andrews curves and it could be the implementation corresponded with a valid type, however this didn't match with the docstring, and the one with this coefficient is the canonical one.

<img width="613" alt="image" src="https://github.com/user-attachments/assets/d4515aa8-d5c1-4905-8ed2-9d702bf7d13c" />
