### PR TITLE
Preserve the selected backend when importing pandas or xarray

### DIFF
--- a/hvplot/__init__.py
+++ b/hvplot/__init__.py
@@ -146,7 +146,14 @@ except Exception:
 
 def post_patch(extension='bokeh', logo=False, check_loaded=False):
     """Load the HoloViews extension after patching a plotting API."""
-    if not check_loaded:
+    if extension is None:
+        if not getattr(_hv.extension, '_loaded', False):
+            hvplot_extension(
+                _hv.Store.current_backend,
+                logo=logo,
+                compatibility=hvplot_extension.compatibility,
+            )
+    elif not check_loaded:
         hvplot_extension(extension, logo=logo)
     elif not getattr(_hv.extension, '_loaded', False):
         hvplot_extension(extension, logo=logo)

--- a/hvplot/pandas.py
+++ b/hvplot/pandas.py
@@ -3,7 +3,7 @@
 from .interactive import Interactive
 
 
-def patch(name='hvplot', interactive='interactive', extension='bokeh', logo=False):
+def patch(name='hvplot', interactive='interactive', extension=None, logo=False):
     """Patch the hvPlot plotting API onto pandas DataFrame and Series."""
     from . import _module_extensions, hvPlotTabular, post_patch
 

--- a/hvplot/tests/testpatch.py
+++ b/hvplot/tests/testpatch.py
@@ -3,13 +3,65 @@ Tests patching of supported libraries
 """
 
 import sys
+from importlib import import_module, reload
 from unittest import SkipTest, TestCase
 
+import holoviews as hv
 import numpy as np
 import pandas as pd
+import pytest
 
+import hvplot
 from hvplot.plotting import hvPlot, hvPlotTabular
 from hvplot.util import _HV_VERSION
+
+
+@pytest.mark.parametrize('module_name', ['pandas', 'xarray'])
+@pytest.mark.parametrize('backend', ['matplotlib', 'plotly'])
+def test_import_preserves_selected_backend(module_name, backend):
+    original_backend = hv.Store.current_backend
+    original_compatibility = hvplot.extension.compatibility
+    module = import_module(f'hvplot.{module_name}')
+    try:
+        hvplot.extension(backend, compatibility='bokeh')
+        reload(module)
+        assert hv.Store.current_backend == backend
+        assert hvplot.extension.compatibility == 'bokeh'
+    finally:
+        hvplot.extension(original_backend, compatibility=original_compatibility)
+
+
+@pytest.mark.parametrize('module_name', ['pandas', 'xarray'])
+def test_patch_loads_default_backend(module_name, monkeypatch):
+    original_backend = hv.Store.current_backend
+    original_compatibility = hvplot.extension.compatibility
+    module = import_module(f'hvplot.{module_name}')
+    monkeypatch.setattr(hv.extension, '_loaded', False)
+    try:
+        hv.Store.set_current_backend('bokeh')
+        module.patch()
+        assert hv.Store.current_backend == 'bokeh'
+        data = (
+            pd.Series([1, 2])
+            if module_name == 'pandas'
+            else module.xr.DataArray([1, 2], dims=['x'], name='value')
+        )
+        assert hv.render(data.hvplot.line()) is not None
+    finally:
+        hvplot.extension(original_backend, compatibility=original_compatibility)
+
+
+@pytest.mark.parametrize('module_name', ['pandas', 'xarray'])
+def test_patch_honors_explicit_backend(module_name):
+    original_backend = hv.Store.current_backend
+    original_compatibility = hvplot.extension.compatibility
+    module = import_module(f'hvplot.{module_name}')
+    try:
+        hvplot.extension('matplotlib')
+        module.patch(extension='plotly')
+        assert hv.Store.current_backend == 'plotly'
+    finally:
+        hvplot.extension(original_backend, compatibility=original_compatibility)
 
 
 class TestPatchPandas(TestCase):

--- a/hvplot/utilities.py
+++ b/hvplot/utilities.py
@@ -147,8 +147,9 @@ class hvplot_extension(_hv.extension):
 
     Notes
     -----
-    - Installing a data source with e.g. `import hvplot.pandas` automatically
-      calls this extension, enabling the Bokeh plotting backend.
+    - Installing a data source with e.g. `import hvplot.pandas` initializes
+      the plotting extension, preserving a previously selected backend.
+      Bokeh is used by default.
     - Calling the extension in a notebook environment injects some CSS/HTML/JS
       content in the cell output, content that is required for the plots to
       be rendered and interacted with.
@@ -174,9 +175,6 @@ class hvplot_extension(_hv.extension):
         """Enable the extension."""
         from . import _PATCH_PLOT_SIGNATURES
 
-        # importing e.g. hvplot.pandas always loads the bokeh extension.
-        # so hvplot.extension('matplotlib', compatibility='bokeh') doesn't
-        # require the user or the code to explicitly load bokeh.
         compatibility = params.pop('compatibility', None)
         super().__call__(*args, **params)
         backend = _hv.Store.current_backend

--- a/hvplot/xarray.py
+++ b/hvplot/xarray.py
@@ -44,7 +44,7 @@ class XArrayInteractive(Interactive):
     isel.__doc__ = xr.DataArray.isel.__doc__
 
 
-def patch(name='hvplot', interactive='interactive', extension='bokeh', logo=False):
+def patch(name='hvplot', interactive='interactive', extension=None, logo=False):
     """Patch xarray objects with the hvplot accessors."""
     from . import _module_extensions, hvPlot, post_patch
 


### PR DESCRIPTION
Importing `hvplot.pandas` or `hvplot.xarray` currently switches an explicitly selected Matplotlib or Plotly backend back to Bokeh. Treat an omitted patch extension as automatic selection, preserving the current backend and compatibility setting while initializing plotting resources when needed. An explicit `patch(extension=...)` still selects the requested backend.

Fixes #1735.

Four import/reload cases fail before the change. The related patching, signature, backend-transformation and plotting suites pass: 138 tests, with four Streamz skips on HoloViews 1.23. The final patch tests also verify default Bokeh rendering and explicit backend switching. Applicable pre-commit hooks pass.

## Post-Deploy Monitoring & Validation

Select Matplotlib or Plotly before importing the pandas/xarray integration and check that subsequent plots use that backend. New tests also retain the compatibility setting. Browser notebook rendering was not separately exercised.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
