### PR TITLE
Add support for log10 binning for histograms with logx and loglog

### DIFF
--- a/hvplot/converter.py
+++ b/hvplot/converter.py
@@ -2599,6 +2599,7 @@ class HoloViewsConverter:
             'bin_range': self.kwds.get('bin_range', None),
             'normed': self.kwds.get('normed', False),
             'cumulative': self.kwds.get('cumulative', False),
+            'log': self._plot_opts.get('logx', False),
         }
         if 'bins' in self.kwds:
             bins = self.kwds['bins']

--- a/hvplot/tests/testcharts.py
+++ b/hvplot/tests/testcharts.py
@@ -159,16 +159,7 @@ class TestChart1D(ComparisonTestCase):
                 'Volume {m3}': ['1', '2', '3'],
             }
         )
-        self.df_hist = pd.DataFrame(
-            {
-                'z': [
-                    1,
-                    1,
-                    4,
-                    4,
-                ]
-            }
-        )
+        self.df_hist = pd.DataFrame({'z': [1, 1, 4, 4]})
 
     @parameterized.expand([('line', Curve), ('area', Area), ('scatter', Scatter)])
     def test_wide_chart(self, kind, element):

--- a/hvplot/tests/testcharts.py
+++ b/hvplot/tests/testcharts.py
@@ -159,6 +159,16 @@ class TestChart1D(ComparisonTestCase):
                 'Volume {m3}': ['1', '2', '3'],
             }
         )
+        self.df_hist = pd.DataFrame(
+            {
+                'z': [
+                    1,
+                    1,
+                    4,
+                    4,
+                ]
+            }
+        )
 
     @parameterized.expand([('line', Curve), ('area', Area), ('scatter', Scatter)])
     def test_wide_chart(self, kind, element):
@@ -343,6 +353,13 @@ class TestChart1D(ComparisonTestCase):
         assert not plot_0.opts['axiswise']
         assert plot_0.range('x') == (1, 6)
         assert plot_1.range('y') == (1, 6)
+
+    def test_histogram_log_bins(self):
+        df = pd.DataFrame({'z': [1, 1, 4, 4]})
+        plot_logx = df.hvplot.hist(bins=2, logx=True)
+        plot_loglog = df.hvplot.hist(bins=2, loglog=True)
+        np.testing.assert_array_equal(plot_logx.data['z'], np.array([1.0, 2.0, 4.0]))
+        np.testing.assert_array_equal(plot_loglog.data['z'], np.array([1.0, 2.0, 4.0]))
 
     def test_scatter_color_internally_set_to_dim(self):
         altered_df = self.cat_df.copy().rename(columns={'category': 'red'})
@@ -601,6 +618,7 @@ class TestChart1DDask(TestChart1D):
         self.cat_df_index = dd.from_pandas(self.cat_df_index, npartitions=3)
         self.cat_df_index_y = dd.from_pandas(self.cat_df_index_y, npartitions=3)
         self.cat_only_df = dd.from_pandas(self.cat_only_df, npartitions=1)
+        self.df_hist = dd.from_pandas(self.df_hist, npartitions=1)
 
     def test_by_datetime_accessor(self):
         raise SkipTest("Can't expand dt accessor columns when using dask")


### PR DESCRIPTION
Resolves https://github.com/holoviz/hvplot/issues/1313

Setting `logx` or `loglog` to `True` plots the histogram bin edges on a log10 scale (new) and plots the x-axis with a log scale (not new). This is different from Pandas, which plots the data on an x-axis log scale. I think it's a better default.

```python
import numpy as np, polars as pl
import hvplot.polars
rng = np.random.default_rng(seed=123)
df = pl.DataFrame({
    "x": 10. ** rng.standard_normal(size=100)
})
df.hvplot.hist(logx=True)
```
<img width="735" alt="image" src="https://github.com/user-attachments/assets/33715f0b-17b4-431f-8815-5a989113f1db" />
