### PR TITLE
Change `project` to `workspace`

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -1,4 +1,4 @@
-[project]
+[workspace]
 name = "hvplot"
 channels = ["pyviz/label/dev",  "conda-forge"]
 platforms = ["linux-64", "osx-arm64", "osx-64", "win-64"]


### PR DESCRIPTION
This PR updates the project configuration by switching from a `[project]` section to a `[workspace]` section. See https://github.com/prefix-dev/pixi/pull/4921