### PR TITLE
Enable branch coverage

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -188,9 +188,9 @@ jobs:
       - name: download datasets
         run: python scripts/download_data.py
       - name: unit tests
-        run: pytest -v hvplot --cov=hvplot --cov-append
+        run: pytest -v hvplot --cov=hvplot --cov-branch --cov-append
       - name: unit tests geo
-        run: pytest -v hvplot --geo --cov=hvplot --cov-append
+        run: pytest -v hvplot --geo --cov=hvplot --cov-branch --cov-append
       - name: examples tests
         run: pytest -n logical --dist loadscope --nbval-lax -p no:python
       - name: Upload coverage reports to Codecov

--- a/pixi.toml
+++ b/pixi.toml
@@ -211,8 +211,8 @@ pygraphviz = "*"
 
 [feature.test.tasks]
 test-unit-geo = 'pytest -v hvplot --geo'
-test-unit-cov = 'pytest -v hvplot --cov=hvplot --cov-append'
-test-unit-geo-cov = 'pytest -v hvplot --geo --cov=hvplot --cov-append'
+test-unit-cov = 'pytest -v hvplot --cov=hvplot --cov-branch --cov-append'
+test-unit-geo-cov = 'pytest -v hvplot --geo --cov=hvplot --cov-branch --cov-append'
 
 [feature.test-core.tasks]
 test-unit = 'pytest -v hvplot'


### PR DESCRIPTION
Thought it'd be useful given the converter code is "a big `if` statement". Global coverage will go down by about 2% based on local testing with branch coverage enabled.