### PR TITLE
Apply dynspread before combining conditional resampling layers

### DIFF
--- a/hvplot/converter.py
+++ b/hvplot/converter.py
@@ -2253,13 +2253,18 @@ class HoloViewsConverter:
             if self.pixel_ratio:
                 opts['pixel_ratio'] = self.pixel_ratio
 
-        processed = self._resample_obj(operation, obj, opts)
         if self.dynspread:
-            processed = dynspread(
-                processed,
-                max_px=self.kwds.get('max_px', 3),
-                threshold=self.kwds.get('threshold', 0.5),
-            )
+            resample = partial(operation, **opts)
+
+            def spread_resampled(data, **spread_opts):
+                return dynspread(resample(data), **spread_opts)
+
+            operation = spread_resampled
+            opts = {
+                'max_px': self.kwds.get('max_px', 3),
+                'threshold': self.kwds.get('threshold', 0.5),
+            }
+        processed = self._resample_obj(operation, obj, opts)
 
         opts = filter_opts(eltype, dict(self._plot_opts, **style), backend='bokeh')
         layers = self._apply_layers(processed).opts(eltype, **opts, backend='bokeh')

--- a/hvplot/tests/testoperations.py
+++ b/hvplot/tests/testoperations.py
@@ -322,6 +322,38 @@ class TestDatashader(ComparisonTestCase):
         assert isinstance(element, eltype)
         assert len(element) == 0
 
+    @parameterized.expand(
+        [(operation, limit) for operation in ('rasterize', 'datashade') for limit in (1, 10, None)]
+    )
+    def test_dynspread_resample_when(self, operation, limit):
+        df = pd.DataFrame({'x': [0, 1, 2], 'y': [0, 1, 2]})
+        dmap = df.hvplot.points(
+            'x',
+            'y',
+            width=40,
+            height=40,
+            xlim=(-1, 3),
+            ylim=(-1, 3),
+            resample_when=limit,
+            dynspread=True,
+            max_px=2,
+            threshold=1,
+            **{operation: True},
+        )
+
+        render(dmap)
+        result = dmap[()]
+        if limit is None:
+            image = result
+        else:
+            image, points = result.values()
+            assert isinstance(points, Points)
+            assert len(points) == (len(df) if limit >= len(df) else 0)
+        assert isinstance(image, Image)
+        if limit is None or limit < len(df):
+            array = image.dimension_values(image.vdims[-1], flat=False)
+            assert np.count_nonzero(np.nan_to_num(array)) > len(df)
+
     def test_selector_error_if_no_datashading_operation(self):
         with pytest.raises(
             ValueError, match='rasterize or datashade must be enabled when selector is set'


### PR DESCRIPTION
Combining `dynspread=True` with `resample_when` raises a Points-type error during rendering. Conditional resampling creates an image layer and a raw-points fallback; spreading is then applied to both.

Compose rasterization/datashading and spreading before building that conditional overlay. Six regression cases cover both operations above and below the threshold, plus unconditional spreading. They check fallback row counts and that image pixels are still spread.

Fixes #1414.

Validation: four initial regressions reproduce the reported error. The operations/options suites finish with 248 passed, 21 skipped, 20 expected failures and one existing XPASS. Applicable pre-commit hooks pass. Separate `geo=True` render checks cover rasterization and datashading on both sides of the threshold.

## Post-Deploy Monitoring & Validation

Render a points plot with dynamic spreading and conditional resampling. Dense views should retain spread images; sparse views should show the raw points. Local checks exercise Bokeh models and GeoViews, without browser interaction or tile-server requests.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
