### PR TITLE
fix: auto-triage bot

### DIFF
--- a/.github/workflows/auto_triage.yml
+++ b/.github/workflows/auto_triage.yml
@@ -16,11 +16,11 @@ jobs:
         run: |
           # Get current labels and issue type - if any exist, the issue has been looked at
           label_count=$(gh issue view "$NUMBER" --json labels --jq '.labels | length')
-          issue_type=$(gh api repos/$GH_REPO/issues/$NUMBER --jq '.type')
+          issue_type=$(gh api repos/$GH_REPO/issues/$NUMBER --jq '.type // empty')
           echo "Number of existing labels: $label_count"
           echo "Issue type: $issue_type"
 
-          if [ "$label_count" -eq 0 ] && [ "$issue_type" = "null" ]; then
+          if [ "$label_count" -eq 0 ] && [ -z "$issue_type" ]; then
             needs_triage=true
           else
             needs_triage=false


### PR DESCRIPTION
This pull request makes a small improvement to the issue triage workflow by handling cases where the issue type is missing more robustly.

- Improved the shell script in `.github/workflows/auto_triage.yml` to ensure that issues with a missing `type` field are correctly detected by using a default empty value instead of comparing to "null". This fixes the bug where issues without labels or types weren't receiving the TRIAGE label, e.g in issues #1709, #1692, and #1689 etc

See https://github.com/Azaya89/hvplot/issues/11 for a test of the fix.

Closes #1712 