### PR TITLE
Add bar value labels to gallery examples

### DIFF
--- a/doc/gallery/categorical/horizontal_bar.ipynb
+++ b/doc/gallery/categorical/horizontal_bar.ipynb
@@ -31,6 +31,12 @@
     "    title='Horizontal Bar Chart (Bokeh)',\n",
     "    ylabel='Body Mass (g)',\n",
     "    xlabel='Species',\n",
+    ") * grouped.hvplot.labels(\n",
+    "    x='species',\n",
+    "    y='body_mass_g',\n",
+    "    text=\"{body_mass_g:.0f} g \",\n",
+    "    text_color='white',\n",
+    "    text_align=\"right\",\n",
     ")"
    ]
   },


### PR DESCRIPTION
Adds value labels to the horizontal bar
<img width="957" height="646" alt="image" src="https://github.com/user-attachments/assets/8f0963e1-c811-44dc-81f5-59c59ed50c7f" />

However, I couldn't get matplotlib to work :)
```python
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
File ~/miniconda3/envs/hvplot/lib/python3.10/site-packages/matplotlib/axis.py:1769, in Axis.convert_units(self, x)
   1768 try:
-> 1769     ret = self.converter.convert(x, self.units, self)
   1770 except Exception as e:

File ~/miniconda3/envs/hvplot/lib/python3.10/site-packages/matplotlib/category.py:49, in StrCategoryConverter.convert(value, unit, axis)
     48 if unit is None:
---> 49     raise ValueError(
     50         'Missing category information for StrCategoryConverter; '
     51         'this might be caused by unintendedly mixing categorical and '
     52         'numeric data')
     53 StrCategoryConverter._validate_unit(unit)

ValueError: Missing category information for StrCategoryConverter; this might be caused by unintendedly mixing categorical and numeric data

The above exception was the direct cause of the following exception:

ConversionError                           Traceback (most recent call last)
File ~/miniconda3/envs/hvplot/lib/python3.10/site-packages/IPython/core/formatters.py:974, in MimeBundleFormatter.__call__(self, obj, include, exclude)
    971     method = get_real_method(obj, self.print_method)
    973     if method is not None:
--> 974         return method(include=include, exclude=exclude)
    975     return None
    976 else:

File ~/miniconda3/envs/hvplot/lib/python3.10/site-packages/holoviews/core/dimension.py:1275, in Dimensioned._repr_mimebundle_(self, include, exclude)
   1268 def _repr_mimebundle_(self, include=None, exclude=None):
   1269     """
   1270     Resolves the class hierarchy for the class rendering the
   1271     object using any display hooks registered on Store.display
   1272     hooks.  The output of all registered display_hooks is then
   1273     combined and returned.
   1274     """
-> 1275     return Store.render(self)

File ~/miniconda3/envs/hvplot/lib/python3.10/site-packages/holoviews/core/options.py:1428, in Store.render(cls, obj)
   1426 data, metadata = {}, {}
   1427 for hook in hooks:
-> 1428     ret = hook(obj)
   1429     if ret is None:
   1430         continue

File ~/miniconda3/envs/hvplot/lib/python3.10/site-packages/holoviews/ipython/display_hooks.py:287, in pprint_display(obj)
    285 if not ip.display_formatter.formatters['text/plain'].pprint:
    286     return None
--> 287 return display(obj, raw_output=True)

File ~/miniconda3/envs/hvplot/lib/python3.10/site-packages/holoviews/ipython/display_hooks.py:255, in display(obj, raw_output, **kwargs)
    253 elif isinstance(obj, (CompositeOverlay, ViewableElement)):
    254     with option_state(obj):
--> 255         output = element_display(obj)
    256 elif isinstance(obj, (Layout, NdLayout, AdjointLayout)):
    257     with option_state(obj):

File ~/miniconda3/envs/hvplot/lib/python3.10/site-packages/holoviews/ipython/display_hooks.py:149, in display_hook.<locals>.wrapped(element)
    147 try:
    148     max_frames = OutputSettings.options['max_frames']
--> 149     mimebundle = fn(element, max_frames=max_frames)
    150     if mimebundle is None:
    151         return {}, {}

File ~/miniconda3/envs/hvplot/lib/python3.10/site-packages/holoviews/ipython/display_hooks.py:195, in element_display(element, max_frames)
    192 if type(element) not in Store.registry[backend]:
    193     return None
--> 195 return render(element)

File ~/miniconda3/envs/hvplot/lib/python3.10/site-packages/holoviews/ipython/display_hooks.py:76, in render(obj, **kwargs)
     73 if renderer.fig == 'pdf':
     74     renderer = renderer.instance(fig='png')
---> 76 return renderer.components(obj, **kwargs)

File ~/miniconda3/envs/hvplot/lib/python3.10/site-packages/holoviews/plotting/renderer.py:380, in Renderer.components(self, obj, fmt, comm, **kwargs)
    377     plot, fmt = self._validate(obj, fmt)
    379 if not isinstance(plot, Viewable):
--> 380     html = self._figure_data(plot, fmt, as_script=True, **kwargs)
    381     return {'text/html': html}, {MIME_TYPES['jlab-hv-exec']: {}}
    383 registry = list(Stream.registry.items())

File ~/miniconda3/envs/hvplot/lib/python3.10/site-packages/holoviews/plotting/mpl/renderer.py:171, in MPLRenderer._figure_data(self, plot, fmt, bbox_inches, as_script, **kwargs)
    169         pass
    170     bytes_io = BytesIO()
--> 171     fig.canvas.print_figure(bytes_io, **kw)
    172     data = bytes_io.getvalue()
    174 if as_script:

File ~/miniconda3/envs/hvplot/lib/python3.10/site-packages/matplotlib/backend_bases.py:2164, in FigureCanvasBase.print_figure(self, filename, dpi, facecolor, edgecolor, orientation, format, bbox_inches, pad_inches, bbox_extra_artists, backend, **kwargs)
   2161     # we do this instead of `self.figure.draw_without_rendering`
   2162     # so that we can inject the orientation
   2163     with getattr(renderer, "_draw_disabled", nullcontext)():
-> 2164         self.figure.draw(renderer)
   2165 if bbox_inches:
   2166     if bbox_inches == "tight":

File ~/miniconda3/envs/hvplot/lib/python3.10/site-packages/matplotlib/artist.py:95, in _finalize_rasterization.<locals>.draw_wrapper(artist, renderer, *args, **kwargs)
     93 @wraps(draw)
     94 def draw_wrapper(artist, renderer, *args, **kwargs):
---> 95     result = draw(artist, renderer, *args, **kwargs)
     96     if renderer._rasterizing:
     97         renderer.stop_rasterizing()

File ~/miniconda3/envs/hvplot/lib/python3.10/site-packages/matplotlib/artist.py:72, in allow_rasterization.<locals>.draw_wrapper(artist, renderer)
     69     if artist.get_agg_filter() is not None:
     70         renderer.start_filter()
---> 72     return draw(artist, renderer)
     73 finally:
     74     if artist.get_agg_filter() is not None:

File ~/miniconda3/envs/hvplot/lib/python3.10/site-packages/matplotlib/figure.py:3154, in Figure.draw(self, renderer)
   3151         # ValueError can occur when resizing a window.
   3153 self.patch.draw(renderer)
-> 3154 mimage._draw_list_compositing_images(
   3155     renderer, self, artists, self.suppressComposite)
   3157 for sfig in self.subfigs:
   3158     sfig.draw(renderer)

File ~/miniconda3/envs/hvplot/lib/python3.10/site-packages/matplotlib/image.py:132, in _draw_list_compositing_images(renderer, parent, artists, suppress_composite)
    130 if not_composite or not has_images:
    131     for a in artists:
--> 132         a.draw(renderer)
    133 else:
    134     # Composite any adjacent images together
    135     image_group = []

File ~/miniconda3/envs/hvplot/lib/python3.10/site-packages/matplotlib/artist.py:72, in allow_rasterization.<locals>.draw_wrapper(artist, renderer)
     69     if artist.get_agg_filter() is not None:
     70         renderer.start_filter()
---> 72     return draw(artist, renderer)
     73 finally:
     74     if artist.get_agg_filter() is not None:

File ~/miniconda3/envs/hvplot/lib/python3.10/site-packages/matplotlib/axes/_base.py:3070, in _AxesBase.draw(self, renderer)
   3067 if artists_rasterized:
   3068     _draw_rasterized(self.figure, artists_rasterized, renderer)
-> 3070 mimage._draw_list_compositing_images(
   3071     renderer, self, artists, self.figure.suppressComposite)
   3073 renderer.close_group('axes')
   3074 self.stale = False

File ~/miniconda3/envs/hvplot/lib/python3.10/site-packages/matplotlib/image.py:132, in _draw_list_compositing_images(renderer, parent, artists, suppress_composite)
    130 if not_composite or not has_images:
    131     for a in artists:
--> 132         a.draw(renderer)
    133 else:
    134     # Composite any adjacent images together
    135     image_group = []

File ~/miniconda3/envs/hvplot/lib/python3.10/site-packages/matplotlib/artist.py:72, in allow_rasterization.<locals>.draw_wrapper(artist, renderer)
     69     if artist.get_agg_filter() is not None:
     70         renderer.start_filter()
---> 72     return draw(artist, renderer)
     73 finally:
     74     if artist.get_agg_filter() is not None:

File ~/miniconda3/envs/hvplot/lib/python3.10/site-packages/matplotlib/text.py:754, in Text.draw(self, renderer)
    751 # don't use self.get_position here, which refers to text
    752 # position in Text:
    753 posx = float(self.convert_xunits(self._x))
--> 754 posy = float(self.convert_yunits(self._y))
    755 posx, posy = trans.transform((posx, posy))
    756 if not np.isfinite(posx) or not np.isfinite(posy):

File ~/miniconda3/envs/hvplot/lib/python3.10/site-packages/matplotlib/artist.py:291, in Artist.convert_yunits(self, y)
    289 if ax is None or ax.yaxis is None:
    290     return y
--> 291 return ax.yaxis.convert_units(y)

File ~/miniconda3/envs/hvplot/lib/python3.10/site-packages/matplotlib/axis.py:1771, in Axis.convert_units(self, x)
   1769     ret = self.converter.convert(x, self.units, self)
   1770 except Exception as e:
-> 1771     raise munits.ConversionError('Failed to convert value(s) to axis '
   1772                                  f'units: {x!r}') from e
   1773 return ret

ConversionError: Failed to convert value(s) to axis units: 'Adelie'
```