### PR TITLE
Add donut and waterfall plot support

### DIFF
--- a/hvplot/converter.py
+++ b/hvplot/converter.py
@@ -27,6 +27,7 @@ from holoviews.element import (
     Curve,
     Dataset,
     Distribution,
+    Donut,
     ErrorBars,
     HeatMap,
     HexTiles,
@@ -44,6 +45,7 @@ from holoviews.element import (
     TriMesh,
     VectorField,
     Violin,
+    Waterfall,
 )
 from holoviews.operation import apply_when, histogram
 from holoviews.plotting.bokeh import OverlayPlot, colormap_generator
@@ -800,6 +802,7 @@ class HoloViewsConverter:
         'contourf': Polygons,
         'dataset': Dataset,
         'density': Distribution,
+        'donut': Donut,
         'errorbars': ErrorBars,
         'heatmap': HeatMap,
         'hexbin': HexTiles,
@@ -820,6 +823,7 @@ class HoloViewsConverter:
         'trimesh': TriMesh,
         'vectorfield': VectorField,
         'violin': Violin,
+        'waterfall': Waterfall,
     }
 
     # Types which have a colorbar by default
@@ -2687,6 +2691,16 @@ class HoloViewsConverter:
         """Line plot."""
         self._error_if_unavailable('line')
         return self.chart(Curve, x, y, data)
+
+    def donut(self, x=None, y=None, data=None):
+        """Donut plot."""
+        self._error_if_unavailable('donut')
+        return self.chart(Donut, x, y, data)
+
+    def waterfall(self, x=None, y=None, data=None):
+        """Waterfall plot."""
+        self._error_if_unavailable('waterfall')
+        return self.chart(Waterfall, x, y, data)
 
     def step(self, x=None, y=None, data=None):
         """Step plot."""

--- a/hvplot/plotting/core.py
+++ b/hvplot/plotting/core.py
@@ -253,6 +253,8 @@ class hvPlotTabular(hvPlotBase):
         'polygons',
         'paths',
         'labels',
+        'donut',
+        'waterfall',
         'explorer',
     ]
 
@@ -1230,6 +1232,102 @@ class hvPlotTabular(hvPlotBase):
     def density(self, y=None, by=None, **kwds):
         """Alias of :meth:`hvplot.hvPlot.kde`."""
         return self(kind='kde', x=None, y=y, by=by, **kwds)
+
+    def donut(self, x=None, y=None, **kwds):
+        """
+        Create a donut plot.
+
+        A donut plot displays data as a circular chart with a hole in the center,
+        useful for showing proportions of a whole.
+
+        Reference: https://hvplot.holoviz.org/ref/api/manual/hvplot.hvPlot.donut.html
+
+        Plotting options: https://hvplot.holoviz.org/ref/plotting_options/index.html
+
+        Parameters
+        ----------
+        x : str, optional
+            Field name(s) to draw x-positions from. If not specified, the index is
+            used. Can refer to continuous and categorical data.
+        y : str or list of str, optional
+            Field name(s) to draw y-positions from. If not specified, all numerical
+            fields are used.
+        **kwds : optional
+            Additional keyword arguments documented in :ref:`plot-options`.
+            Run ``hvplot.help('donut')`` for the full method documentation.
+
+        Returns
+        -------
+        :class:`holoviews:holoviews.element.Donut` or Panel object
+            A HoloViews Donut element or Panel object if using Panel widgets.
+            You can ``print`` the object to study its composition and run:
+
+            .. code-block:: python
+
+                import holoviews as hv
+                hv.help(the_holoviews_object)
+
+            to learn more about its parameters and options.
+
+        See Also
+        --------
+        :meth:`waterfall` : Waterfall plot.
+
+        References
+        ----------
+        - HoloViews: https://holoviews.org/reference/elements/chart/Donut.html
+        - Plotly: https://plotly.com/python/donut-charts/
+        - Wiki: https://en.wikipedia.org/wiki/Donut_chart
+        """
+        return self(kind='donut', x=x, y=y, **kwds)
+
+    def waterfall(self, x=None, y=None, **kwds):
+        """
+        Create a waterfall plot.
+
+        A waterfall plot displays data as a series of columns that rise and fall,
+        commonly used to visualize running totals or contributions to a net change.
+
+        Reference: https://hvplot.holoviz.org/ref/api/manual/hvplot.hvPlot.waterfall.html
+
+        Plotting options: https://hvplot.holoviz.org/ref/plotting_options/index.html
+
+        Parameters
+        ----------
+        x : str, optional
+            Field name(s) to draw x-positions from. If not specified, the index is
+            used. Can refer to continuous and categorical data.
+        y : str or list of str, optional
+            Field name(s) to draw y-positions from. If not specified, all numerical
+            fields are used.
+        **kwds : optional
+            Additional keyword arguments documented in :ref:`plot-options`.
+            Run ``hvplot.help('waterfall')`` for the full method documentation.
+
+        Returns
+        -------
+        :class:`holoviews:holoviews.element.Waterfall` or Panel object
+            A HoloViews Waterfall element or Panel object if using Panel widgets.
+            You can ``print`` the object to study its composition and run:
+
+            .. code-block:: python
+
+                import holoviews as hv
+                hv.help(the_holoviews_object)
+
+            to learn more about its parameters and options.
+
+        See Also
+        --------
+        :meth:`donut` : Donut plot.
+
+        References
+        ----------
+        - HoloViews: https://holoviews.org/reference/elements/chart/Waterfall.html
+        - Plotly: https://plotly.com/python/waterfall-charts/
+        - Wiki: https://en.wikipedia.org/wiki/Waterfall_chart
+        """
+        return self(kind='waterfall', x=x, y=y, **kwds)
 
     def table(self, columns=None, **kwds):
         """

--- a/hvplot/tests/testplotting.py
+++ b/hvplot/tests/testplotting.py
@@ -132,6 +132,38 @@ def test_pandas_frame_specials_plot_explicit_return_holoviews_object(backend, ki
     assert isinstance(plot, el)
 
 
+@pytest.mark.parametrize('kind,el', [('donut', hv.Donut), ('waterfall', hv.Waterfall)])
+def test_hvplot_direct_returns_type_and_contents(plotting_backend, kind, el):
+    """Test df.hvplot.<kind>() returns NdOverlay with correct contained elements."""
+    import hvplot.pandas  # noqa: F401 - registers hvPlot accessor on pandas
+
+    df = pd.DataFrame({'a': [1, 2, 3], 'b': [4, 5, 6]})
+    plot = df.hvplot.__getattribute__(kind)()
+    # Assert top-level is NdOverlay
+    assert isinstance(plot, hv.NdOverlay), f'Expected NdOverlay, got {type(plot).__name__}'
+    # Assert all contained elements are the expected type
+    for key, element in plot.data.items():
+        assert isinstance(element, el), (
+            f'Expected {el.__name__} for key {key}, got {type(element).__name__}'
+        )
+
+
+@pytest.mark.parametrize('kind,el', [('donut', hv.Donut), ('waterfall', hv.Waterfall)])
+def test_hvplot_kind_returns_type_and_contents(plotting_backend, kind, el):
+    """Test df.hvplot(kind='<kind>') returns NdOverlay with correct contained elements."""
+    import hvplot.pandas  # noqa: F401 - registers hvPlot accessor on pandas
+
+    df = pd.DataFrame({'a': [1, 2, 3], 'b': [4, 5, 6]})
+    plot = df.hvplot(kind=kind)
+    # Assert top-level is NdOverlay
+    assert isinstance(plot, hv.NdOverlay), f'Expected NdOverlay, got {type(plot).__name__}'
+    # Assert all contained elements are the expected type
+    for key, element in plot.data.items():
+        assert isinstance(element, el), (
+            f'Expected {el.__name__} for key {key}, got {type(element).__name__}'
+        )
+
+
 def test_pandas_plot_reuse_plot_dropped(plotting_backend):
     df = pd.DataFrame([0, 1, 2])
     with patch('hvplot.plotting.hvPlotTabular.__call__') as hvcall:


### PR DESCRIPTION
## Description

Closes Issue : #1745 

Adds support for the HoloViews 1.23 `Donut` and `Waterfall` element types in hvPlot.

The new plot kinds are available through both the direct hvPlot API and the `kind` parameter:

```python
import pandas as pd
import hvplot.pandas

df = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})

df.hvplot.donut()
df.hvplot.waterfall()

df.hvplot(kind="donut")
df.hvplot(kind="waterfall")
```

The implementation adds:

* `donut` and `waterfall` mappings to `HoloViewsConverter._kind_mapping`
* Converter methods for `Donut` and `Waterfall`
* Public `hvPlotTabular.donut()` and `hvPlotTabular.waterfall()` APIs
* Regression tests covering both direct API and `kind=` usage

Fixes #1745

### Testing

* `pixi run lint`
* `pixi run test-unit`

Full unit test results:

```text
1497 passed, 32 skipped, 58 deselected, 24 xfailed, 1 xpassed
```

## AI Disclosure

Tool & Model: ChatGPT (GPT-5.6 Luna) and OpenCode with NeMoTron 3.5 Lightning

Usage: AI tools were used to assist with repository exploration, understanding the existing architecture and test conventions, investigating the issue, and reviewing the proposed implementation. All code changes and AI-assisted suggestions were manually reviewed and tested locally.

* [x] I have tested all AI-generated content in my PR.
* [x] I take responsibility for all AI-generated content in my PR.

## Checklist

* [x] Tests added and are passing

## Screenshots

<img width="1544" height="817" alt="Screenshot From 2026-09-04 19-14-09" src="https://github.com/user-attachments/assets/7f0377ec-4614-4d8e-8ee6-54823e5847b0" />
