### PR TITLE
Document resampling, geographic, and streaming options

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -211,12 +211,14 @@ autosummary_generate = True
 # autosummary_generate_overwrite = False
 
 intersphinx_mapping = {
+    'cartopy': ('https://scitools.org.uk/cartopy/docs/latest/', None),
     'holoviews': ('https://holoviews.org/', None),
     'pandas': (
         'https://pandas.pydata.org/pandas-docs/stable/',
         'https://pandas.pydata.org/pandas-docs/stable/objects.inv',
     ),
     'panel': ('https://panel.holoviz.org/', None),
+    'pyproj': ('https://pyproj4.github.io/pyproj/stable/', None),
 }
 # See https://docs.readthedocs.com/platform/stable/guides/intersphinx.html
 intersphinx_disabled_reftypes = ['*']

--- a/doc/ref/plotting_options/geographic.ipynb
+++ b/doc/ref/plotting_options/geographic.ipynb
@@ -1,0 +1,537 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "0a5b6e8f-829d-4ebc-a07f-4b73bc3028f4",
+   "metadata": {},
+   "source": [
+    "# Geographic Options\n",
+    "\n",
+    ":::{note}\n",
+    "Most of the options below require the [GeoViews](https://geoviews.org) library to be installed. One notable exception is the [`tiles`](option-tiles) option, which, if the data is in *lat/lon* coordinates (e.g. GPS data) or already in the *Web Mercator* coordinate reference system, allows to overlay the data on a web tiled map without requiring GeoViews.\n",
+    ":::\n",
+    "\n",
+    ":::{note}\n",
+    "Supported plot types:\n",
+    "\n",
+    "Only certain plot types support geographic coordinates, currently including: {meth}`hvplot.hvPlot.points`, {meth}`hvplot.hvPlot.paths`, {meth}`hvplot.hvPlot.polygons`, {meth}`hvplot.hvPlot.image`, {meth}`hvplot.hvPlot.quadmesh`, {meth}`hvplot.hvPlot.contour`, and {meth}`hvplot.hvPlot.contourf`.\n",
+    ":::\n",
+    "\n",
+    "\n",
+    "```{eval-rst}\n",
+    ".. plotting-options-table:: Geographic Options\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2ca798a0-f299-414f-bc87-12c0ea203757",
+   "metadata": {},
+   "source": [
+    "(option-coastline)=\n",
+    "## `coastline`\n",
+    "\n",
+    "The `coastline` option overlays coastlines on the plot. You can set `coastline=True` to use the default scale (`'110m'`), or specify one of the available resolution strings: `'10m'`, `'50m'`, or `'110m'`. The dataset originates from [Natural Earth](https://www.naturalearthdata.com/features/).\n",
+    "\n",
+    "Enabling this option implies `geo=True` and requires [GeoViews](https://geoviews.org) to be installed."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "297ea059-4f44-42b5-9d49-9a1884ccef43",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import hvplot.pandas  # noqa\n",
+    "import hvsampledata\n",
+    "\n",
+    "df = hvsampledata.earthquakes(\"pandas\")\n",
+    "\n",
+    "plot_opts = dict(x='lon', y='lat', frame_width=250, alpha=0.5)\n",
+    "df.hvplot.points(coastline=True, title=\"Coastline=True\", **plot_opts) +\\\n",
+    "df.hvplot.points(coastline='50m', title='Coastline=50m', **plot_opts)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "47e112f9-fd34-4d58-8feb-b0611f3a049c",
+   "metadata": {},
+   "source": [
+    "(option-crs)=\n",
+    "## `crs`\n",
+    "\n",
+    "The `crs` option sets the [Coordinate Reference System](https://en.wikipedia.org/wiki/Spatial_reference_system) (CRS) of the data (the input/source projection). It accepts a variety of values, including:\n",
+    "\n",
+    "- {class}`cartopy:cartopy.crs.CRS` instance (e.g. {class}`cartopy:cartopy.crs.PlateCarree`) or class name (e.g. `'PlateCarree'`)\n",
+    "- [EPSG code](https://en.wikipedia.org/wiki/EPSG_Geodetic_Parameter_Dataset) string or integer (e.g. `'EPSG:4326'`, `4326`)\n",
+    "- {class}`pyproj:pyproj.crs.CRS` or {class}`pyproj:pyproj.Proj` instances\n",
+    "- PROJ.4 string\n",
+    "- [WKT](https://en.wikipedia.org/wiki/Well-known_text_representation_of_geometry) string\n",
+    "\n",
+    "If not provided, [PlateCarree](https://en.wikipedia.org/wiki/Equirectangular_projection) (lat/lon) is assumed when `geo=True`.\n",
+    "\n",
+    "Enabling this option implies `geo=True` and requires [GeoViews](https://geoviews.org) to be installed."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5ac96974-7f01-4bf7-822c-d3627dcac793",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import hvplot.pandas  # noqa\n",
+    "import hvsampledata\n",
+    "import cartopy.crs as ccrs\n",
+    "import pyproj\n",
+    "\n",
+    "df = hvsampledata.earthquakes(\"pandas\")\n",
+    "\n",
+    "plot_opts = dict(x='lon', y='lat', coastline=True, frame_width=250, alpha=0.5)\n",
+    "\n",
+    "(\n",
+    "    df.hvplot.points(crs=ccrs.PlateCarree(), title=\"cartopy PlateCarree\", **plot_opts) +\n",
+    "    df.hvplot.points(crs='PlateCarree', title=\"PlateCarree string\", **plot_opts) +\n",
+    "    df.hvplot.points(crs='EPSG:4326', title=\"EPSG:4326 string\", **plot_opts) +\n",
+    "    df.hvplot.points(crs=pyproj.CRS(4326), title=\"pyproj CRS 4326\", **plot_opts)\n",
+    ").cols(2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b4d4d9cf-fe86-484e-99e5-28a466eca40d",
+   "metadata": {},
+   "source": [
+    ":::{seealso}\n",
+    "The [`projection`](option-projection) option to set the output/target projection.\n",
+    ":::"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1f76fbab-3df1-4727-a85c-48fcdeeaa40b",
+   "metadata": {},
+   "source": [
+    "(option-features)=\n",
+    "## `features`\n",
+    "\n",
+    "The `features` option overlays additional geographic features such as land, ocean, rivers, and borders. These features originate from the [Natural Earth](https://www.naturalearthdata.com/features/) dataset.\n",
+    "\n",
+    "It accepts:\n",
+    "- A list of feature names\n",
+    "- A dictionary with feature names as keys and resolution strings as values\n",
+    "\n",
+    "Available features: `'borders'`, `'coastline'`, `'lakes'`, `'land'`, `'ocean'`, `'rivers'`, `'states'`.\n",
+    "Available scales: `'10m'`, `'50m'`, `'110m'`.\n",
+    "\n",
+    "`'land'` and `'ocean'` feature are underlaid, other features are overlaid.\n",
+    "\n",
+    ":::{warning}\n",
+    "This option requires a live internet connection to download Natural Earth datasets.\n",
+    ":::\n",
+    "\n",
+    "Enabling this option implies `geo=True` and requires [GeoViews](https://geoviews.org) to be installed."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d9fcb88b-8442-4864-8c7e-11ea6de636fc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import hvplot.pandas  # noqa\n",
+    "import hvsampledata\n",
+    "\n",
+    "df = hvsampledata.earthquakes(\"pandas\")\n",
+    "\n",
+    "plot_opts = dict(x='lon', y='lat', frame_width=250, alpha=0.5)\n",
+    "df.hvplot.points(\n",
+    "    features=['ocean', 'land'],\n",
+    "    title=\"Features: ocean + land\", **plot_opts\n",
+    ") +\\\n",
+    "df.hvplot.points(\n",
+    "    features={'ocean': '50m', 'land': '50m'},\n",
+    "    title=\"Features with resolution\", **plot_opts\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "579dd50c-4e14-41ef-bc75-4e910656a4b7",
+   "metadata": {},
+   "source": [
+    "(option-geo)=\n",
+    "## `geo`\n",
+    "\n",
+    "The `geo` option declares the plot is geographic and enables plotting with [GeoViews](https://geoviews.org), which is required to be installed.\n",
+    "\n",
+    "When `geo=True` and without further definition, the input data is assumed to be in lat/lon coordinates. When not set explicitly, the [`data_aspect`](option-data_aspect) option is set to `1`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8f10c599-9db7-4045-aefb-c743db296ac5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import hvplot.pandas  # noqa\n",
+    "import hvsampledata\n",
+    "\n",
+    "df = hvsampledata.earthquakes(\"pandas\")\n",
+    "\n",
+    "plot_opts = dict(x='lon', y='lat', frame_width=250, alpha=0.5)\n",
+    "plot = df.hvplot.points(title=\"geo=False\", **plot_opts)\n",
+    "plot_geo = df.hvplot.points(geo=True, title=\"geo=True\", **plot_opts)\n",
+    "(plot + plot_geo).opts(shared_axes=False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6c2575c8-73f5-4cd4-a4d0-93b2257806c4",
+   "metadata": {},
+   "source": [
+    "The object returned by the `df.hvplot.points()` call is a GeoViews `Points` element."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "10499099-cb32-449c-8dd5-f9ac8f4fa168",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "type(plot_geo)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f17a82c0-04ff-4c31-9361-bb9d97fc3a3c",
+   "metadata": {},
+   "source": [
+    "(option-global_extent)=\n",
+    "## `global_extent`\n",
+    "\n",
+    "The `global_extent` option expands the plot extent to span the full globe. This is useful when your data covers only part of the globe, but you still want to display the full world extent.\n",
+    "\n",
+    "Enabling this option implies `geo=True` and requires [GeoViews](https://geoviews.org) to be installed."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8f9d2f15-6623-49ee-ba52-2b2bf700137e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import hvplot.pandas  # noqa\n",
+    "import hvsampledata\n",
+    "\n",
+    "df = hvsampledata.earthquakes(\"pandas\")\n",
+    "\n",
+    "df.hvplot.points(\n",
+    "    x='lon',\n",
+    "    y='lat',\n",
+    "    frame_height=200,\n",
+    "    global_extent=True,\n",
+    "    coastline=True,\n",
+    "    title=\"Global Extent Enabled\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7a809094-4fd6-4260-8c93-7dceee7b7c3f",
+   "metadata": {},
+   "source": [
+    "(option-project)=\n",
+    "## `project`\n",
+    "\n",
+    "The `project` option projects the data to the output/target projection before applying operations enabled by the [`datashade`](option-datashade) or [`rasterize`](option-rasterize) options. This can greatly improve interactivity when one of these operations is enabled, avoiding to re-project the data when panning/zooming.\n",
+    "\n",
+    "Enabling this option implies `geo=True` and requires [GeoViews](https://geoviews.org) to be installed."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "85cb61a9-ebcb-4894-a0de-39bff4df26f9",
+   "metadata": {},
+   "source": [
+    "(option-projection)=\n",
+    "## `projection`\n",
+    "\n",
+    "The `projection` option sets the **display CRS** of the plot (the output/target projection).\n",
+    "\n",
+    "Accepts the same values as [`crs`](option-crs), including:\n",
+    "- {class}`cartopy:cartopy.crs.CRS` instance (e.g. {class}`cartopy:cartopy.crs.PlateCarree`) or class name (e.g. `'PlateCarree'`)\n",
+    "- [EPSG code](https://en.wikipedia.org/wiki/EPSG_Geodetic_Parameter_Dataset) string or integer (e.g. `'EPSG:4326'`, `4326`)\n",
+    "- {class}`pyproj:pyproj.crs.CRS` or {class}`pyproj:pyproj.Proj` instances\n",
+    "- PROJ.4 string\n",
+    "- [WKT](https://en.wikipedia.org/wiki/Well-known_text_representation_of_geometry) string\n",
+    "\n",
+    "If not specified, defaults to [PlateCarree](https://en.wikipedia.org/wiki/Equirectangular_projection), or to [Web Mercator](https://en.wikipedia.org/wiki/Web_Mercator_projection) when [`tiles=True`](option-tiles).\n",
+    "\n",
+    "Enabling this option implies `geo=True` and requires [GeoViews](https://geoviews.org) to be installed."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "91a107e2-5801-410f-9419-182cac0de6d1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import hvplot.pandas  # noqa\n",
+    "import hvsampledata\n",
+    "import cartopy.crs as ccrs\n",
+    "\n",
+    "df = hvsampledata.earthquakes(\"pandas\")\n",
+    "\n",
+    "plot_opts = dict(x='lon', y='lat', coastline=True, alpha=0.5)\n",
+    "layout = df.hvplot.points(\n",
+    "    frame_width=250,\n",
+    "    geo=True,\n",
+    "    global_extent=True,\n",
+    "    title='Default display CRS: PlateCarree',\n",
+    "    **plot_opts\n",
+    ") +\\\n",
+    "df.hvplot.points(\n",
+    "    frame_width=200,\n",
+    "    projection=ccrs.Orthographic(125, 0),\n",
+    "    global_extent=True,\n",
+    "    title='Orthographic Projection',\n",
+    "    **plot_opts\n",
+    ") +\\\n",
+    "df.hvplot.points(\n",
+    "    frame_height=250,\n",
+    "    projection='EPSG:32651',\n",
+    "    title='UTM 51N',\n",
+    "    **plot_opts\n",
+    ")\n",
+    "layout.opts(shared_axes=False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9428dcff-3704-4c21-ae79-e8d88ef33d6c",
+   "metadata": {},
+   "source": [
+    ":::{seealso}\n",
+    "The [`crs`](option-crs) option to define the source CRS.\n",
+    ":::"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bdc6fcbc-eca7-4e06-bcfc-9360f7409477",
+   "metadata": {},
+   "source": [
+    "(option-tiles)=\n",
+    "## `tiles`\n",
+    "\n",
+    ":::{tip}\n",
+    "This option can be used without having to install GeoViews to plot data in lat/lon or Web Mercator coordinates.\n",
+    ":::\n",
+    "\n",
+    "The `tiles` option adds a [tiled web map](https://en.wikipedia.org/wiki/Tiled_web_map), or tile map, as a basemap layer. It accepts:\n",
+    "\n",
+    "- `True`: defaults to the [OpenStreetMap](https://en.wikipedia.org/wiki/OpenStreetMap) layer\n",
+    "- `xyzservices.TileProvider` instance (e.g. `xyz.Esri.WorldPhysical`): the [`xyzservices`](https://xyzservices.readthedocs.io) library gives easy access to [hundreds of tiled web maps](https://xyzservices.readthedocs.io/en/stable/gallery.html).\n",
+    "- HoloViews/GeoViews tile name strings (e.g. `'EsriTerrain'`): see the list below of tiles available as a string\n",
+    "- [`holoviews.Tiles`](https://holoviews.org/reference/elements/bokeh/Tiles.html) class or instance (e.g. `hv.element.tiles.CartoDark`)\n",
+    "- [`geoviews.WMTS`](https://geoviews.org/user_guide/Working_with_Bokeh.html#wmts-tile-sources) class or instance (e.g. `gv.tile_sources.CartoDark`)\n",
+    "\n",
+    ":::{info}\n",
+    "This option requires a live internet connection to download the web tiles on the fly (zooming/panning).\n",
+    ":::\n",
+    "\n",
+    "\n",
+    "When `tiles` is enabled, the target [`projection`](option-projection) is internally set to Web Mercator (`EPSG:3857`) as this is the only projection supported by tiled web maps.\n",
+    "\n",
+    "hvPlot can display the data overlaid on a tile map without having to set `geo=True` and rely on GeoViews:\n",
+    "- If the data is already in the Web Mercator CRS (easting (X) /northing (Y) metric units), as no projection is needed.\n",
+    "- If the coordinate values fall within lat/lon bounds, the data is auto-projected (except for lazy data objects) to Web Mercator. This behavior can be disabled by setting the [`projection`](option-projection) to `False`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "559f1409-3475-4871-b138-fce916c9d470",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import geoviews as gv\n",
+    "import holoviews as hv\n",
+    "\n",
+    "print(\"HoloViews tiles:\", *hv.element.tiles.tile_sources, sep=\" \", end=\"\\n\\n\")\n",
+    "print(\"GeoViews tiles:\", *gv.tile_sources.tile_sources, sep=\" \")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1bfe5698-c665-42fd-af05-082f04e8fbbb",
+   "metadata": {},
+   "source": [
+    "First we'll set `geo=True` together with `tiles` to enable plotting with GeoViews."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7b78d812-f8ce-4ac5-ab7a-16e8442e1648",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import geoviews as gv\n",
+    "import hvplot.pandas  # noqa\n",
+    "import hvsampledata\n",
+    "import xyzservices.providers as xyz\n",
+    "\n",
+    "df = hvsampledata.earthquakes(\"pandas\")\n",
+    "\n",
+    "plot_opts = dict(geo=True, x='lon', y='lat', alpha=0.2, c='brown', frame_width=250)\n",
+    "layout = (\n",
+    "    df.hvplot.points(tiles=True, title=\"Default to OpenStreetMap\", **plot_opts) +\n",
+    "    df.hvplot.points(tiles=xyz.Esri.WorldPhysical, title=\"xyz.Esri.WorldPhysical\", **plot_opts) +\n",
+    "    df.hvplot.points(tiles='EsriTerrain', title=\"EsriTerrain string\", **plot_opts) +\n",
+    "    df.hvplot.points(tiles=gv.tile_sources.EsriImagery, title=\"GeoViews WMTS\", **plot_opts)\n",
+    ")\n",
+    "layout.cols(2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b5e3da05-760b-4198-bd2f-8ea0ca44c9fa",
+   "metadata": {},
+   "source": [
+    "We now create the same plots but without `geo=True`. The dataset contains lat/lon coordinates, that hvPlot will automatically project to Web Mercator. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ccb5ed4f-d0c7-4889-8ef2-449395124f93",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import holoviews as hv\n",
+    "import hvplot.pandas  # noqa\n",
+    "import hvsampledata\n",
+    "import xyzservices.providers as xyz\n",
+    "\n",
+    "df = hvsampledata.earthquakes(\"pandas\")\n",
+    "\n",
+    "plot_opts = dict(x='lon', y='lat', alpha=0.2, c='brown', frame_width=250)\n",
+    "layout = (\n",
+    "    df.hvplot.points(tiles=True, title=\"Default to OpenStreetMap\", **plot_opts) +\n",
+    "    df.hvplot.points(tiles=xyz.Esri.WorldPhysical, title=\"xyz.Esri.WorldPhysical\", **plot_opts) +\n",
+    "    df.hvplot.points(tiles='EsriTerrain', title=\"EsriTerrain string\", **plot_opts) +\n",
+    "    df.hvplot.points(tiles=hv.element.tiles.EsriImagery, title=\"HoloViews Tiles\", **plot_opts)\n",
+    ")\n",
+    "layout.cols(2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d0db0527-bb56-4e99-8864-22819b6367c3",
+   "metadata": {},
+   "source": [
+    ":::{tip}\n",
+    "When dealing with large datasets meant to be overlaid on a tile map, it may be appropriate to project them to Web Mercator beforehand. HoloViews provides a simple utility {function}`holoviews:holoviews.util.transform.lon_lat_to_easting_northing` to convert lat/lon coordinates to Web Mercator northing/easting metric values. See the example below.\n",
+    ":::"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "00f95f04-8f3a-458c-8440-8309d20259a6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from holoviews.util.transform import lon_lat_to_easting_northing\n",
+    "import hvsampledata\n",
+    "\n",
+    "df = hvsampledata.earthquakes(\"pandas\")\n",
+    "\n",
+    "df['x'], df['y'] = lon_lat_to_easting_northing(df['lon'], df['lat'])\n",
+    "print(df[['lat', 'lon', 'x', 'y']].head(2))\n",
+    "df.hvplot.points(x='x', y='y', alpha=0.2, c='brown', frame_width=250, tiles=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c9c94396-02e6-4a3c-92dc-ca28e359d095",
+   "metadata": {},
+   "source": [
+    "[GeoPandas](https://geopandas.org/) `GeoDataFrame` objects can also be overlaid on a tile map without GeoViews, like in the example below, where a dataset in the *UTM 51N* CRS is plotted (hvPlot internally converting the data to Web Mercator)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c7286032-5d00-41a5-9ccb-2b183510db75",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import geopandas as gpd\n",
+    "import hvplot.pandas  # noqa\n",
+    "import hvsampledata\n",
+    "\n",
+    "df = hvsampledata.earthquakes(\"pandas\")\n",
+    "gdf = gpd.GeoDataFrame(\n",
+    "    df,\n",
+    "    geometry=gpd.points_from_xy(df['lon'], df['lat']),\n",
+    "    crs=\"EPSG:4326\"\n",
+    ").to_crs(\"EPSG:32651\")  # UTM 51N\n",
+    "\n",
+    "gdf.hvplot.points(alpha=0.2, c='brown', frame_width=250, tiles=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9208b284-fc6f-49be-8a79-13d00a8d4637",
+   "metadata": {},
+   "source": [
+    "(option-tiles_opts)=\n",
+    "## `tiles_opts`\n",
+    "\n",
+    "The `tiles_opts` option is a dictionary of style properties applied to the tiles layer. Requires [`tiles`](option-tiles) to be set.\n",
+    "\n",
+    "Common keys include: `alpha`, `width`, `height`, etc."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ffa119f3-a144-46bf-86c0-3aa7c88d403a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import hvplot.pandas  # noqa\n",
+    "import hvsampledata\n",
+    "\n",
+    "df = hvsampledata.earthquakes(\"pandas\")\n",
+    "\n",
+    "df.hvplot.points(\n",
+    "    x='lon',\n",
+    "    y='lat',\n",
+    "    frame_width=300,\n",
+    "    c='mag',\n",
+    "    tiles=True,\n",
+    "    tiles_opts={'alpha': 0.3},\n",
+    "    title=\"Tile Layer with Alpha\"\n",
+    ")"
+   ]
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "name": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/doc/ref/plotting_options/geographic.ipynb
+++ b/doc/ref/plotting_options/geographic.ipynb
@@ -8,11 +8,10 @@
     "# Geographic Options\n",
     "\n",
     ":::{note}\n",
-    "Most of the options below require the [GeoViews](https://geoviews.org) library to be installed. One notable exception is the [`tiles`](option-tiles) option, which, if the data is in *lat/lon* coordinates (e.g. GPS data) or already in the *Web Mercator* coordinate reference system, allows to overlay the data on a web tiled map without requiring GeoViews.\n",
+    "Most of the options below require the [GeoViews](https://geoviews.org) library to be installed. One notable exception is the [`tiles`](option-tiles) option, which, if the data is in *lat/lon* coordinates (e.g. GPS data) or already in the *Web Mercator* coordinate reference system, allows you to overlay the data on a web tiled map without requiring GeoViews.\n",
     ":::\n",
     "\n",
-    ":::{note}\n",
-    "Supported plot types:\n",
+    ":::{admonition} Supported Plot Types\n",
     "\n",
     "Only certain plot types support geographic coordinates, currently including: {meth}`hvplot.hvPlot.points`, {meth}`hvplot.hvPlot.paths`, {meth}`hvplot.hvPlot.polygons`, {meth}`hvplot.hvPlot.image`, {meth}`hvplot.hvPlot.quadmesh`, {meth}`hvplot.hvPlot.contour`, and {meth}`hvplot.hvPlot.contourf`.\n",
     ":::\n",
@@ -91,10 +90,10 @@
     "plot_opts = dict(x='lon', y='lat', coastline=True, frame_width=250, alpha=0.5)\n",
     "\n",
     "(\n",
-    "    df.hvplot.points(crs=ccrs.PlateCarree(), title=\"cartopy PlateCarree\", **plot_opts) +\n",
+    "    df.hvplot.points(crs=ccrs.PlateCarree(), title=\"cartopy.PlateCarree instance\", **plot_opts) +\n",
     "    df.hvplot.points(crs='PlateCarree', title=\"PlateCarree string\", **plot_opts) +\n",
     "    df.hvplot.points(crs='EPSG:4326', title=\"EPSG:4326 string\", **plot_opts) +\n",
-    "    df.hvplot.points(crs=pyproj.CRS(4326), title=\"pyproj CRS 4326\", **plot_opts)\n",
+    "    df.hvplot.points(crs=pyproj.CRS(4326), title=\"pyproj.CRS 4326 instance\", **plot_opts)\n",
     ").cols(2)"
    ]
   },
@@ -125,9 +124,9 @@
     "Available features: `'borders'`, `'coastline'`, `'lakes'`, `'land'`, `'ocean'`, `'rivers'`, `'states'`.\n",
     "Available scales: `'10m'`, `'50m'`, `'110m'`.\n",
     "\n",
-    "`'land'` and `'ocean'` feature are underlaid, other features are overlaid.\n",
+    "`'land'` and `'ocean'` features are underlaid, other features are overlaid.\n",
     "\n",
-    ":::{warning}\n",
+    ":::{important}\n",
     "This option requires a live internet connection to download Natural Earth datasets.\n",
     ":::\n",
     "\n",
@@ -165,7 +164,7 @@
     "(option-geo)=\n",
     "## `geo`\n",
     "\n",
-    "The `geo` option declares the plot is geographic and enables plotting with [GeoViews](https://geoviews.org), which is required to be installed.\n",
+    "The `geo` option declares that the plot is geographic and enables plotting with [GeoViews](https://geoviews.org), which is required to be installed.\n",
     "\n",
     "When `geo=True` and without further definition, the input data is assumed to be in lat/lon coordinates. When not set explicitly, the [`data_aspect`](option-data_aspect) option is set to `1`."
    ]
@@ -338,12 +337,12 @@
     "The `tiles` option adds a [tiled web map](https://en.wikipedia.org/wiki/Tiled_web_map), or tile map, as a basemap layer. It accepts:\n",
     "\n",
     "- `True`: defaults to the [OpenStreetMap](https://en.wikipedia.org/wiki/OpenStreetMap) layer\n",
-    "- `xyzservices.TileProvider` instance (e.g. `xyz.Esri.WorldPhysical`): the [`xyzservices`](https://xyzservices.readthedocs.io) library gives easy access to [hundreds of tiled web maps](https://xyzservices.readthedocs.io/en/stable/gallery.html).\n",
-    "- HoloViews/GeoViews tile name strings (e.g. `'EsriTerrain'`): see the list below of tiles available as a string\n",
+    "- `xyzservices.TileProvider` instance (e.g. `xyz.Esri.WorldPhysical`). The [`xyzservices`](https://xyzservices.readthedocs.io) library gives easy access to [hundreds of tiled web maps](https://xyzservices.readthedocs.io/en/stable/gallery.html).\n",
+    "- HoloViews/GeoViews tile name strings (e.g. `'EsriTerrain'`). See the table below of tiles available as a string\n",
     "- [`holoviews.Tiles`](https://holoviews.org/reference/elements/bokeh/Tiles.html) class or instance (e.g. `hv.element.tiles.CartoDark`)\n",
     "- [`geoviews.WMTS`](https://geoviews.org/user_guide/Working_with_Bokeh.html#wmts-tile-sources) class or instance (e.g. `gv.tile_sources.CartoDark`)\n",
     "\n",
-    ":::{info}\n",
+    ":::{important}\n",
     "This option requires a live internet connection to download the web tiles on the fly (zooming/panning).\n",
     ":::\n",
     "\n",
@@ -356,17 +355,19 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "559f1409-3475-4871-b138-fce916c9d470",
+   "cell_type": "markdown",
+   "id": "f98d5559-8a77-4873-b765-d2070c2c21f9",
    "metadata": {},
-   "outputs": [],
    "source": [
-    "import geoviews as gv\n",
-    "import holoviews as hv\n",
+    ":::{table} **Available Tiles**\n",
+    ":widths: auto\n",
+    ":align: center\n",
     "\n",
-    "print(\"HoloViews tiles:\", *hv.element.tiles.tile_sources, sep=\" \", end=\"\\n\\n\")\n",
-    "print(\"GeoViews tiles:\", *gv.tile_sources.tile_sources, sep=\" \")"
+    "| Library   | Tiles |                                                                      \n",
+    "|-----------|-------|\n",
+    "| HoloViews | CartoDark, CartoLight, EsriImagery, EsriNatGeo, EsriUSATopo, EsriTerrain, EsriStreet, EsriReference, OSM, OpenTopoMap |\n",
+    "| GeoViews  | CartoDark, CartoEco, CartoLight, CartoMidnight, EsriImagery, EsriNatGeo, EsriUSATopo, EsriTerrain, EsriReference, EsriOceanBase, EsriOceanReference, EsriWorldPhysical, EsriWorldShadedRelief, EsriWorldTopo, EsriWorldDarkGrayBase, EsriWorldDarkGrayReference, EsriWorldLightGrayBase, EsriWorldLightGrayReference, EsriWorldHillshadeDark, EsriWorldHillshade, EsriAntarcticImagery, EsriArcticImagery, EsriArcticOceanBase, EsriArcticOceanReference, EsriWorldBoundariesAndPlaces, EsriWorldBoundariesAndPlacesAlternate, EsriWorldTransportation, EsriDelormeWorldBaseMap, EsriWorldNavigationCharts, EsriWorldStreetMap, OSM, OpenTopoMap |\n",
+    ":::"
    ]
   },
   {
@@ -425,7 +426,7 @@
     "\n",
     "plot_opts = dict(x='lon', y='lat', alpha=0.2, c='brown', frame_width=250)\n",
     "layout = (\n",
-    "    df.hvplot.points(tiles=True, title=\"Default to OpenStreetMap\", **plot_opts) +\n",
+    "    df.hvplot.points(tiles=True, title=\"Default: OpenStreetMap\", **plot_opts) +\n",
     "    df.hvplot.points(tiles=xyz.Esri.WorldPhysical, title=\"xyz.Esri.WorldPhysical\", **plot_opts) +\n",
     "    df.hvplot.points(tiles='EsriTerrain', title=\"EsriTerrain string\", **plot_opts) +\n",
     "    df.hvplot.points(tiles=hv.element.tiles.EsriImagery, title=\"HoloViews Tiles\", **plot_opts)\n",
@@ -439,7 +440,7 @@
    "metadata": {},
    "source": [
     ":::{tip}\n",
-    "When dealing with large datasets meant to be overlaid on a tile map, it may be appropriate to project them to Web Mercator beforehand. HoloViews provides a simple utility {function}`holoviews:holoviews.util.transform.lon_lat_to_easting_northing` to convert lat/lon coordinates to Web Mercator northing/easting metric values. See the example below.\n",
+    "When dealing with large datasets meant to be overlaid on a tile map, it may be appropriate to project them to Web Mercator beforehand. HoloViews provides a simple utility [function](inv:holoviews#holoviews.util.transform.lon_lat_to_easting_northing) to convert lat/lon coordinates to Web Mercator northing/easting metric values. See the example below.\n",
     ":::"
    ]
   },
@@ -465,7 +466,7 @@
    "id": "c9c94396-02e6-4a3c-92dc-ca28e359d095",
    "metadata": {},
    "source": [
-    "[GeoPandas](https://geopandas.org/) `GeoDataFrame` objects can also be overlaid on a tile map without GeoViews, like in the example below, where a dataset in the *UTM 51N* CRS is plotted (hvPlot internally converting the data to Web Mercator)."
+    "[GeoPandas GeoDataFrame](https://geopandas.org/en/stable/docs/reference/geodataframe.html) objects can also be overlaid on a tile map without GeoViews, like in the example below, where a dataset in the *UTM 51N* CRS is plotted (hvPlot internally converting the data to Web Mercator)."
    ]
   },
   {

--- a/doc/ref/plotting_options/geographic.ipynb
+++ b/doc/ref/plotting_options/geographic.ipynb
@@ -338,7 +338,7 @@
     "\n",
     "- `True`: defaults to the [OpenStreetMap](https://en.wikipedia.org/wiki/OpenStreetMap) layer\n",
     "- `xyzservices.TileProvider` instance (e.g. `xyz.Esri.WorldPhysical`). The [`xyzservices`](https://xyzservices.readthedocs.io) library gives easy access to [hundreds of tiled web maps](https://xyzservices.readthedocs.io/en/stable/gallery.html).\n",
-    "- HoloViews/GeoViews tile name strings (e.g. `'EsriTerrain'`). See the table below of tiles available as a string\n",
+    "- HoloViews/GeoViews tile name strings (e.g. `'EsriTerrain'`). See the list below of tiles available as a string\n",
     "- [`holoviews.Tiles`](https://holoviews.org/reference/elements/bokeh/Tiles.html) class or instance (e.g. `hv.element.tiles.CartoDark`)\n",
     "- [`geoviews.WMTS`](https://geoviews.org/user_guide/Working_with_Bokeh.html#wmts-tile-sources) class or instance (e.g. `gv.tile_sources.CartoDark`)\n",
     "\n",
@@ -355,19 +355,17 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "id": "f98d5559-8a77-4873-b765-d2070c2c21f9",
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d3ab1697-e73b-40d1-b1ce-3da91cf191e4",
    "metadata": {},
+   "outputs": [],
    "source": [
-    ":::{table} **Available Tiles**\n",
-    ":widths: auto\n",
-    ":align: center\n",
+    "import geoviews as gv\n",
+    "import holoviews as hv\n",
     "\n",
-    "| Library   | Tiles |                                                                      \n",
-    "|-----------|-------|\n",
-    "| HoloViews | CartoDark, CartoLight, EsriImagery, EsriNatGeo, EsriUSATopo, EsriTerrain, EsriStreet, EsriReference, OSM, OpenTopoMap |\n",
-    "| GeoViews  | CartoDark, CartoEco, CartoLight, CartoMidnight, EsriImagery, EsriNatGeo, EsriUSATopo, EsriTerrain, EsriReference, EsriOceanBase, EsriOceanReference, EsriWorldPhysical, EsriWorldShadedRelief, EsriWorldTopo, EsriWorldDarkGrayBase, EsriWorldDarkGrayReference, EsriWorldLightGrayBase, EsriWorldLightGrayReference, EsriWorldHillshadeDark, EsriWorldHillshade, EsriAntarcticImagery, EsriArcticImagery, EsriArcticOceanBase, EsriArcticOceanReference, EsriWorldBoundariesAndPlaces, EsriWorldBoundariesAndPlacesAlternate, EsriWorldTransportation, EsriDelormeWorldBaseMap, EsriWorldNavigationCharts, EsriWorldStreetMap, OSM, OpenTopoMap |\n",
-    ":::"
+    "print(\"HoloViews tiles:\", *hv.element.tiles.tile_sources, sep=\" \", end=\"\\n\\n\")\n",
+    "print(\"GeoViews tiles:\", *gv.tile_sources.tile_sources, sep=\" \")"
    ]
   },
   {

--- a/doc/ref/plotting_options/index.md
+++ b/doc/ref/plotting_options/index.md
@@ -114,4 +114,7 @@ Styling Options <styling>
 Interactivity Options <interactivity>
 Grid And Legend Options <grid_legend>
 Size And Layout Options <size_layout>
+Resampling Options <resampling>
+Geographic Options <geographic>
+Streaming Options <streaming>
 ```

--- a/doc/ref/plotting_options/index.md
+++ b/doc/ref/plotting_options/index.md
@@ -6,7 +6,7 @@ hvPlot's plotting API exposes three main types of options:
 
 - **Plot kind specific**: options specific to each plot kind; for example, `marker` is not a generic option but is specific to {meth}`hvplot.hvPlot.scatter`.
 - **Generic**: options that can be passed to most of the plotting methods/kinds; these are the options displayed in the tables below, such as `width` or `title`.
-- **Plotting backend and method/kind specific styling options**: in addition to the generic [Styling Options](plotting-options-styling), hvPlot exposes styling options that are specific to a particular plotting backend and plot kind. With these options, it is possible to customize each component in detail, exposing all the options a plotting backend exposes in HoloViews (they are applied to the specific HoloViews Element(s) returned by a plotting call, for example {class}`holoviews:holoviews.element.Scatter` for {meth}`hvplot.hvPlot.scatter`). These usually include options to color the line and fill color, alpha and style. These options  can be found on the reference page of each plotting method (e.g. {meth}`hvplot.hvPlot.scatter`).
+- **Plotting backend and method/kind specific styling options**: in addition to the generic [Styling Options](plotting-options-styling), hvPlot exposes styling options that are specific to a particular plotting backend and plot kind. With these options, it is possible to customize each component in detail, exposing all the options a plotting backend exposes in HoloViews (they are applied to the specific HoloViews Element(s) returned by a plotting call, for example {class}`holoviews:holoviews.element.Scatter` for {meth}`hvplot.hvPlot.scatter`). These usually include options to color the line and fill color, alpha and style. These options can be found on the reference page of each plotting method (e.g. {meth}`hvplot.hvPlot.scatter`).
 
 The {func}`hvplot.help` function can be used to interactively display these options:
 
@@ -55,6 +55,7 @@ Options for setting the grid or legend of plots as well as colorbar options:
 See [this page](./grid_legend) for more information on these options.
 
 (plotting-options-styling)=
+
 ## Styling Options
 
 Visual styling options to adjust colors, fonts, and other aesthetic elements of the plot.
@@ -67,6 +68,7 @@ reference page of each plotting method (e.g. {meth}`hvplot.hvPlot.scatter`) or b
 ```{eval-rst}
 .. plotting-options-table:: Styling Options
 ```
+
 See [this page](./styling) for more information on these options.
 
 ## Interactivity Options
@@ -87,6 +89,8 @@ Performance related options for handling large datasets, including downsampling,
 .. plotting-options-table:: Resampling Options
 ```
 
+See [this page](./resampling) for more information on these options.
+
 ## Geographic Options
 
 Options for geographic plots, including map projections, tile overlays, and geographic features like coastlines and borders:
@@ -95,6 +99,8 @@ Options for geographic plots, including map projections, tile overlays, and geog
 .. plotting-options-table:: Geographic Options
 ```
 
+See [this page](./geographic) for more information on these options.
+
 ## Streaming Options
 
 Options for handling live data streams:
@@ -102,6 +108,8 @@ Options for handling live data streams:
 ```{eval-rst}
 .. plotting-options-table:: Streaming Options
 ```
+
+See [this page](./streaming) for more information on these options.
 
 ```{toctree}
 :titlesonly:

--- a/doc/ref/plotting_options/resampling.ipynb
+++ b/doc/ref/plotting_options/resampling.ipynb
@@ -6,16 +6,12 @@
    "source": [
     "# Resampling Options\n",
     "\n",
-    ":::{note}\n",
-    "Most of the options below require the [Datashader](https://datashader.org) library to be installed. The [`downsample`](option-downsample) option should preferably used with the [tsdownsample](https://github.com/predict-idlab/tsdownsample) library installed.\n",
-    ":::\n",
+    ":::{admonition} Notes\n",
+    "1. Most of the options below require the [Datashader](https://datashader.org) library to be installed. The [`downsample`](option-downsample) option should preferably be used with the [tsdownsample](https://github.com/predict-idlab/tsdownsample) library installed.\n",
     "\n",
-    ":::{seealso}\n",
-    "To dive deeper into the Datashader-related option, users are encouraged to read HoloViews' [Large Data user guide](https://holoviews.org/user_guide/Large_Data.html) and Dashader's [website](https://datashader.org), in particular the [Plotting pitfalls user guide](https://datashader.org/user_guide/Plotting_Pitfalls.html).\n",
-    ":::\n",
+    "2. To dive deeper into the Datashader-related option, users are encouraged to read HoloViews' [Large Data user guide](https://holoviews.org/user_guide/Large_Data.html) and the [Datashader website](https://datashader.org), in particular the [Plotting pitfalls user guide](https://datashader.org/user_guide/Plotting_Pitfalls.html).\n",
     "\n",
-    ":::{warning}\n",
-    "Most of the examples below require to be run in a Jupyter notebook to experience their full interactivity (dynamic resampling after zoomin/panning).\n",
+    "3. Most of the examples below require to be run in a Jupyter notebook to experience their full interactivity (dynamic resampling after zoomin/panning).\n",
     ":::"
    ]
   },
@@ -23,7 +19,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The `hvsampledata.synthetic_clusters` dataset is many examples below."
+    "The `hvsampledata.synthetic_clusters` dataset is in many examples below."
    ]
   },
   {
@@ -200,10 +196,10 @@
     "- Rendering large datasets in the browser that would otherwise crash it as it can easily handle billions of data points.\n",
     "- Dynamically exploring large datasets and discovering patterns, which would otherwise be difficult to find as plotting large data come with [many pitfalls](https://datashader.org/user_guide/Plotting_Pitfalls.html) such as overplotting.\n",
     "\n",
-    "This approach can turn even the largest datasets into an image that captures patterns such as density or value distribution, making it for example ideal for high-volume scatter plots. When `datashade=True`, hvPlot returns a [`DynamicMap`](inv:holoviews#reference/containers/bokeh/DynamicMap) containing an [`RGB`](inv:holoviews#reference/elements/bokeh/RGB) instead of individual glyphs.\n",
+    "This approach can turn even the largest datasets into an image that captures patterns such as density or value distribution, making it ideal for high-volume scatter plots. When `datashade=True`, hvPlot returns a [`DynamicMap`](inv:holoviews#reference/containers/bokeh/DynamicMap) containing an [`RGB`](inv:holoviews#reference/elements/bokeh/RGB) instead of individual glyphs.\n",
     "\n",
     ":::{tip}\n",
-    "Since `datashade=True` produces an RGB image, the underlying data (e.g. the aggregated values per pixel) is not directly available to the plot. Enabling the `'hover'` [tool](option-tools) (disabled by default when `datashade=True`) would only show the RGB value per pixel, and no meaningful colorbar can be attached to the plot. To let the frontend apply colormapping instead of the backend, and as a consequence expose the underlying data, we recommend setting [`rasterize=True`](option-rasterize) instead of `datashade=True`.\n",
+    "Since `datashade=True` produces an RGB image, the underlying data (e.g. the aggregated values per pixel) is not directly available to the plot. Enabling the `'hover'` [tool](options-hover) (disabled by default when `datashade=True`) would only show the RGB value per pixel, and no meaningful colorbar can be attached to the plot. To let the frontend apply colormapping instead of the backend, and as a consequence expose the underlying data, we recommend setting [`rasterize=True`](option-rasterize) instead of `datashade=True`.\n",
     ":::\n",
     "\n",
     "The [`cnorm`](option-cnorm) option defaults to `'eq_hist'` when `datashade=True`."
@@ -240,7 +236,7 @@
     "(option-downsample)=\n",
     "## `downsample`\n",
     "\n",
-    "The `downsample` option can be used to dynamically reduce the number of plotted points by summarizing data before rendering, making it for example ideal for large timeseries datasets. This results in lighter plots and faster rendering.\n",
+    "The `downsample` option can be used to dynamically reduce the number of plotted points by summarizing data before rendering, making it ideal for large timeseries datasets. This results in lighter plots and faster rendering.\n",
     "\n",
     "Valid values include (most require the [`tsdownsample`](https://github.com/predict-idlab/tsdownsample) library to be installed):\n",
     "\n",
@@ -357,7 +353,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    ":::{tip}\n",
+    ":::{note}\n",
     "Larger values make sparse data more prominent but can also distort the visual scale if overused.\n",
     ":::"
    ]
@@ -400,9 +396,9 @@
     "(option-precompute)=\n",
     "## `precompute`\n",
     "\n",
-    "Operations that involve rasterization ([`rasterize`](option-rasterize) and [`datashade`](option-datashade)) can be computationally expensive as they operate on the full dataset (unlike e.g. [`dysnpread`](option-dyspread)). `precompute` can be set to `True` to get faster performance in interactive usage by caching the last set of data used in plotting (*after* any transformations needed) and reusing it when it is requested again. This is particularly useful when your data is not in one of the supported data formats already and needs to be converted. `precompute` is `False` by default, because it requires using memory to store the cached data, but if you have enough memory, you can enable it so that repeated interactions (such as zooming and panning) will be much faster than the first one. Learn more about this option in the [HoloViews large data user guide](https://holoviews.org/user_guide/Large_Data.html#cache-initial-processing-with-precompute-true).\n",
+    "Operations that involve rasterization ([`rasterize`](option-rasterize) and [`datashade`](option-datashade)) can be computationally expensive as they operate on the full dataset (unlike e.g. [`dynspread`](option-dynspread)). `precompute` can be set to `True` to get faster performance in interactive usage by caching the last set of data used in plotting (*after* any transformations needed) and reusing it when it is requested again. This is particularly useful when your data is not in one of the supported data formats already and needs to be converted. `precompute` is `False` by default, because it requires using memory to store the cached data, but if you have enough memory, you can enable it so that repeated interactions (such as zooming and panning) will be much faster than the first one. Learn more about this option in the [HoloViews large data user guide](https://holoviews.org/user_guide/Large_Data.html#cache-initial-processing-with-precompute-true).\n",
     "\n",
-    ":::{note}\n",
+    ":::{tip}\n",
     "In practice, most Datashader-plots don't need to do extensive precomputing, but enabling it for {meth}`hvplot.hvPlot.polygons` and {meth}`hvplot.hvPlot.quadmesh` plots can greatly speed up interactive usage.\n",
     ":::"
    ]

--- a/doc/ref/plotting_options/resampling.ipynb
+++ b/doc/ref/plotting_options/resampling.ipynb
@@ -1,0 +1,552 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Resampling Options\n",
+    "\n",
+    ":::{note}\n",
+    "Most of the options below require the [Datashader](https://datashader.org) library to be installed. The [`downsample`](option-downsample) option should preferably used with the [tsdownsample](https://github.com/predict-idlab/tsdownsample) library installed.\n",
+    ":::\n",
+    "\n",
+    ":::{seealso}\n",
+    "To dive deeper into the Datashader-related option, users are encouraged to read HoloViews' [Large Data user guide](https://holoviews.org/user_guide/Large_Data.html) and Dashader's [website](https://datashader.org), in particular the [Plotting pitfalls user guide](https://datashader.org/user_guide/Plotting_Pitfalls.html).\n",
+    ":::\n",
+    "\n",
+    ":::{warning}\n",
+    "Most of the examples below require to be run in a Jupyter notebook to experience their full interactivity (dynamic resampling after zoomin/panning).\n",
+    ":::"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The `hvsampledata.synthetic_clusters` dataset is many examples below."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import hvsampledata\n",
+    "\n",
+    "df = hvsampledata.synthetic_clusters(\"pandas\")\n",
+    "print(f\"This dataset contains {len(df)} rows.\")\n",
+    "print(\"Sample from each of the 5 clusters\")\n",
+    "df.iloc[[int(i *len(df)) / 5 for i in range(5)]]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "```{eval-rst}\n",
+    ".. plotting-options-table:: Resampling Options\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "(option-aggregator)=\n",
+    "## `aggregator`\n",
+    "\n",
+    "The `aggregator` option determines how data is reduced when applying [`datashade=True`](option-datashade) or [`rasterize=True`](option-rasterize). Precisely, aggregators dynamically compute a single value per pixel when converting many raw data points into a rasterized image. By default, a simple `count` aggregator is applied, which creates a plot that displays how many data points are contained within each pixel.\n",
+    "\n",
+    "This can be particularly useful for large datasets where plotting every point is impractical. Choosing the right aggregator helps highlight the relevant aspects of the data — whether you want to count point density, show average values, or observe minimums and maximums across regions.\n",
+    "\n",
+    "Two main types of aggregators are available:\n",
+    "- Mathematical combination of data such as the `count` of data points per pixel or the `mean` of a dimension of the supplied dataset, including: `'any'`, `'count'`, `'mode'`, `'mean'`, `'sum'`, `'var'`, `'std'`.\n",
+    "- Selection of data from a dimension of the supplied dataset, or the index of the corresponding row in the dataset, including: `'first'`, `'last'`, `'min'`, `'max'`.\n",
+    "\n",
+    "`aggregator` accepts either:\n",
+    "- A [Datashader reduction object](https://datashader.org/api.html#reductions), such as `ds.count()` or `ds.mean('val')`.\n",
+    "- A string (e.g. `'mean'`, `'count'`, `'min'`, `'max'`, etc.), in which case the aggregated dimension can be defined by setting the [`color`](option-color) option (if not, the first non-coordinate variable found is used).\n",
+    "\n",
+    "The `'count_cat'` or `'by'` aggregators can be used for categorical cata. `ds.by(<column>, <reduction>)` allows to define the per-category reduction function (default is `count`). Alternatively, setting the [`by`](option-by) option to a categorical column is equivalent to setting `aggregator=ds.by(<cat_column>)`.\n",
+    "\n",
+    "Two additional aggregators are available:\n",
+    "- `ds.summary(...)` can be used to compute multiple aggregates simultaneously, by defining a sequence of key/value pairs representing the aggregate labels and reductions. For example, setting `aggregator=ds.summary(min_s=ds.min('s'), max_s=ds.max('s'))` will make both the `min_s` and `max_s` aggregated values available in the hover tooltip.\n",
+    "- `ds.where(<selector_reduction>, lookup_column)` can be used to extract the values of another column based on a selector refuction (e.g. `'first'`, `'min'`). For example, setting `aggregator=ds.where(ds.min('s'), 'val')` will display in each pixel the value of the variable `'val'` where the variable `'s'` is minimum.\n",
+    "\n",
+    "Let's start with the simple case, setting aggregator with a plain string and with a datashader reduction object."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import hvplot.pandas  # noqa\n",
+    "import hvsampledata\n",
+    "import datashader as ds\n",
+    "\n",
+    "df = hvsampledata.synthetic_clusters(\"pandas\")\n",
+    "\n",
+    "plot_opts = dict(x='x', y='y', data_aspect=1, frame_height=250)\n",
+    "df.hvplot.points(\n",
+    "    rasterize=True, aggregator='var', color='s',\n",
+    "    clabel='var(s)', **plot_opts\n",
+    ") +\\\n",
+    "df.hvplot.points(\n",
+    "    rasterize=True, aggregator=ds.min('s'), clabel='min(s)',\n",
+    "    **plot_opts\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The example below shows how `aggregator` can be used to handle categorical data."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import hvplot.pandas  # noqa\n",
+    "import hvsampledata\n",
+    "import datashader as ds\n",
+    "\n",
+    "df = hvsampledata.synthetic_clusters(\"pandas\")\n",
+    "\n",
+    "plot_opts = dict(x='x', y='y', data_aspect=1, frame_height=250)\n",
+    "df.hvplot.points(\n",
+    "    datashade=True, aggregator=ds.by('cat'),\n",
+    "    title=\"Categorical datashading with\\n'count' aggregator'\", **plot_opts\n",
+    ") +\\\n",
+    "df.hvplot.points(\n",
+    "    datashade=True, aggregator=ds.by('cat', ds.min('s')), hover_cols=['s'],\n",
+    "    title=\"Categorical datashading with\\n'min(s)' aggregator'\", **plot_opts\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The next examples show how to leverage `ds.summary()` and `ds.where()`. Hover over the plots to see how what information is made available in the tooltip."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ds.summary(min_s=ds.min('s'), min_val=ds.min('val'))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ds.where(ds.min('s'), 'val')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ds.summary(min_s=ds.min('s'), min_val=ds.min('val'))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import hvplot.pandas  # noqa\n",
+    "import hvsampledata\n",
+    "import datashader as ds\n",
+    "\n",
+    "df = hvsampledata.synthetic_clusters(\"pandas\")\n",
+    "\n",
+    "plot_opts = dict(x='x', y='y', data_aspect=1, frame_height=250)\n",
+    "df.hvplot.points(\n",
+    "    rasterize=True, title=\"summary(\\n  min_s=min('s'), max_s=max('s')\\n)\",\n",
+    "    aggregator=ds.summary(min_s=ds.min('s'), min_val=ds.min('val')),\n",
+    "    **plot_opts\n",
+    ") +\\\n",
+    "df.hvplot.points(\n",
+    "    rasterize=True, title=\"where(min('s', 'val')\",\n",
+    "    aggregator=ds.where(ds.min('s'), 'val'),\n",
+    "    **plot_opts\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "(option-datashade)=\n",
+    "## `datashade`\n",
+    "\n",
+    "The `datashade` option can be used to apply rasterization (aggregation into a grid of pixels) and colormapping operations using the [Datashader](https://datashader.org) library. Enabling this options allows:\n",
+    "- Rendering large datasets in the browser that would otherwise crash it as it can easily handle billions of data points.\n",
+    "- Dynamically exploring large datasets and discovering patterns, which would otherwise be difficult to find as plotting large data come with [many pitfalls](https://datashader.org/user_guide/Plotting_Pitfalls.html) such as overplotting.\n",
+    "\n",
+    "This approach can turn even the largest datasets into an image that captures patterns such as density or value distribution, making it for example ideal for high-volume scatter plots. When `datashade=True`, hvPlot returns a [`DynamicMap`](inv:holoviews#reference/containers/bokeh/DynamicMap) containing an [`RGB`](inv:holoviews#reference/elements/bokeh/RGB) instead of individual glyphs.\n",
+    "\n",
+    ":::{tip}\n",
+    "Since `datashade=True` produces an RGB image, the underlying data (e.g. the aggregated values per pixel) is not directly available to the plot. Enabling the `'hover'` [tool](option-tools) (disabled by default when `datashade=True`) would only show the RGB value per pixel, and no meaningful colorbar can be attached to the plot. To let the frontend apply colormapping instead of the backend, and as a consequence expose the underlying data, we recommend setting [`rasterize=True`](option-rasterize) instead of `datashade=True`.\n",
+    ":::\n",
+    "\n",
+    "The [`cnorm`](option-cnorm) option defaults to `'eq_hist'` when `datashade=True`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import hvplot.pandas  # noqa\n",
+    "import hvsampledata\n",
+    "\n",
+    "df = hvsampledata.synthetic_clusters(\"pandas\")\n",
+    "\n",
+    "df.hvplot.scatter(\n",
+    "    x='x', y='y', datashade=True, data_aspect=1, frame_height=250,\n",
+    "    title='Datashaded scatter plot with\\n\"count\" aggregator and\\n\"eq_hist\" cnorm'\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In this example, the entire dataset is rasterized into a colormapped image, with denser areas appearing darker."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "(option-downsample)=\n",
+    "## `downsample`\n",
+    "\n",
+    "The `downsample` option can be used to dynamically reduce the number of plotted points by summarizing data before rendering, making it for example ideal for large timeseries datasets. This results in lighter plots and faster rendering.\n",
+    "\n",
+    "Valid values include (most require the [`tsdownsample`](https://github.com/predict-idlab/tsdownsample) library to be installed):\n",
+    "\n",
+    "- `False`: No downsampling is applied.\n",
+    "- `True`: Applies downsampling using HoloViews' default algorithm LTTB.\n",
+    "- `'lttb'`: Explicitly applies the [Largest Triangle Three Buckets algorithm (LTTB)](https://skemman.is/handle/1946/15343). Uses `tsdownsample` if installed, if not defers to HoloViews' LTTB implementation (slower).\n",
+    "- `'minmax'`: Applies the MinMax algorithm, selecting the minimum and maximum values in each bin. Requires ``tsdownsample``.\n",
+    "- `'m4'`: Applies the M4 algorithm, selecting the minimum, maximum, first, and last values in each bin. Requires ``tsdownsample``.\n",
+    "- `'minmax-lttb'`: Combines MinMax and LTTB algorithms for downsampling, first applying MinMax to reduce to a preliminary set of points, then LTTB for further reduction. Requires `tsdownsample`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import hvplot.pandas  # noqa\n",
+    "import hvsampledata\n",
+    "\n",
+    "df = (\n",
+    "    hvsampledata.stocks(\"pandas\")\n",
+    "    .set_index(\"date\")[[\"Apple\"]]\n",
+    "    .resample(\"2Min\")\n",
+    "    .interpolate(method=\"polynomial\", order=5)\n",
+    ")\n",
+    "print(f\"This dataset contains {len(df)} rows.\")\n",
+    "\n",
+    "df.hvplot.line(downsample=\"lttb\", width=500, height=300, title=\"downsampled with lttb\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    ":::{note}\n",
+    "Requires `holoviews>=1.16`.\n",
+    ":::"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "(option-dynspread)=\n",
+    "## `dynspread`\n",
+    "\n",
+    "When rendering with [`datashade=True`](option-datashade) or [`rasterize=True`](option-datashade), individual points can become hard to see, especially when sparse (1 isolated data point will color 1 pixel only which can be hard to see on a screen). Enabling `dynspread=True` dynamically increases the size of points in less dense areas, making them more visible.\n",
+    "\n",
+    "In more details, spreading expands each pixel a certain number of pixels on all sides according to a circular shape, merging pixels using a compositing operator. Dynamic spreading determines how many pixels to spread based on a density heuristic. Spreading starts at 1 pixel, and stops when the fraction of adjacent non-empty pixels reaches the specified [`threshold`](option-threshold), or the [`max_px`](option-max_px) is reached, whichever comes first.\n",
+    "\n",
+    "In the example below, we zoom in over an area with sparse data. The colored pixels are difficult to distinguish on the left plot, while they are clearly visible on the right plot with `dynspread=True`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import hvsampledata\n",
+    "\n",
+    "df = hvsampledata.synthetic_clusters(\"pandas\")\n",
+    "\n",
+    "plot_opts = dict(\n",
+    "    x='x', y='y', frame_height=250, data_aspect=1,\n",
+    "    xlim=(-5.5, -5), ylim=(2.5, 3),\n",
+    ")\n",
+    "df.hvplot.scatter(\n",
+    "    rasterize=True, dynspread=False,\n",
+    "    title=\"Datashade without dynspread\", **plot_opts,\n",
+    ") +\\\n",
+    "df.hvplot.scatter(\n",
+    "    rasterize=True, dynspread=True,\n",
+    "    title=\"Datashade with dynspread\", **plot_opts,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "(option-max_px)=\n",
+    "## `max_px`\n",
+    "\n",
+    "The `max_px` option sets the upper limit on how much [`dynspread`](option-dynspread) can increase point size (in pixels, default is `3`). It only applies when `dynspread=True`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import hvsampledata\n",
+    "\n",
+    "df = hvsampledata.synthetic_clusters(\"pandas\")\n",
+    "\n",
+    "plot_opts = dict(\n",
+    "    x='x', y='y', frame_height=250, data_aspect=1,\n",
+    "    xlim=(-5.5, -5), ylim=(2.5, 3),\n",
+    ")\n",
+    "df.hvplot.scatter(\n",
+    "    rasterize=True, dynspread=True,\n",
+    "    title=\"Dynspread with max_px=3 (default)\", **plot_opts,\n",
+    ") +\\\n",
+    "df.hvplot.scatter(\n",
+    "    rasterize=True, dynspread=True, max_px=8,\n",
+    "    title=\"Dynspread with max_px=8\", **plot_opts\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    ":::{tip}\n",
+    "Larger values make sparse data more prominent but can also distort the visual scale if overused.\n",
+    ":::"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "(option-pixel_ratio)=\n",
+    "## `pixel_ratio`\n",
+    "\n",
+    "This option adjusts the internal pixel resolution used by [`datashade`](option-datashade) or [`rasterize`](option-rasterize), relative to the actual display size.\n",
+    "\n",
+    ":::{note}\n",
+    "By default, and if possible, `pixel_ratio` is inferred automatically from the browser and will be internally set to `2` on high-DPI screens to improve sharpness. You can override it manually for consistent rendering across devices.\n",
+    ":::"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import hvplot.pandas  # noqa\n",
+    "import hvsampledata\n",
+    "\n",
+    "df = hvsampledata.synthetic_clusters(\"pandas\")\n",
+    "\n",
+    "df.hvplot.scatter(\n",
+    "    x='x', y='y', datashade=True, pixel_ratio=0.1, frame_height=250,\n",
+    "    data_aspect=1, title=\"Datashade with low pixel ratio\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "(option-precompute)=\n",
+    "## `precompute`\n",
+    "\n",
+    "Operations that involve rasterization ([`rasterize`](option-rasterize) and [`datashade`](option-datashade)) can be computationally expensive as they operate on the full dataset (unlike e.g. [`dysnpread`](option-dyspread)). `precompute` can be set to `True` to get faster performance in interactive usage by caching the last set of data used in plotting (*after* any transformations needed) and reusing it when it is requested again. This is particularly useful when your data is not in one of the supported data formats already and needs to be converted. `precompute` is `False` by default, because it requires using memory to store the cached data, but if you have enough memory, you can enable it so that repeated interactions (such as zooming and panning) will be much faster than the first one. Learn more about this option in the [HoloViews large data user guide](https://holoviews.org/user_guide/Large_Data.html#cache-initial-processing-with-precompute-true).\n",
+    "\n",
+    ":::{note}\n",
+    "In practice, most Datashader-plots don't need to do extensive precomputing, but enabling it for {meth}`hvplot.hvPlot.polygons` and {meth}`hvplot.hvPlot.quadmesh` plots can greatly speed up interactive usage.\n",
+    ":::"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "(option-rasterize)=\n",
+    "## `rasterize`\n",
+    "\n",
+    "The `rasterize` option can be used to apply a rasterization (aggregation into a grid of pixels) operation using the [Datashader](https://datashader.org) library. Enabling this options allows:\n",
+    "- Rendering large datasets in the browser that would otherwise crash it as it can easily handle billions of data points.\n",
+    "- Dynamically exploring large datasets and discovering patterns, which would otherwise be difficult to find as plotting large data come with [many pitfalls](https://datashader.org/user_guide/Plotting_Pitfalls.html) such as overplotting.\n",
+    "\n",
+    "This approach can turn even the largest datasets into an image that captures patterns such as density or value distribution, making it for example ideal for high-volume scatter plots. This option applies only rasterization, leaving colormapping to the plotting backend. Unlike [`datashade`](option-datashade), the returned [`DynamicMap`](inv:holoviews#reference/containers/bokeh/DynamicMap) does not contain an `RGB` element but data grid ([`Image`](inv:holoviews#reference/elements/bokeh/Image) or [`ImageStack`](inv:holoviews#reference/elements/bokeh/ImageStack)). This allows exposing the underlying data to the user interface via for example a colorbar and additional values displayed in the hover tooltip.\n",
+    "\n",
+    "The [`cnorm`](option-cnorm) option defaults to `'linear'` when `datashade=True`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import hvplot.pandas  # noqa\n",
+    "import hvsampledata\n",
+    "\n",
+    "df = hvsampledata.synthetic_clusters(\"pandas\")\n",
+    "\n",
+    "df.hvplot.scatter(\n",
+    "    x='x', y='y', rasterize=True, data_aspect=1, frame_height=250, cnorm='log',\n",
+    "    title='Rasterized scatter with count aggregator\\nand log cnorm'\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In this example, the entire dataset is rasterized into an image grid that is colormapped in the front-end, with denser areas appearing darker. Hover over the plot to see the count computed in each bin/pixel."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "(option-resample_when)=\n",
+    "## `resample_when`\n",
+    "\n",
+    "Operations like [`rasterize`](option-rasterize), [`datashade`](option-datashade), and [`downsample`](option-downsample) are very effective at displaying large datasets. When interacting with a plot, and for example zooming in over a region with a few points, these operations are in practice no longer needed. `resample_when` can be set to a number of data points present in the viewport below which resampling is toggled off. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import hvplot.pandas  # noqa\n",
+    "import hvsampledata\n",
+    "\n",
+    "df = hvsampledata.synthetic_clusters(\"pandas\")\n",
+    "\n",
+    "df.hvplot.scatter(\n",
+    "    x='x', y='y', rasterize=True, resample_when=1_000,\n",
+    "    data_aspect=1, frame_height=250, cnorm='log',\n",
+    "    title=\"Rasterize only when >1000 points in view\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "When running the code above, you will notice that after zooming in enough, the original data points appear. This gives a hybrid experience: raw points at low density, rasterized aggregates when zoomed out."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "(option-threshold)=\n",
+    "## `threshold`\n",
+    "\n",
+    "Controls sensitivity for [`dynspread`](option-dynspread). A value of `1.0` always spreads sparse points, while `0.0` never does. Intermediate values let you tune spreading behavior. It only applies when `dynspread=True`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import hvplot.pandas  # noqa\n",
+    "import hvsampledata\n",
+    "\n",
+    "df = hvsampledata.synthetic_clusters(\"pandas\")\n",
+    "\n",
+    "plot_opts = dict(\n",
+    "    x='x', y='y', datashade=True, dynspread=True,\n",
+    "    data_aspect=1, frame_width=200, xlim=(-2, 0), ylim=(7, 9),\n",
+    ")\n",
+    "df.hvplot.scatter(threshold=0.0, title=\"Dynspread threshold=0.0\", **plot_opts) +\\\n",
+    "df.hvplot.scatter(threshold=0.5, title=\"Dynspread threshold=0.5\", **plot_opts) +\\\n",
+    "df.hvplot.scatter(threshold=1.0, title=\"Dynspread threshold=1.0\", **plot_opts)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "(option-x_sampling__y_sampling)=\n",
+    "## `x_sampling` / `y_sampling`\n",
+    "\n",
+    "Set minimum data resolution in the x and/or y direction when setting [`datashade`](option-datashade) or [`rasterize`](option-rasterize). This is useful to set the granularity of the pixel grid when zoomed in, or when visualizing images or gridded data that requires consistent resolution control."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import hvplot.pandas  # noqa\n",
+    "import hvsampledata\n",
+    "\n",
+    "df = hvsampledata.synthetic_clusters(\"pandas\")\n",
+    "\n",
+    "df.hvplot.scatter(\n",
+    "    x='x', y='y', rasterize=True, x_sampling=0.1, y_sampling=0.1,\n",
+    "    data_aspect=1, cnorm='log', xlim=(0, 1), ylim=(0, 1), frame_height=250,\n",
+    "    title='Zoomed in rasterized plot\\nwith custom x/y-sampling'\n",
+    ")"
+   ]
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "name": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/doc/ref/plotting_options/streaming.ipynb
+++ b/doc/ref/plotting_options/streaming.ipynb
@@ -7,6 +7,10 @@
    "source": [
     "# Streaming Options\n",
     "\n",
+    ":::{note}\n",
+    "All the examples below require a live python process to experience the full interactivity of the plots.\n",
+    ":::\n",
+    "\n",
     "```{eval-rst}\n",
     ".. plotting-options-table:: Streaming Options\n",
     "```"
@@ -67,7 +71,7 @@
     "\n",
     "The `stream` option accepts a stream object for streaming plots, allowing data updates without re-rendering the entire plot. The object returned when `stream` is set is a HoloViews [`DynamicMap`](inv:holoviews#reference/containers/bokeh/DynamicMap).\n",
     "\n",
-    "In this first example, we set up and attach a HoloViews [`Pipe`](https://holoviews.org/user_guide/Streaming_Data.html#pipe) stream, we then call its `send` method in the next cell with a new DataFrame, which will replace entirely the plotted data, plotting a year after the other with an interval of 1 second."
+    "In this first example, we set up and attach a HoloViews [`Pipe`](https://holoviews.org/user_guide/Streaming_Data.html#pipe) stream, we then call its `send` method in the next cell with a new DataFrame, which will entirely replace the plotted data, plotting a year after the other with an interval of 1 second."
    ]
   },
   {

--- a/doc/ref/plotting_options/streaming.ipynb
+++ b/doc/ref/plotting_options/streaming.ipynb
@@ -1,0 +1,160 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "0f8b8e64-9334-432d-9b7f-d0f3c7bc478f",
+   "metadata": {},
+   "source": [
+    "# Streaming Options\n",
+    "\n",
+    "```{eval-rst}\n",
+    ".. plotting-options-table:: Streaming Options\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8668be54-5ccd-4bf8-aa69-0da2674cba9f",
+   "metadata": {},
+   "source": [
+    "(option-backlog)=\n",
+    "## `backlog`\n",
+    "\n",
+    "The `backlog` option allows to define the maximum number of rows to keep in the stream buffer when using a streaming data source. Default is `1000`. The object returned when `stream` is set is a HoloViews [`DynamicMap`](inv:holoviews#reference/containers/bokeh/DynamicMap)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7b386801-a5f3-4f24-90ad-8bac0722a69c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import hvplot.streamz  # noqa\n",
+    "from streamz.dataframe import Random\n",
+    "\n",
+    "df = Random(interval='200ms', freq='50ms')\n",
+    "df.hvplot.table(width=400, backlog=5)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b399fc32-78e4-4571-ac50-3b16d456e77a",
+   "metadata": {},
+   "source": [
+    "When running these two cells in a notebook one after the other, the data in the table above will be updated every 200ms for 2 seconds."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cb6df3b5-0020-4195-85d0-62ad85fcbc6d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import asyncio\n",
+    "await asyncio.sleep(2)\n",
+    "df.stop()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "36176689-9ee3-4c70-ae5d-8504277c27aa",
+   "metadata": {},
+   "source": [
+    "(option-stream)=\n",
+    "## `stream`\n",
+    "\n",
+    "The `stream` option accepts a stream object for streaming plots, allowing data updates without re-rendering the entire plot. The object returned when `stream` is set is a HoloViews [`DynamicMap`](inv:holoviews#reference/containers/bokeh/DynamicMap).\n",
+    "\n",
+    "In this first example, we set up and attach a HoloViews [`Pipe`](https://holoviews.org/user_guide/Streaming_Data.html#pipe) stream, we then call its `send` method in the next cell with a new DataFrame, which will replace entirely the plotted data, plotting a year after the other with an interval of 1 second."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "506a9785-04bb-449b-9f0a-9a5ac296aa57",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import hvplot.pandas  # noqa\n",
+    "import hvsampledata\n",
+    "from holoviews.streams import Pipe\n",
+    "\n",
+    "df = hvsampledata.stocks(\"pandas\").set_index(\"date\")\n",
+    "years = df.index.year.drop_duplicates()\n",
+    "\n",
+    "sdf = df.loc[str(years[0]), :]\n",
+    "stream = Pipe(data=sdf)\n",
+    "plot_opts = dict(height=250, width=500, xlim=(df.index.min(), df.index.max()), ylim=(0, 6))\n",
+    "plot = sdf.hvplot.line(stream=stream, **plot_opts)\n",
+    "plot"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "14db1a5f-2b9c-4a4c-96f2-bb7b4d35b095",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import time\n",
+    "\n",
+    "for year in years[1:]:\n",
+    "    stream.send(df.loc[str(year), :])\n",
+    "    time.sleep(1)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5b229030-aec9-4500-b465-5f6fba3adfbf",
+   "metadata": {},
+   "source": [
+    "In this second example we set up and attach a HoloViews [`Buffer`](https://holoviews.org/user_guide/Streaming_Data.html#buffer) stream, we then call its `send` method in the next cell with a new DataFrame, which will accumulate the data, gradually plotting the whole dataset with an interval of 1 second."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d5ef2720-e1e5-4124-9bda-2f9a73b628b7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import hvplot.pandas  # noqa\n",
+    "import hvsampledata\n",
+    "from holoviews.streams import Buffer\n",
+    "\n",
+    "df = hvsampledata.stocks(\"pandas\").set_index(\"date\")\n",
+    "years = df.index.year.drop_duplicates()\n",
+    "\n",
+    "sdf = df.loc[str(years[0]), :]\n",
+    "stream = Buffer(data=sdf, index=False)\n",
+    "plot_opts = dict(height=250, width=500, xlim=(df.index.min(), df.index.max()), ylim=(0, 6))\n",
+    "plot = sdf.hvplot.line(stream=stream, **plot_opts)\n",
+    "plot"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "60af4458-e15b-4b97-90a7-aa534abbed97",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import time\n",
+    "\n",
+    "for year in years[1:]:\n",
+    "    stream.send(df.loc[str(year), :])\n",
+    "    time.sleep(1)"
+   ]
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "name": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/doc/ref/plotting_options/styling.ipynb
+++ b/doc/ref/plotting_options/styling.ipynb
@@ -132,7 +132,7 @@
     "If no colors are specified, it defaults to the `glasbey_hv` color cycle. You can override this by passing a custom list of colors to `color=[...]`.\n",
     "\n",
     "\n",
-    "In addition, using `color='<categorical column>'` is usually faster than `by='<categorical column>'`, especially when working with large datasets or many unique categories. This is because `color` performs vectorized color mapping within a single plot, while `by` generates an overlay of multiple plots — each of which is rendered and managed separately. See [`by` keyword](data.ipynb#by)\n",
+    "In addition, using `color='<categorical column>'` is usually faster than `by='<categorical column>'`, especially when working with large datasets or many unique categories. This is because `color` performs vectorized color mapping within a single plot, while `by` generates an overlay of multiple plots — each of which is rendered and managed separately. See [`by` keyword](option-by)\n",
     "\n",
     "**Summary of differences:**\n",
     "\n",

--- a/hvplot/converter.py
+++ b/hvplot/converter.py
@@ -419,28 +419,29 @@ class HoloViewsConverter:
         Controls the application of downsampling to the plotted data,
         which is particularly useful for large timeseries datasets to
         reduce the amount of data sent to browser and improve
-        visualization performance. Requires HoloViews >= 1.16. Additional
-        dependencies: Installing the ``tsdownsample`` library is required
-        for using any downsampling methods other than the default 'lttb'.
+        visualization performance.
 
         Acceptable values:
 
-        - False: No downsampling is applied.
-        - True: Applies downsampling using HoloViews' default algorithm
+        - ``False``: No downsampling is applied.
+        - ``True``: Applies downsampling using HoloViews' default algorithm
           (LTTB - Largest Triangle Three Buckets).
-        - 'lttb': Explicitly applies the Largest Triangle Three Buckets
-          algorithm.
-        - 'minmax': Applies the MinMax algorithm, selecting the minimum
+        - ``'lttb'``: Explicitly applies the Largest Triangle Three Buckets
+          algorithm. Uses ``tsdownsample`` if installed.
+        - ``'minmax'``: Applies the MinMax algorithm, selecting the minimum
           and maximum values in each bin. Requires ``tsdownsample``.
-        - 'm4': Applies the M4 algorithm, selecting the minimum, maximum,
+        - ``'m4'``: Applies the M4 algorithm, selecting the minimum, maximum,
           first, and last values in each bin. Requires ``tsdownsample``.
-        - 'minmax-lttb': Combines MinMax and LTTB algorithms for
+        - ``'minmax-lttb'``: Combines MinMax and LTTB algorithms for
           downsampling, first applying MinMax to reduce to a preliminary
           set of points, then LTTB for further reduction. Requires
           ``tsdownsample``.
 
         Other string values corresponding to supported algorithms in
         HoloViews may also be used.
+
+        .. note::
+           Requires ``holoviews>=1.16``.
     dynspread : bool, default=False
         For plots generated with datashade=True or rasterize=True,
         automatically increase the point size when the data is sparse
@@ -461,9 +462,9 @@ class HoloViewsConverter:
         Whether to apply rasterization using the Datashader library,
         returning an aggregated Image (to be colormapped by the
         plotting backend) instead of individual points
-    resample_when : int, default=None
+    resample_when : int or None, default=None
         Applies a resampling operation (datashade, rasterize or downsample) if
-        the number of individual data points present in the current zoom range
+        the number of individual data points present in the current viewport
         is above this threshold. The raw plot is displayed otherwise.
     threshold : float, default=0.5
         When using ``dynspread``, this value defines the minimum density of overlapping points


### PR DESCRIPTION
The resampling options notebook depends on https://github.com/holoviz/hvsampledata/pull/34 being merged and released.

Note to self: I found the rasterize/datashade + categorical experience to be quite a bit of a mess and in need of somehow going through all the combinations of options possible and streamlining their behavior/output.