### PR TITLE
Add violin with scatter

### DIFF
--- a/doc/gallery/statistical/violin.ipynb
+++ b/doc/gallery/statistical/violin.ipynb
@@ -28,7 +28,14 @@
     "    by='species',\n",
     "    title='Violin Plot by Species (Bokeh)',\n",
     "    ylabel='Flipper Length (mm)',\n",
-    ")"
+    "    violin_fill_alpha=0\n",
+    ") * df.hvplot.scatter(\n",
+    "    x='species',  # the `by` column\n",
+    "    y='flipper_length_mm',  # the `y` column\n",
+    "    color=\"black\",\n",
+    "    alpha=0.7,\n",
+    "    size=8,\n",
+    ").opts(jitter=0.25)"
    ]
   },
   {
@@ -40,16 +47,28 @@
    "source": [
     "import hvplot.pandas  # noqa\n",
     "import hvsampledata\n",
+    "import numpy as np\n",
     "\n",
     "hvplot.extension('matplotlib')\n",
     "\n",
     "df = hvsampledata.penguins('pandas')\n",
+    "df = df[df['species'].notna()].copy()\n",
+    "df = df.sort_values('species')\n",
+    "\n",
+    "species_map = {'Adelie': 0, 'Chinstrap': 1, 'Gentoo': 2}\n",
+    "df['x'] = df['species'].map(species_map) + np.random.uniform(-0.2, 0.2, size=len(df))\n",
     "\n",
     "df.hvplot.violin(\n",
     "    y='flipper_length_mm',\n",
     "    by='species',\n",
     "    title='Violin Plot by Species (Matplotlib)',\n",
     "    ylabel='Flipper Length (mm)',\n",
+    ") * df.hvplot.scatter(\n",
+    "    x='x',  # the `by` column\n",
+    "    y='flipper_length_mm',  # the `y` column\n",
+    "    color='black',\n",
+    "    alpha=0.7,\n",
+    "    size=20,\n",
     ")"
    ]
   },


### PR DESCRIPTION
Couldn't figure out how to do no fill alpha for matplotlib, also had to use the numpy way to jitter mpl.

<img width="1043" height="846" alt="image" src="https://github.com/user-attachments/assets/d8c8f8b7-3294-446b-affa-28cfe445b50f" />
