### PR TITLE
Add auto-label action

### DIFF
--- a/.github/workflows/auto_triage.yml
+++ b/.github/workflows/auto_triage.yml
@@ -1,0 +1,15 @@
+name: Auto-label new issues with "triage"
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  add-triage-label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add TRIAGE label
+        uses: actions-ecosystem/action-add-labels@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          labels: TRIAGE

--- a/.github/workflows/auto_triage.yml
+++ b/.github/workflows/auto_triage.yml
@@ -1,15 +1,19 @@
-name: Auto-label new issues with "triage"
+name: Auto-label new issues with "TRIAGE"
 
 on:
   issues:
-    types: [opened]
-
+    types:
+      - reopened
+      - opened
 jobs:
   add-triage-label:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
     steps:
-      - name: Add TRIAGE label
-        uses: actions-ecosystem/action-add-labels@v1
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          labels: TRIAGE
+      - run: gh issue edit "$NUMBER" --add-label "$LABELS"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          NUMBER: ${{ github.event.issue.number }}
+          LABELS: TRIAGE


### PR DESCRIPTION
fixes #1581 

This PR add a GitHub action tool that automatically labels every new issue as `TRIAGE` regardless of how it was created.

Tested via:

1. [Web UI](https://github.com/Azaya89/hvplot/issues/6)
2. [GH CLI](https://github.com/Azaya89/hvplot/issues/7)