### PR TITLE
Add the backend_opts option

### DIFF
--- a/doc/ref/plotting_options/styling.ipynb
+++ b/doc/ref/plotting_options/styling.ipynb
@@ -20,6 +20,156 @@
   },
   {
    "cell_type": "markdown",
+   "id": "129d145e-956f-4435-9e7a-9033e2ebe93b",
+   "metadata": {},
+   "source": [
+    "(option-backend_opts)=\n",
+    "## `backend_opts`\n",
+    "\n",
+    "hvPlot offers many options to customize a plot. Yet, sometimes this is not enough, in which case `backend_opts` offers a powerful mechanism to customize many properties of the plot objects created internally by HoloViews (Bokeh models, Matplotlib figure and axis, etc.). This option accepts a dictionary whose keys are string accessors, i.e. they mirror attribute access on these plot objects. The values of this dictionary are the values to set.\n",
+    "\n",
+    "The objects that can be targeted via this accessor pattern are those referenced in the HoloViews plot `handles` dictionary. Usually that would be the `plot` key for Bokeh giving access to the [`figure`](https://docs.bokeh.org/en/latest/docs/reference/plotting/figure.html) object, and the `fig` key for Matplotlib giving access to the [`Figure`](https://matplotlib.org/stable/api/_as_gen/matplotlib.figure.Figure) object. Note that accessors starting with `plot` for Bokeh and `fig` for Matplotlib can omit these terms (e.g. `xgrid.grid_line_color` instead of `plot.xgrid.grid_line_colore` for Bokeh).\n",
+    "\n",
+    "Let's start with a Bokeh example where we set properties of the grid, the x- and y-axis, and hover. These options cannot be directly customized with the current hvPlot's API."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2aa1b2a7-aa24-40c0-9d84-63c4fcc3a964",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import hvplot.pandas  # noqa\n",
+    "\n",
+    "df = hvplot.sampledata.penguins(\"pandas\")\n",
+    "\n",
+    "plot = df.hvplot.scatter(\n",
+    "    x=\"bill_length_mm\", y=\"bill_depth_mm\", color=\"black\",\n",
+    "    backend_opts={\n",
+    "        \"plot.xgrid.grid_line_color\": \"grey\",\n",
+    "        \"plot.xgrid.grid_line_dash\": \"dotted\",\n",
+    "        \"plot.xaxis.axis_label_text_font_style\": \"bold\",\n",
+    "        \"plot.yaxis.axis_label_text_font_style\": \"bold\",\n",
+    "        \"hover.attachment\": \"vertical\",\n",
+    "    }\n",
+    ")\n",
+    "plot"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "eee8f810-7d65-4c91-9f73-adc82097fcd5",
+   "metadata": {},
+   "source": [
+    "With the code below, we can see all the handles we could have referenced for *this plot* (other plots may have different handles)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b06789f5-d78c-4e2a-9052-31845df33a67",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import holoviews as hv\n",
+    "\n",
+    "hv.renderer('bokeh').get_plot(plot).handles"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d080b507-b96d-419c-81a7-a448559207e8",
+   "metadata": {},
+   "source": [
+    "We can see the Bokeh property `grid_line_color` exists and has been correctly set."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "742cc487-4a4a-4fea-aa53-f5fd8dc9ab36",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "hv.renderer('bokeh').get_plot(plot).handles['plot'].xgrid.grid_line_color"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "297c4bba-85e2-40d7-b018-c7410cc1fb49",
+   "metadata": {},
+   "source": [
+    "In this Matplotlib example we disable the plot frame. Note that we could also have written the accessor as `'axes.set_frame_on'` (which is the method called internally by HoloViews)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a0e3e933-b307-4943-b970-5f35860a9205",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import hvplot.pandas  # noqa\n",
+    "hv.extension(\"matplotlib\")\n",
+    "\n",
+    "df = hvplot.sampledata.penguins(\"pandas\")\n",
+    "\n",
+    "plot = df.hvplot.scatter(\n",
+    "    x=\"bill_length_mm\", y=\"bill_depth_mm\",\n",
+    "    backend_opts={\"axes.frame_on\": False}\n",
+    ")\n",
+    "plot"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "eb98d466-79dd-4c52-889b-7e66e0451e98",
+   "metadata": {},
+   "source": [
+    "Here's the list of handles for *this plot*."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "061b2b5b-b889-4c12-83d8-f46d3a7fe8fb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "hv.renderer('matplotlib').get_plot(plot).handles"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1bf917bb-5a8b-44d3-b55f-dbb09d00d4a7",
+   "metadata": {},
+   "source": [
+    "We can see the Matplotlib method `set_frame_on` exists and has been correctly executed."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "756590f9-75ef-4acf-a238-b289fe142a83",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "hv.renderer('matplotlib').get_plot(plot).handles['axis'].set_frame_on"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c9056f16-18b5-4e66-b70d-6180341d5b72",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "hv.renderer('matplotlib').get_plot(plot).handles['axis'].get_frame_on()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "881751c3-4dc2-4027-9b7f-147fbe64a4f6",
    "metadata": {},
    "source": [

--- a/hvplot/converter.py
+++ b/hvplot/converter.py
@@ -442,6 +442,12 @@ class HoloViewsConverter:
 
     Styling Options
     ---------------
+    backend_opts : dict or None, optional
+        A dictionary of custom options to apply to the plot or subcomponents of
+        the plot. The keys in the dictionary mirror attribute access on the
+        underlying plotting backend objects stored in the plot's handles, e.g.
+        ``{'hover.attachment': 'vertical'}`` will index the hover in the handles
+        and then set the attachment.
     fontscale : number
         Scales the size of all fonts by the same amount, e.g. fontscale=1.5
         enlarges all fonts (title, xticks, labels etc.) by 50%.
@@ -653,6 +659,7 @@ class HoloViewsConverter:
     ]
 
     _style_options = [
+        'backend_opts',
         'fontscale',
         'fontsize',
         'grid',
@@ -885,6 +892,7 @@ class HoloViewsConverter:
         rescale_discrete_levels=None,
         autorange=None,
         subcoordinate_y=None,
+        backend_opts=None,
         **kwds,
     ):
         if debug:
@@ -1144,6 +1152,9 @@ class HoloViewsConverter:
             else:
                 plot_opts['autohide_toolbar'] = autohide_toolbar
         plot_opts['tools'] = tools
+
+        if backend_opts is not None:
+            plot_opts['backend_opts'] = backend_opts
 
         if self.crs and global_extent:
             plot_opts['global_extent'] = global_extent

--- a/hvplot/tests/testoptions.py
+++ b/hvplot/tests/testoptions.py
@@ -575,6 +575,27 @@ class TestOptions:
         opts = Store.lookup_options(backend, plot, 'plot')
         assert opts.kwargs['autohide_toolbar'] is True
 
+    @pytest.mark.parametrize(
+        'backend',
+        [
+            'bokeh',
+            'matplotlib',
+            pytest.param(
+                'plotly',
+                marks=pytest.mark.skip(reason='backend_opts not supported w/ plotly'),
+            ),
+        ],
+        indirect=True,
+    )
+    def test_backend_opts(self, df, backend):
+        if backend == 'bokeh':
+            bo = {'plot.xgrid.grid_line_color': 'grey'}
+        elif backend == 'matplotlib':
+            bo = {'axes.frame_on': False}
+        plot = df.hvplot.scatter('x', 'y', backend_opts=bo)
+        opts = Store.lookup_options(backend, plot, 'plot')
+        assert opts.kwargs['backend_opts'] == bo
+
 
 @pytest.fixture(scope='module')
 def da():


### PR DESCRIPTION
Useful for further customization of Bokeh and Matplotlib plots without having to directly interact with their objects.

```python
import hvplot.pandas  # noqa

df = hvplot.sampledata.penguins("pandas")

plot = df.hvplot.scatter(
    x="bill_length_mm", y="bill_depth_mm", color="black",
    backend_opts={
        "plot.xgrid.grid_line_color": "grey",
        "plot.xgrid.grid_line_dash": "dotted",
        "plot.xaxis.axis_label_text_font_style": "bold",
        "plot.yaxis.axis_label_text_font_style": "bold",
        "hover.attachment": "vertical",
    }
)
plot
```

<img width="745" height="313" alt="image" src="https://github.com/user-attachments/assets/019c6d55-688c-421d-b6f3-e2c023f95814" />
