### PR TITLE
Document attr_labels

### DIFF
--- a/doc/ref/plotting_options/data.ipynb
+++ b/doc/ref/plotting_options/data.ipynb
@@ -66,13 +66,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In this example, when `attr_labels` is not disabled, the coordinate labels are enhanced with their `long_name` attributes and `units` information. When disabled, the plot uses the raw dimension names without the additional metadata."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "(option-by)=\n",
     "## `by`\n",
     "\n",


### PR DESCRIPTION
resolves #1671 

documents the `attr_labels` in the data options reference.

<img width="530" height="656" alt="Screenshot 2025-09-22 at 5 03 59 PM" src="https://github.com/user-attachments/assets/2cef88a2-d92e-42fc-b104-a5e39a2332e5" />
