### PR TITLE
Define the top-level public API

### DIFF
--- a/hvplot/__init__.py
+++ b/hvplot/__init__.py
@@ -63,23 +63,23 @@ import sys
 
 import holoviews as _hv
 import panel as _pn
-from holoviews import render  # noqa: F401
+from holoviews import render
 
-from . import sampledata  # noqa: F401
-from .converter import HoloViewsConverter  # noqa: F401
+from . import sampledata
+from .converter import HoloViewsConverter
 from .interactive import Interactive
 from .plotting import (
-    andrews_curves,  # noqa: F401
-    hvPlot,  # noqa: F401
-    hvPlotTabular,  # noqa: F401
-    lag_plot,  # noqa: F401
-    parallel_coordinates,  # noqa: F401
-    plot,  # noqa: F401
-    scatter_matrix,  # noqa: F401
+    andrews_curves,
+    hvPlot,
+    hvPlotTabular,
+    lag_plot,
+    parallel_coordinates,
+    plot,
+    scatter_matrix,
 )
-from .ui import explorer  # noqa: F401
+from .ui import explorer
 from .util import _in_ipython, _PatchHvplotDocstrings
-from .utilities import help, hvplot_extension, output, save, show  # noqa: F401
+from .utilities import help, hvplot_extension, output, save, show
 
 # Define '__version__'
 try:
@@ -115,6 +115,30 @@ except (ImportError, LookupError, FileNotFoundError):
             # The user is probably trying to run this without having installed
             # the package.
             __version__ = '0.0.0+unknown'
+
+__all__ = [
+    'HoloViewsConverter',
+    'Interactive',
+    '__version__',
+    'andrews_curves',
+    'bind',
+    'explorer',
+    'extension',
+    'help',
+    'hvPlot',
+    'hvPlotTabular',
+    'hvplot_extension',
+    'lag_plot',
+    'output',
+    'parallel_coordinates',
+    'plot',
+    'post_patch',
+    'render',
+    'sampledata',
+    'save',
+    'scatter_matrix',
+    'show',
+]
 
 _PATCH_PLOT_SIGNATURES = _in_ipython() or (
     os.getenv('HVPLOT_PATCH_PLOT_DOCSTRING_SIGNATURE', 'false').lower() in ('1', 'true')

--- a/hvplot/tests/test_api.py
+++ b/hvplot/tests/test_api.py
@@ -1,0 +1,30 @@
+import hvplot
+
+EXPECTED_PUBLIC_API = [
+    'HoloViewsConverter',
+    'Interactive',
+    '__version__',
+    'andrews_curves',
+    'bind',
+    'explorer',
+    'extension',
+    'help',
+    'hvPlot',
+    'hvPlotTabular',
+    'hvplot_extension',
+    'lag_plot',
+    'output',
+    'parallel_coordinates',
+    'plot',
+    'post_patch',
+    'render',
+    'sampledata',
+    'save',
+    'scatter_matrix',
+    'show',
+]
+
+
+def test_public_api():
+    assert hvplot.__all__ == EXPECTED_PUBLIC_API
+    assert all(hasattr(hvplot, name) for name in hvplot.__all__)


### PR DESCRIPTION
## Summary

- add a sorted `__all__` to `hvplot/__init__.py`, including `__version__` and the existing documented top-level objects
- remove the import-level `F401` suppressions that are no longer needed once those imports are declared exports
- add an exact public-API contract test that also verifies every exported name exists

This addresses the top-level portion of #1626.

## Context

#1718 previously proposed the same top-level scope and established the intended export set. Thank you to @toroleapinc for that initial work. This replacement starts from current `main`, applies the maintainer feedback recorded there, adds regression coverage, and includes the requested AI disclosure.

## Validation

- regression test verified red on `main` because `hvplot.__all__` was absent
- `python -m pytest hvplot/tests/test_api.py hvplot/tests/testdeprecations.py hvplot/tests/testpatchsignature.py hvplot/tests/testplotting.py -q` (103 passed, 7 skipped)
- `python -m pytest hvplot/tests -q` (1039 passed, 376 skipped, 58 deselected, 24 xfailed)
- `pre-commit run --files hvplot/__init__.py hvplot/tests/test_api.py` (all applicable hooks passed)
- `from hvplot import *` smoke test
- `git diff --check`

## AI assistance

OpenAI Codex assisted with issue and prior-PR research, implementation, testing, and PR drafting. I reviewed the full diff and validation results. No private data or generated project assets are included.
